### PR TITLE
Add check for SNOMED codelist

### DIFF
--- a/analysis/check_cohort.R
+++ b/analysis/check_cohort.R
@@ -12,14 +12,26 @@ myData <- df_input
 
 check_cohort <- data.frame(
                           all_patients = nrow(myData),
-                          has_cancer = length(which(myData$has_cancer == "1")),
+                          has_cancer_CTV3 = length(which(myData$has_cancer == "1")),
                           has_surgery = length(which(myData$has_surgery == "1")),
-                          has_both = length(which(myData$has_cancer == "1" &
+                          has_both_CTV3 = length(which(myData$has_cancer == "1" &
                                          myData$has_surgery == "1")),
+                          has_cancer_snomed = length(which(myData$has_cancer_lung == "1" |
+                                                       myData$has_cancer_haematological == "1" |
+                                                       myData$has_cancer_excluding_lung_and_haematological == "1")),
+                          has_both_snomed = length(which((myData$has_cancer_lung == "1" |
+                                                       myData$has_cancer_haematological == "1" |
+                                                       myData$has_cancer_excluding_lung_and_haematological == "1") &
+                                                         myData$has_surgery == "1")),
                           has_pos_test = length(which(myData$has_test_preOp_SARS_CoV_2_outcome_positive == "1")),
-                          has_all = length(which(myData$has_cancer == "1" &
+                          has_all_CTV3 = length(which(myData$has_cancer == "1" &
                                                    myData$has_surgery == "1" &
-                                                   myData$has_test_preOp_SARS_CoV_2_outcome_positive == "1"))
+                                                   myData$has_test_preOp_SARS_CoV_2_outcome_positive == "1")),
+                          has_all_snomed = length(which((myData$has_cancer_lung == "1" |
+                                                            myData$has_cancer_haematological == "1" |
+                                                            myData$has_cancer_excluding_lung_and_haematological == "1") &
+                                                           myData$has_surgery == "1" &
+                                                           myData$has_test_preOp_SARS_CoV_2_outcome_positive == "1"))
                           )
 
 

--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -4,14 +4,16 @@ from cohortextractor import (codelist_from_csv, combine_codelists)
 ## Cohort definition
 ## #####################
 
-# Patients with a cancer diagnosis (https://www.opencodelists.org/codelist/user/jkua/cancer/1d9bf8ff/).
+# Patients with a cancer diagnosis (CTV3)
+# (https://www.opencodelists.org/codelist/user/jkua/cancer/1d9bf8ff/).
 codelist_cancer = codelist_from_csv(
    "codelists/user-jkua-cancer.csv",
    system="snomed",
    column="code",
 )
 
-#Patients undergoing surgery (https://www.opencodelists.org/codelist/user/ciaranmci/surgery-covidsurg-replication-excluding-exclusions/5c09dd62/).
+# Patients undergoing surgery (CTV3)
+# (https://www.opencodelists.org/codelist/user/ciaranmci/surgery-covidsurg-replication-excluding-exclusions/5c09dd62/).
 codelist_cancer_surgery = codelist_from_csv(
     "codelists/user-ciaranmci-surgery-covidsurg-replication-excluding-exclusions.csv",
     system="snomed",
@@ -24,6 +26,31 @@ codelist_COVID_first_vaccination = codelist_from_csv(
     system="snomed",
     column="code",
 )
+
+# Patients with a cancer diagnosis, excluding lung and haematological cancers (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/cancer-excluding-lung-and-haematological-snomed/2020-04-15/).
+codelist_cancer_excluding_lung_and_haematological = codelist_from_csv(
+   "codelists/opensafely-cancer-excluding-lung-and-haematological-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
+# Patients with a lung cancer diagnosis (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/lung-cancer-snomed/2020-04-15/).
+codelist_cancer_lung = codelist_from_csv(
+   "codelists/opensafely-lung-cancer-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
+# Patients with a haematological cancer diagnosis (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/haematological-cancer-snomed/2020-04-15/).
+codelist_cancer_haematological = codelist_from_csv(
+   "codelists/opensafely-haematological-cancer-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
 
 # #####################
 # Exposure

--- a/analysis/codelists.py.bak
+++ b/analysis/codelists.py.bak
@@ -4,17 +4,19 @@ from cohortextractor import (codelist_from_csv, combine_codelists)
 ## Cohort definition
 ## #####################
 
-# Patients with a cancer diagnosis (https://www.opencodelists.org/codelist/user/jkua/cancer/1d9bf8ff/).
+# Patients with a cancer diagnosis (CTV3)
+# (https://www.opencodelists.org/codelist/user/jkua/cancer/1d9bf8ff/).
 codelist_cancer = codelist_from_csv(
    "codelists/user-jkua-cancer.csv",
    system="snomed",
    column="code",
 )
 
-#Patients undergoing surgery (https://www.opencodelists.org/codelist/user/ciaranmci/surgery-covidsurg-replication-excluding-exclusions/5c09dd62/).
+# Patients undergoing surgery (CTV3)
+# (https://www.opencodelists.org/codelist/user/ciaranmci/surgery-covidsurg-replication-excluding-exclusions/5c09dd62/).
 codelist_cancer_surgery = codelist_from_csv(
     "codelists/user-ciaranmci-surgery-covidsurg-replication-excluding-exclusions.csv",
-    system="opcs-4",
+    system="snomed",
     column="code",
 )
 
@@ -24,6 +26,31 @@ codelist_COVID_first_vaccination = codelist_from_csv(
     system="snomed",
     column="code",
 )
+
+# Patients with a cancer diagnosis, excluding lung and haematological cancers (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/cancer-excluding-lung-and-haematological-snomed/2020-04-15/).
+codelist_cancer_excluding_lung_and_haematological = codelist_from_csv(
+   "codelists/opensafely-cancer-excluding-lung-and-haematological-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
+# Patients with a lung cancer diagnosis (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/lung-cancer-snomed/2020-04-15/).
+codelist_cancer_lung = codelist_from_csv(
+   "codelists/opensafely-lung-cancer-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
+# Patients with a haematological cancer diagnosis (SNOMED)
+# (https://www.opencodelists.org/codelist/opensafely/haematological-cancer-snomed/2020-04-15/).
+codelist_cancer_haemtalogical = codelist_from_csv(
+   "codelists/opensafely-haematological-cancer-snomed.csv",
+   system="snomed",
+   column="id",
+)
+
 
 # #####################
 # Exposure

--- a/analysis/study_definition_flow_chart.py
+++ b/analysis/study_definition_flow_chart.py
@@ -30,7 +30,7 @@ study = StudyDefinition(
     # Get count of patients in entire database.
 	population = patients.all(),
     
-    # Get indication of patients who satisfy the cancer criterion.
+    # Get indication of patients who satisfy the cancer criterion (CTV3).
     has_cancer = patients.with_these_clinical_events(
 			codelist_cancer,
 			on_or_after = start_date
@@ -46,5 +46,24 @@ study = StudyDefinition(
         find_last_match_in_period = True,
         returning = "binary_flag",
         test_result = "positive"  
+        ),
+        
+    # Get indication of patients who satisfy the lung cancer criterion (SNOMED).
+    has_cancer_lung = patients.with_these_clinical_events(
+			codelist_cancer_lung,
+			on_or_after = start_date
+        ),
+        
+    # Get indication of patients who satisfy the haematological cancer criterion (SNOMED).
+    has_cancer_haematological = patients.with_these_clinical_events(
+			codelist_cancer_haematological,
+			on_or_after = start_date
+        ),
+        
+    # Get indication of patients who satisfy the cancer criterion,
+    # excluding lung and haematological cancers (SNOMED).
+    has_cancer_excluding_lung_and_haematological = patients.with_these_clinical_events(
+			codelist_cancer_excluding_lung_and_haematological,
+			on_or_after = start_date
         ),
 ) # End of StudyDefinition().

--- a/analysis/study_definition_flow_chart.py.bak
+++ b/analysis/study_definition_flow_chart.py.bak
@@ -47,6 +47,4 @@ study = StudyDefinition(
         returning = "binary_flag",
         test_result = "positive"  
         ),
-	),
-
 ) # End of StudyDefinition().

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -17,6 +17,24 @@
       "url": "https://codelists.opensafely.org/codelist/primis-covid19-vacc-uptake/covadm1/v1/",
       "downloaded_at": "2022-02-25 09:28:32.237120Z",
       "sha": "5e6a8bef2da93467d11c25affbd33755205e4204"
+    },
+    "opensafely-cancer-excluding-lung-and-haematological-snomed.csv": {
+      "id": "opensafely/cancer-excluding-lung-and-haematological-snomed/7ce531c3",
+      "url": "https://codelists.opensafely.org/codelist/opensafely/cancer-excluding-lung-and-haematological-snomed/7ce531c3/",
+      "downloaded_at": "2022-04-04 07:41:09.005032Z",
+      "sha": "d43aff12fcb3b404c635e24f964ba2a368c96c98"
+    },
+    "opensafely-haematological-cancer-snomed.csv": {
+      "id": "opensafely/haematological-cancer-snomed/3469981a",
+      "url": "https://codelists.opensafely.org/codelist/opensafely/haematological-cancer-snomed/3469981a/",
+      "downloaded_at": "2022-04-04 07:41:09.354684Z",
+      "sha": "c87e49e8d2965bc489f9baba670783f15ce73896"
+    },
+    "opensafely-lung-cancer-snomed.csv": {
+      "id": "opensafely/lung-cancer-snomed/502bcb45",
+      "url": "https://codelists.opensafely.org/codelist/opensafely/lung-cancer-snomed/502bcb45/",
+      "downloaded_at": "2022-04-04 07:41:09.650186Z",
+      "sha": "f0debdf1c968242fa8790cd0b773662b8e169f43"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -1,3 +1,6 @@
 user/jkua/cancer/1d9bf8ff
 user/ciaranmci/surgery-covidsurg-replication-excluding-exclusions/5c09dd62
 primis-covid19-vacc-uptake/covadm1/v1
+opensafely/cancer-excluding-lung-and-haematological-snomed/7ce531c3
+opensafely/haematological-cancer-snomed/3469981a
+opensafely/lung-cancer-snomed/502bcb45

--- a/codelists/opensafely-cancer-excluding-lung-and-haematological-snomed.csv
+++ b/codelists/opensafely-cancer-excluding-lung-and-haematological-snomed.csv
@@ -1,0 +1,5892 @@
+id,name,active,notes
+94632009,Secondary malignant neoplasm of thymus (disorder),y,direct mapping
+18105004,"Endometrioid adenofibroma, malignant (morphologic abnormality)",y,direct mapping
+269533000,Carcinoma of colon (disorder),y,direct mapping
+110458000,Malignant odontogenic ghost cell tumor (morphologic abnormality),y,direct mapping
+363510005,Malignant tumor of large intestine (disorder),y,direct mapping
+94453007,Secondary malignant neoplasm of orbit proper (disorder),y,direct mapping
+448668007,Malignant neoplasm of mandible (disorder),y,direct mapping
+94066004,Primary malignant neoplasm of sphenoid bone (disorder),y,direct mapping
+363381003,Malignant tumor of sublingual gland (disorder),y,direct mapping
+285613005,Metastasis to liver of unknown primary (disorder),y,direct mapping
+363450006,Malignant tumor of foreskin (disorder),y,direct mapping
+269463006,Malignant tumor of middle ear and mastoid (disorder),y,direct mapping
+363353009,Malignant tumor of gallbladder (disorder),y,direct mapping
+276803003,Adenocarcinoma of esophagus (disorder),y,direct mapping
+285312008,Carcinoma of sigmoid colon (disorder),y,direct mapping
+109874003,Overlapping malignant neoplasm of male genital organs (disorder),y,direct mapping
+187641009,Malignant tumor of frenum linguae (disorder),y,direct mapping
+363423001,Malignant tumor of nasal septum (disorder),y,direct mapping
+188209005,Malignant neoplasm of vaginal vault (disorder),y,direct mapping
+30289006,Endometrioid carcinoma (morphologic abnormality),y,direct mapping
+315009006,Metastasis from malignant tumor of tongue (disorder),y,direct mapping
+1090901000000102,Malignant neoplasm of peripheral nerves of trunk (disorder),y,direct mapping
+372095001,Malignant neoplasm of male breast (disorder),y,direct mapping
+254856004,Undifferentiated carcinoma of ovary (disorder),y,direct mapping
+372142002,Carcinoma of pancreas (disorder),y,direct mapping
+274088005,Secondary malignant neoplasm of unknown site (disorder),y,direct mapping
+19756007,"Gastrinoma, malignant (morphologic abnormality)",y,direct mapping
+285618001,Metastasis to bone of unknown primary (disorder),y,direct mapping
+255017003,Adenocarcinoma of non-pigmented epithelium of ciliary body (disorder),y,direct mapping
+363437005,Malignant tumor of myocardium (disorder),y,direct mapping
+1090131000000106,Secondary malignant neoplasm of anterior cervical lymph nodes (disorder),y,direct mapping
+33176006,"Hemangioendothelioma, malignant (morphologic abnormality)",y,direct mapping
+269473008,Secondary malignant neoplasm of respiratory and digestive systems (disorder),y,direct mapping
+109391009,Kaposi's sarcoma of lymph nodes (disorder),y,direct mapping
+363376007,Malignant tumor of base of tongue (disorder),y,direct mapping
+59367005,Adenosquamous carcinoma (morphologic abnormality),y,direct mapping
+285619009,Metastasis to vertebral column of unknown primary (disorder),y,direct mapping
+255091001,Malignant neoplasm of metacarpal bones (disorder),y,direct mapping
+93798006,Primary malignant neoplasm of femur (disorder),y,direct mapping
+44769000,"Choriocarcinoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+188195000,Malignant neoplasm of isthmus of uterine body (disorder),y,direct mapping
+187613005,"Malignant neoplasm of lower lip, buccal aspect (disorder)",y,direct mapping
+109385007,Kaposi's sarcoma (disorder),y,direct mapping
+708921005,Carcinoma of central portion of breast (disorder),y,direct mapping
+254844000,Malignant phyllodes tumor of breast (disorder),y,direct mapping
+254474002,Malignant tumor of nasal skeleton (disorder),y,direct mapping
+363473003,Malignant neoplasm of brainstem (disorder),y,direct mapping
+187994003,Malignant neoplasm of connective and soft tissue of forearm (disorder),y,direct mapping
+253001006,Merkel cell carcinoma (disorder),y,direct mapping
+188003000,Malignant neoplasm of connective and soft tissue of lower leg (disorder),y,direct mapping
+189857001,Choriocarcinoma combined with teratoma (morphologic abnormality),y,direct mapping
+94580002,Secondary malignant neoplasm of small intestine (disorder),y,direct mapping
+424413001,Sarcoma (disorder),y,direct mapping
+94313005,Secondary malignant neoplasm of gastrointestinal tract (disorder),y,direct mapping
+94661005,Secondary malignant neoplasm of urethra (disorder),y,direct mapping
+93217003,Malignant melanoma of skin of cheek (disorder),y,direct mapping
+275394001,Carcinoma ventral surface of tongue (disorder),y,direct mapping
+188454009,Secondary malignant neoplasm of skin of head (disorder),y,direct mapping
+188188009,Choriocarcinoma (disorder),y,direct mapping
+188002005,Malignant neoplasm of connective and soft tissue of popliteal space (disorder),y,direct mapping
+188044004,Malignant melanoma of scalp AND/OR neck (disorder),y,direct mapping
+363478007,Malignant tumor of thyroid gland (disorder),y,direct mapping
+94600009,Secondary malignant neoplasm of spinal cord (disorder),y,direct mapping
+269516007,Tongue carcinoma (disorder),y,direct mapping
+65140001,Periosteal fibrosarcoma (morphologic abnormality),y,direct mapping
+68880006,Papillary mucinous cystadenocarcinoma (morphologic abnormality),y,direct mapping
+276809004,Early gastric cancer (disorder),y,direct mapping
+89740008,Lobular carcinoma (morphologic abnormality),y,direct mapping
+276797002,Malignant tumor of fibrous tissue (disorder),y,direct mapping
+413737006,Cancer hospital treatment completed (situation),y,direct mapping
+254888007,Adenosquamous carcinoma of cervix (disorder),y,direct mapping
+109384006,"Overlapping malignant neoplasm of heart, mediastinum and pleura (disorder)",y,direct mapping
+94112009,Primary malignant neoplasm of ulna (disorder),y,direct mapping
+255110003,Adenocarcinoma of bladder (disorder),y,direct mapping
+54734006,Sebaceous adenocarcinoma (morphologic abnormality),y,direct mapping
+372131006,Malignant neoplasm of upper limb bones and scapula (disorder),y,direct mapping
+363404008,Malignant tumor of jejunum (disorder),y,direct mapping
+188016000,Malignant neoplasm of connective and soft tissue of abdominal wall (disorder),y,direct mapping
+314997007,Metastasis from malignant tumor of rectum (disorder),y,direct mapping
+269544008,Carcinoma of the rectosigmoid junction (disorder),y,direct mapping
+255118005,Secondary lymphangitic carcinoma (disorder),y,direct mapping
+57622002,"Thecoma, malignant (morphologic abnormality)",y,direct mapping
+255088001,Malignant tumor of exocrine pancreas (disorder),y,direct mapping
+188219004,Malignant tumor of undescended testis (disorder),y,direct mapping
+94554003,Secondary malignant neoplasm of skin of face (disorder),y,direct mapping
+363518003,Malignant tumor of kidney (disorder),y,direct mapping
+188445006,Secondary malignant neoplasm of retroperitoneum and peritoneum (disorder),y,direct mapping
+255012009,Malignant melanoma of iris (disorder),y,direct mapping
+93975006,Primary malignant neoplasm of pubis (disorder),y,direct mapping
+188032002,Malignant melanoma of ear and/or external auditory canal (disorder),y,direct mapping
+109876001,Primary malignant neoplasm of descended testis (disorder),y,direct mapping
+188005007,Malignant neoplasm of connective and soft tissue of toe (disorder),y,direct mapping
+254974009,Malignant tumor of optic nerve sheath (disorder),y,direct mapping
+363441009,Malignant tumor of soft tissue of neck (disorder),y,direct mapping
+269467007,Malignant neoplasm of hand bones (disorder),y,direct mapping
+85654004,Medullary carcinoma with lymphoid stroma (morphologic abnormality),y,direct mapping
+363422006,Malignant tumor of nasal cavity (disorder),y,direct mapping
+363427000,Malignant tumor of frontal sinus (disorder),y,direct mapping
+363372009,Malignant tumor of vermilion border of upper lip (disorder),y,direct mapping
+188312005,Malignant neoplasm of cerebral dura mater (disorder),y,direct mapping
+94597008,Secondary malignant neoplasm of spermatic cord (disorder),y,direct mapping
+285603002,Metastasis to bronchus of unknown primary (disorder),y,direct mapping
+21708004,"Osteosarcoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+187957007,Malignant neoplasm of coccygeal vertebra (disorder),y,direct mapping
+405945003,Malignant neoplasm of metatarsal bone of foot (disorder),y,direct mapping
+126885006,Neoplasm of bladder (disorder),y,direct mapping
+93841009,Primary malignant neoplasm of intrathoracic organs (disorder),y,direct mapping
+94668004,Secondary malignant neoplasm of vagina (disorder),y,direct mapping
+39005004,Medulloepithelioma (morphologic abnormality),y,direct mapping
+254424004,Carcinoma of upper gum (disorder),y,direct mapping
+314962005,Local recurrence of malignant tumor of gallbladder (disorder),y,direct mapping
+187635002,Malignant neoplasm of midline of tongue (disorder),y,direct mapping
+46710009,Esthesioneurocytoma (morphologic abnormality),y,direct mapping
+254454009,Carcinoma of lower labial sulcus (disorder),y,direct mapping
+82591005,Paget's disease and infiltrating duct carcinoma of breast (morphologic abnormality),y,direct mapping
+363382005,Malignant tumor of gum (disorder),y,direct mapping
+188010006,Malignant neoplasm of connective and soft tissue of axilla (disorder),y,direct mapping
+188023004,Malignant neoplasm of connective and soft tissue of sacrum or coccyx (disorder),y,direct mapping
+1090961000000103,Malignant neoplasm of soft tissues of lower limb (disorder),y,direct mapping
+278411006,Primary intra-osseous carcinoma (morphologic abnormality),y,direct mapping
+188075008,Malignant melanoma of foot (disorder),y,direct mapping
+255121007,Carcinomatosis of peritoneal cavity (disorder),y,direct mapping
+12690005,Fibroblastic osteosarcoma (morphologic abnormality),y,direct mapping
+428061005,Malignant neoplasm of brain (disorder),y,direct mapping
+314999005,Metastasis from malignant tumor of pancreas (disorder),y,direct mapping
+188060000,Malignant melanoma of shoulder (disorder),y,direct mapping
+187631006,Malignant neoplasm of base of tongue dorsal surface (disorder),y,direct mapping
+716318002,Lynch syndrome (disorder),y,direct mapping
+14990007,"Chondrosarcoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+956331000000107,Malignant melanoma stage IA (finding),y,direct mapping
+187952001,"Malignant neoplasm of pelvic bones, sacrum and coccyx (disorder)",y,direct mapping
+188313000,Malignant neoplasm of cerebral arachnoid mater (disorder),y,direct mapping
+62621002,Pigmented dermatofibrosarcoma protuberans (morphologic abnormality),y,direct mapping
+416669000,Invasive hydatidiform mole (disorder),y,direct mapping
+84664004,"Hemangiopericytoma, malignant (morphologic abnormality)",y,direct mapping
+254988008,Adenocarcinoma of lacrimal gland (disorder),y,direct mapping
+254855000,Mixed epithelial tumor of ovary (disorder),y,direct mapping
+285640005,Metastasis to bladder of unknown primary (disorder),y,direct mapping
+363395000,Malignant tumor of vallecula (disorder),y,direct mapping
+187741001,Malignant tumor of fundus of stomach (disorder),y,direct mapping
+33681003,Osteosarcoma in Paget's disease of bone (morphologic abnormality),y,direct mapping
+254986007,Malignant tumor of peripheral nerve (disorder),y,direct mapping
+363469001,Malignant neoplasm of parietal lobe (disorder),y,direct mapping
+94665001,Secondary malignant neoplasm of uterus (disorder),y,direct mapping
+9801004,Spindle cell sarcoma (morphologic abnormality),y,direct mapping
+10069009,"Giant cell tumor of bone, malignant (morphologic abnormality)",y,direct mapping
+286894008,"Carcinoma of breast - lower, inner quadrant (disorder)",y,direct mapping
+188208002,Malignant neoplasm of Gartner's duct (disorder),y,direct mapping
+4079000,Mucoepidermoid carcinoma (morphologic abnormality),y,direct mapping
+80061003,Oligodendroblastoma (morphologic abnormality),y,direct mapping
+254563009,Carcinoma of lesser curve of stomach (disorder),y,direct mapping
+363393007,Malignant tumor of tonsil (disorder),y,direct mapping
+303012000,Malignant tumor of posterior wall of hypopharynx (disorder),y,direct mapping
+109911004,Overlapping malignant neoplasm of brain and other parts of the central nervous system (disorder),y,direct mapping
+363392002,Malignant tumor of oropharynx (disorder),y,direct mapping
+88400008,"Tumor cells, malignant (morphologic abnormality)",y,direct mapping
+254887002,Adenocarcinoma of cervix (disorder),y,direct mapping
+254889004,Carcinoma of cervix stage 0 (disorder),y,direct mapping
+109842005,Intrahepatic bile duct carcinoma (disorder),y,direct mapping
+3102004,"Oligodendroglioma, anaplastic (morphologic abnormality)",y,direct mapping
+187932002,Malignant neoplasm of humerus (disorder),y,direct mapping
+255115008,Kaposi's sarcoma of cornea (disorder),y,direct mapping
+312113007,Carcinoma of descending colon (disorder),y,direct mapping
+285609003,Metastasis to small intestine of unknown primary (disorder),y,direct mapping
+188366002,Malignant neoplasm of abdomen (disorder),y,direct mapping
+956471000000103,Malignant melanoma stage IIIC (finding),y,direct mapping
+54666007,Paget's disease and intraductal carcinoma of breast (morphologic abnormality),y,direct mapping
+363482009,Malignant tumor of pituitary gland (disorder),y,direct mapping
+188211001,Malignant neoplasm of greater vestibular (Bartholin's) gland (disorder),y,direct mapping
+363508008,Malignant tumor of intestine (disorder),y,direct mapping
+93655004,Malignant melanoma of skin (disorder),y,direct mapping
+35262004,Gliosarcoma (morphologic abnormality),y,direct mapping
+255029007,Papillary thyroid carcinoma (disorder),y,direct mapping
+187808008,Malignant neoplasm of specified parts of peritoneum (disorder),y,direct mapping
+75931002,Malignant melanoma in giant pigmented nevus (morphologic abnormality),y,direct mapping
+188006008,Malignant neoplasm of connective and soft tissue of great toe (disorder),y,direct mapping
+363481002,Malignant tumor of parathyroid gland (disorder),y,direct mapping
+15176003,Adenocarcinoma with squamous metaplasia (morphologic abnormality),y,direct mapping
+342571000000109,Siewert type I adenocarcinoma (disorder),y,direct mapping
+408645001,Adenocarcinoma of large intestine (disorder),y,direct mapping
+430556008,Malignant neoplasm of genital structure (disorder),y,direct mapping
+94298004,Secondary malignant neoplasm of female genital organ (disorder),y,direct mapping
+363374005,Malignant tumor of commissure of lip (disorder),y,direct mapping
+449224009,Malignant neoplasm of anterior mediastinum (disorder),y,direct mapping
+94142007,Primary malignant neoplasm of vomer (disorder),y,direct mapping
+254893005,Carcinoma of vagina (disorder),y,direct mapping
+93786001,Primary malignant neoplasm of ethmoid bone (disorder),y,direct mapping
+254851009,Mucinous cystadenocarcinoma of ovary (disorder),y,direct mapping
+363462005,Malignant tumor of orbit (disorder),y,direct mapping
+94402006,Secondary malignant neoplasm of male genital organ (disorder),y,direct mapping
+363435002,Malignant tumor of heart (disorder),y,direct mapping
+254824006,Malignant tumor of mesothelial tissue (disorder),y,direct mapping
+363452003,Malignant tumor of epididymis (disorder),y,direct mapping
+59238007,Epithelioid sarcoma (morphologic abnormality),y,direct mapping
+276810009,Late gastric cancer (disorder),y,direct mapping
+363377003,Malignant tumor of lingual tonsil (disorder),y,direct mapping
+754371000000109,Grade 3 (Stage pTa) papillary urothelial/transitional cell carcinoma (morphologic abnormality),y,direct mapping
+255056009,Malignant tumor of head and/or neck (disorder),y,direct mapping
+28351005,Myxosarcoma (morphologic abnormality),y,direct mapping
+372097009,Malignant neoplasm of endocervix (disorder),y,direct mapping
+183649005,Combined therapy follow-up (procedure),y,direct mapping
+314998002,Metastasis from malignant tumor of colon (disorder),y,direct mapping
+254843006,Familial cancer of breast (disorder),y,direct mapping
+269515006,Carcinoma of lip (disorder),y,direct mapping
+449377002,Malignant neoplasm of pelvic peritoneum (disorder),y,direct mapping
+64000002,Skin appendage carcinoma (morphologic abnormality),y,direct mapping
+94347008,Secondary malignant neoplasm of intra-abdominal lymph nodes (disorder),y,direct mapping
+187614004,Malignant tumor of frenum of lower lip (disorder),y,direct mapping
+1090821000000101,Malignant neoplasm of bone and articular cartilage (disorder),y,direct mapping
+76594008,Dermatofibrosarcoma (morphologic abnormality),y,direct mapping
+286889008,Carcinoma of upper limb bones/scapula (disorder),y,direct mapping
+363453008,Malignant tumor of spermatic cord (disorder),y,direct mapping
+285612000,Metastasis to rectum of unknown primary (disorder),y,direct mapping
+53654007,Fibrosarcoma (morphologic abnormality),y,direct mapping
+5257006,Follicular adenocarcinoma (morphologic abnormality),y,direct mapping
+109835005,Overlapping malignant neoplasm of esophagus (disorder),y,direct mapping
+363439008,Malignant tumor of soft tissue of head (disorder),y,direct mapping
+285615003,Metastasis to spleen of unknown primary (disorder),y,direct mapping
+271943005,Carcinoma of base of tongue (disorder),y,direct mapping
+93997008,Primary malignant neoplasm of scapula (disorder),y,direct mapping
+188242006,Malignant neoplasm of anterior wall of urinary bladder (disorder),y,direct mapping
+363483004,Malignant tumor of pineal gland (disorder),y,direct mapping
+94398002,Secondary malignant neoplasm of lymph nodes of upper limb (disorder),y,direct mapping
+30383009,"Mesothelioma, biphasic, malignant (morphologic abnormality)",y,direct mapping
+254841008,Cancer en cuirasse (disorder),y,direct mapping
+307216009,Perforated carcinoma of esophagus (disorder),y,direct mapping
+312112002,Carcinoma of transverse colon (disorder),y,direct mapping
+189919000,Primitive polar spongioblastoma (morphologic abnormality),y,direct mapping
+187683004,Malignant neoplasm of glossoepiglottic fold (disorder),y,direct mapping
+314996003,Metastasis from malignant tumor of kidney (disorder),y,direct mapping
+39274007,Balloon cell melanoma (morphologic abnormality),y,direct mapping
+93661001,Primary malignant neoplasm of acromion (disorder),y,direct mapping
+187846001,Malignant neoplasm of thyroid cartilage (disorder),y,direct mapping
+187967002,Malignant neoplasm of calcaneum (disorder),y,direct mapping
+274904007,Carcinoid tumor - argentaffin (morphologic abnormality),y,direct mapping
+363360003,Malignant tumor of anterior two-thirds of tongue (disorder),y,direct mapping
+254876005,Endodermal sinus tumor of ovary (disorder),y,direct mapping
+71447003,"Paget's disease, extramammary (except Paget's disease of bone) (morphologic abnormality)",y,direct mapping
+188040008,Malignant melanoma of forehead (disorder),y,direct mapping
+16034002,Clark melanoma level 5 (finding),y,direct mapping
+94659001,Secondary malignant neoplasm of ureter (disorder),y,direct mapping
+39781001,Primitive neuroectodermal tumor (morphologic abnormality),y,direct mapping
+187977000,Malignant neoplasm of fifth metatarsal bone (disorder),y,direct mapping
+28558000,Villous adenocarcinoma (morphologic abnormality),y,direct mapping
+255111004,Squamous cell carcinoma of bladder (disorder),y,direct mapping
+420524008,Kaposi's sarcoma associated with acquired immunodeficiency syndrome (disorder),y,direct mapping
+363369002,Carcinoma of tail of pancreas (disorder),y,direct mapping
+188055004,Malignant melanoma of umbilicus (disorder),y,direct mapping
+76060004,Esthesioneuroblastoma (morphologic abnormality),y,direct mapping
+721629005,Linitis plastica of stomach (disorder),y,direct mapping
+110457005,Angiomyoliposarcoma (morphologic abnormality),y,direct mapping
+254520006,Malignant tumor of infrahyoid epiglottis (disorder),y,direct mapping
+307502000,Squamous cell carcinoma of mouth (disorder),y,direct mapping
+956551000000106,Malignant melanoma stage IV M1c (finding),y,direct mapping
+78838008,Pleomorphic xanthoastrocytoma (morphologic abnormality),y,direct mapping
+188287005,Malignant neoplasm of thalamus (disorder),y,direct mapping
+310504009,Primary malignant neoplasm of unknown site (disorder),y,direct mapping
+94134006,Primary malignant neoplasm of ventral surface of tongue (disorder),y,direct mapping
+109841003,Liver cell carcinoma (disorder),y,direct mapping
+1090921000000106,Malignant neoplasm of jaw (disorder),y,direct mapping
+372099007,Malignant neoplasm of exocervix (disorder),y,direct mapping
+187843009,Malignant neoplasm of arytenoid cartilage (disorder),y,direct mapping
+398670003,Pigmented dermatofibrosarcoma protuberans of skin (disorder),y,direct mapping
+404037002,Malignant peripheral nerve sheath tumor (disorder),y,direct mapping
+32512003,"Extra-adrenal paraganglioma, malignant (morphologic abnormality)",y,direct mapping
+188020001,Malignant neoplasm of connective and soft tissue of buttock (disorder),y,direct mapping
+253056006,Malignant lymphangioma (morphologic abnormality),y,direct mapping
+254408000,Malignant tumor of anterior two-thirds of tongue - lateral margin (disorder),y,direct mapping
+188264002,Malignant tumor of iris (disorder),y,direct mapping
+94217008,Secondary malignant neoplasm of bone marrow (disorder),y,direct mapping
+93681000,Primary malignant neoplasm of areola of male breast (disorder),y,direct mapping
+956371000000109,Malignant melanoma stage IIA (finding),y,direct mapping
+1556006,Clark melanoma level 4 (finding),y,direct mapping
+109843000,Hepatoblastoma (disorder),y,direct mapping
+363354003,Malignant tumor of cervix (disorder),y,direct mapping
+254896002,Malignant melanoma of vulva (disorder),y,direct mapping
+314974009,Local recurrence of malignant tumor of soft tissue (disorder),y,direct mapping
+187769009,Primary carcinoma of liver (disorder),y,direct mapping
+276420005,Malignant tumor of corpus cavernosum (disorder),y,direct mapping
+70555003,"Endometrial stromal sarcoma, high grade (morphologic abnormality)",y,direct mapping
+254389005,Carcinoma of vermilion border of upper lip (disorder),y,direct mapping
+363440005,Malignant tumor of soft tissue of face (disorder),y,direct mapping
+363401000,Malignant tumor of pyriform fossa (disorder),y,direct mapping
+255021005,Malignant melanoma of choroid (disorder),y,direct mapping
+1090991000000109,Malignant neoplasm of soft tissues of lower leg (disorder),y,direct mapping
+94381002,Secondary malignant neoplasm of liver (disorder),y,direct mapping
+22694002,Adenocarcinoma with apocrine metaplasia (morphologic abnormality),y,direct mapping
+314418005,Leukemic infiltrate of retina (disorder),y,direct mapping
+94634005,Secondary malignant neoplasm of thyroid gland (disorder),y,direct mapping
+52040006,Infantile fibrosarcoma (morphologic abnormality),y,direct mapping
+254987003,Adenoid cystic carcinoma of lacrimal gland (disorder),y,direct mapping
+73676002,Peripheral neuroectodermal tumor (morphologic abnormality),y,direct mapping
+32968003,Inflammatory carcinoma (morphologic abnormality),y,direct mapping
+188065005,Malignant melanoma of thumb (disorder),y,direct mapping
+42194009,"Brenner tumor, malignant (morphologic abnormality)",y,direct mapping
+363346000,Malignant neoplastic disease (disorder),y,direct mapping
+1090291000000102,Malignant neoplasm of prepylorus of stomach (disorder),y,direct mapping
+93870000,Malignant neoplasm of liver (disorder),y,direct mapping
+307576001,Osteosarcoma of bone (disorder),y,direct mapping
+187917009,Malignant neoplasm of thoracic vertebra (disorder),y,direct mapping
+363413005,Malignant tumor of splenic flexure (disorder),y,direct mapping
+188324003,"Malignant neoplasm of peripheral nerves of lower limb, including hip (disorder)",y,direct mapping
+94663008,Secondary malignant neoplasm of urinary system (disorder),y,direct mapping
+187942000,Malignant neoplasm of carpal bone - trapezoid (disorder),y,direct mapping
+285642002,Metastasis to eye of unknown primary (disorder),y,direct mapping
+58477004,Infiltrating ductular carcinoma (morphologic abnormality),y,direct mapping
+53968002,Olfactory neurogenic tumor (morphologic abnormality),y,direct mapping
+187794005,Malignant tumor of Islets of Langerhans (disorder),y,direct mapping
+63634009,"Glioblastoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+43296007,Round cell liposarcoma (morphologic abnormality),y,direct mapping
+44529004,Giant cell glioblastoma (morphologic abnormality),y,direct mapping
+187881004,"Malignant neoplasm of thymus, heart and mediastinum (disorder)",y,direct mapping
+60718004,Dysgerminoma (morphologic abnormality),y,direct mapping
+188250002,Malignant tumor of kidney parenchyma (disorder),y,direct mapping
+281564008,Pelvic neuroblastoma (disorder),y,direct mapping
+302847003,Rhabdomyosarcoma (disorder),y,direct mapping
+45881000,Carcinoma simplex (morphologic abnormality),y,direct mapping
+21165006,Clark melanoma level 3 (finding),y,direct mapping
+363514001,Malignant tumor of female genital organ (disorder),y,direct mapping
+12943006,Polar spongioblastoma (morphologic abnormality),y,direct mapping
+188049009,Malignant melanoma of axilla (disorder),y,direct mapping
+254465004,Carcinoma of submandibular gland (disorder),y,direct mapping
+314964006,Local recurrence of malignant tumor of pancreas (disorder),y,direct mapping
+275490009,Carcinoma of tongue base - dorsal surface (disorder),y,direct mapping
+187950009,Malignant neoplasm of phalanges of hand (disorder),y,direct mapping
+188252005,Malignant tumor of renal calyx (disorder),y,direct mapping
+188471005,Secondary malignant neoplasm of epididymis AND vas deferens (disorder),y,direct mapping
+255127006,Local tumor spread (disorder),y,direct mapping
+278433008,Malignant infiltration of soft tissue (disorder),y,direct mapping
+69317001,Kupffer cell sarcoma (morphologic abnormality),y,direct mapping
+1090951000000101,Malignant neoplasm of supraclavicular fossa (disorder),y,direct mapping
+254870004,Choriocarcinoma of ovary (disorder),y,direct mapping
+188062008,Malignant melanoma of forearm (disorder),y,direct mapping
+18854008,"Struma ovarii, malignant (morphologic abnormality)",y,direct mapping
+188244007,Malignant tumor of bladder neck (disorder),y,direct mapping
+41919003,Juvenile carcinoma of the breast (morphologic abnormality),y,direct mapping
+286902000,Secondary carcinoma of gastrointestinal tract (disorder),y,direct mapping
+285432005,Carcinoma of cervix (disorder),y,direct mapping
+187991006,Malignant neoplasm of connective and soft tissue of upper limb and shoulder (disorder),y,direct mapping
+314408000,Leukemic infiltrate of choroid (disorder),y,direct mapping
+448868009,Malignant neoplasm of lateral wall of oropharynx (disorder),y,direct mapping
+94360002,Secondary malignant neoplasm of kidney (disorder),y,direct mapping
+235966007,Cystadenocarcinoma of pancreas (disorder),y,direct mapping
+363365008,Malignant tumor of soft tissue of thorax (disorder),y,direct mapping
+274087000,Malignant melanoma of eye (disorder),y,direct mapping
+76909002,Ewing's sarcoma (morphologic abnormality),y,direct mapping
+88591002,Teratoid medulloepithelioma (morphologic abnormality),y,direct mapping
+254435009,Carcinoma of soft palate (disorder),y,direct mapping
+11073003,Mixed liposarcoma (morphologic abnormality),y,direct mapping
+254513004,Malignant tumor of posterior commissure (disorder),y,direct mapping
+956451000000107,Malignant melanoma stage IIIB (finding),y,direct mapping
+372011009,Malignant tumor of soft tissue of upper limb (disorder),y,direct mapping
+94602001,Secondary malignant neoplasm of vertebral column (disorder),y,direct mapping
+281565009,Paraspinal neuroblastoma (disorder),y,direct mapping
+269581007,Malignant melanoma of lower limb (disorder),y,direct mapping
+449096009,Malignant neoplasm of respiratory system (disorder),y,direct mapping
+286893002,"Carcinoma of breast - upper, inner quadrant (disorder)",y,direct mapping
+363388009,Malignant tumor of soft palate (disorder),y,direct mapping
+363400004,Malignant tumor of postcricoid region (disorder),y,direct mapping
+813671000000107,Secondary malignant neoplasm of liver and intrahepatic bile duct (disorder),y,direct mapping
+363426009,Malignant tumor of ethmoid sinus (disorder),y,direct mapping
+285639008,Metastasis to kidney of unknown primary (disorder),y,direct mapping
+188289008,Malignant neoplasm of hippocampus (disorder),y,direct mapping
+94275007,Secondary malignant neoplasm of duodenum (disorder),y,direct mapping
+254849005,Malignant epithelial tumor of ovary (disorder),y,direct mapping
+254983004,Malignant tumor of spinal nerve and sheath (disorder),y,direct mapping
+5052009,Merkel cell carcinoma (morphologic abnormality),y,direct mapping
+278046008,Sarcoma of bladder (disorder),y,direct mapping
+187978005,Malignant neoplasm of phalanges of foot (disorder),y,direct mapping
+254398008,Carcinoma of frenum of upper lip (disorder),y,direct mapping
+115223002,Nevus AND/OR melanoma (morphologic abnormality),y,direct mapping
+363373004,Malignant tumor of vermilion border of lower lip (disorder),y,direct mapping
+115241005,Neuroepitheliomatous neoplasm (morphologic abnormality),y,direct mapping
+188017009,Malignant neoplasm of connective and soft tissues of lumbar spine (disorder),y,direct mapping
+29370006,"Pheochromocytoma, malignant (morphologic abnormality)",y,direct mapping
+31396002,Goblet cell carcinoid (morphologic abnormality),y,direct mapping
+254612002,Carcinoma of endocrine pancreas (disorder),y,direct mapping
+187803004,Malignant neoplasm of perinephric tissue (disorder),y,direct mapping
+255191003,Localized malignant reticulohistiocytoma (disorder),y,direct mapping
+109392002,Kaposi's sarcoma of multiple organs (disorder),y,direct mapping
+187999008,Malignant neoplasm of connective and soft tissue of hip and lower limb (disorder),y,direct mapping
+9294008,Spermatocytic seminoma (morphologic abnormality),y,direct mapping
+314965007,Local recurrence of malignant tumor of colon (disorder),y,direct mapping
+1090141000000102,Secondary malignant neoplasm of superficial cervical lymph nodes (disorder),y,direct mapping
+285616002,Metastasis to peritoneum of unknown primary (disorder),y,direct mapping
+93799003,Primary malignant neoplasm of fibula (disorder),y,direct mapping
+50542000,Clark melanoma level 2 (finding),y,direct mapping
+276804009,Squamous cell carcinoma of esophagus (disorder),y,direct mapping
+315058005,Hereditary nonpolyposis colon cancer (disorder),y,direct mapping
+187666008,Malignant neoplasm of junction of hard and soft palate (disorder),y,direct mapping
+187973001,Malignant neoplasm of first metatarsal bone (disorder),y,direct mapping
+313248004,Malignant melanoma of chest wall (disorder),y,direct mapping
+188029000,Kaposi's sarcoma of soft tissue (disorder),y,direct mapping
+187906008,Malignant neoplasm of orbital bone (disorder),y,direct mapping
+363357005,Malignant tumor of ill-defined site (disorder),y,direct mapping
+187624007,Malignant neoplasm of overlapping lesion of lip (disorder),y,direct mapping
+280959007,Malignant tumor of lacrimal drainage structure (disorder),y,direct mapping
+24007003,Clear cell sarcoma of kidney (morphologic abnormality),y,direct mapping
+363406005,Malignant neoplasm of colon (disorder),y,direct mapping
+94623007,Secondary malignant neoplasm of testis (disorder),y,direct mapping
+40244008,"Spindle cell melanoma, type B (morphologic abnormality)",y,direct mapping
+61217001,Hutchinson's melanotic freckle (morphologic abnormality),y,direct mapping
+93763008,Primary malignant neoplasm of common bile duct (disorder),y,direct mapping
+363447008,Malignant neoplasm of labia minora (disorder),y,direct mapping
+428100006,Malignant neoplasm of thoracic cavity structure (disorder),y,direct mapping
+363474009,Malignant neoplasm of cerebral meninges (disorder),y,direct mapping
+314969001,Local recurrence of malignant tumor of prostate (disorder),y,direct mapping
+254437001,Squamous cell carcinoma of buccal mucosa (disorder),y,direct mapping
+255123005,Metastasis to nervous system and eye (disorder),y,direct mapping
+254425003,Carcinoma of lower gum (disorder),y,direct mapping
+188322004,"Malignant neoplasm of peripheral nerves of head, face and neck (disorder)",y,direct mapping
+363470000,Malignant neoplasm of occipital lobe (disorder),y,direct mapping
+94611001,Secondary malignant neoplasm of submental lymph nodes (disorder),y,direct mapping
+371973000,Malignant neoplasm of uterus (disorder),y,direct mapping
+314991008,Metastasis from malignant tumor of adrenal gland (disorder),y,direct mapping
+15674004,Serous surface papillary carcinoma (morphologic abnormality),y,direct mapping
+254840009,Inflammatory carcinoma of breast (disorder),y,direct mapping
+94603006,Secondary malignant neoplasm of spleen (disorder),y,direct mapping
+21968007,"Papillary carcinoma, follicular variant (morphologic abnormality)",y,direct mapping
+307593001,Carcinomatosis (disorder),y,direct mapping
+448233000,Malignant neoplasm of urinary organ (disorder),y,direct mapping
+82267002,"Malignant tumor, small cell type (morphologic abnormality)",y,direct mapping
+326072005,Carcinoma of head of pancreas (disorder),y,direct mapping
+416842003,Malignant sacral teratoma (disorder),y,direct mapping
+314990009,Metastasis from malignant tumor of bone (disorder),y,direct mapping
+94365007,Secondary malignant neoplasm of large intestine (disorder),y,direct mapping
+363386008,Malignant tumor of buccal mucosa (disorder),y,direct mapping
+363385007,Malignant tumor of floor of mouth (disorder),y,direct mapping
+59583009,Embryonal sarcoma (morphologic abnormality),y,direct mapping
+56422000,"Synovial sarcoma, epithelioid cell (morphologic abnormality)",y,direct mapping
+281566005,Abdominothoracic neuroblastoma (disorder),y,direct mapping
+187688008,Malignant tumor of posterior wall of oropharynx (disorder),y,direct mapping
+188234005,Malignant tumor of seminal vesicle (disorder),y,direct mapping
+254850005,Serous papillary cystadenocarcinoma ovary (disorder),y,direct mapping
+188307009,Malignant tumor of cranial nerve (disorder),y,direct mapping
+255107005,Seminoma of testis (disorder),y,direct mapping
+363366009,Malignant tumor of soft tissue of pelvis (disorder),y,direct mapping
+277156006,Malignant tumor of external ear (disorder),y,direct mapping
+363456000,Malignant tumor of urachus (disorder),y,direct mapping
+90725004,Serous cystadenocarcinoma (morphologic abnormality),y,direct mapping
+254441002,Carcinoma of upper buccal sulcus (disorder),y,direct mapping
+92604004,Carcinoma in situ of greater curvature of stomach (disorder),y,direct mapping
+128750008,Rhabdomyosarcoma with ganglionic differentiation (morphologic abnormality),y,direct mapping
+254989000,Carcinoma ex pleomorphic adenoma of lacrimal gland (disorder),y,direct mapping
+188054000,Malignant melanoma of perineum (disorder),y,direct mapping
+45024009,Hepatoblastoma (morphologic abnormality),y,direct mapping
+307608006,Ewing's sarcoma of bone (disorder),y,direct mapping
+254466003,Carcinoma of sublingual gland (disorder),y,direct mapping
+187792009,Malignant tumor of tail of pancreas (disorder),y,direct mapping
+274085008,Tonsil carcinoma (disorder),y,direct mapping
+93941005,Primary malignant neoplasm of paraganglion (disorder),y,direct mapping
+20667008,Myosarcoma (morphologic abnormality),y,direct mapping
+1090311000000101,Malignant neoplasm of trunk (disorder),y,direct mapping
+187724003,Malignant tumor of abdominal part of esophagus (disorder),y,direct mapping
+15949004,"Thymoma, malignant (morphologic abnormality)",y,direct mapping
+32456001,Desmoplastic medulloblastoma (morphologic abnormality),y,direct mapping
+286895009,"Carcinoma of breast - upper, outer quadrant (disorder)",y,direct mapping
+285617006,Metastasis to retroperitoneum of unknown primary (disorder),y,direct mapping
+310498001,Malignant melanoma of back (disorder),y,direct mapping
+56484001,Adenocarcinoma with cartilaginous and osseous metaplasia (morphologic abnormality),y,direct mapping
+448992002,Malignant epithelial neoplasm of appendix (disorder),y,direct mapping
+188069004,Malignant melanoma of thigh (disorder),y,direct mapping
+51217003,Acidophil carcinoma (morphologic abnormality),y,direct mapping
+23444003,Mixed acidophil-basophil carcinoma (morphologic abnormality),y,direct mapping
+188323009,"Malignant neoplasm of peripheral nerves of upper limb, including shoulder (disorder)",y,direct mapping
+1090301000000103,Malignant neoplasm of flank (disorder),y,direct mapping
+27092008,Ameloblastic fibrosarcoma (morphologic abnormality),y,direct mapping
+93927001,Primary malignant neoplasm of occipital bone (disorder),y,direct mapping
+363485006,Malignant tumor of minor salivary gland (disorder),y,direct mapping
+372094002,Malignant neoplasm of axillary tail of breast (disorder),y,direct mapping
+51465000,Composite carcinoid (morphologic abnormality),y,direct mapping
+703545003,Encapsulated papillary carcinoma (morphologic abnormality),y,direct mapping
+253092005,Malignant Schwannoma with divergent mesenchymal and epithelial differentiation (morphologic abnormality),y,direct mapping
+254509006,Malignant tumor of anterior commissure (disorder),y,direct mapping
+14494009,Meningeal sarcomatosis (morphologic abnormality),y,direct mapping
+188033007,Malignant melanoma of auricle (ear) (disorder),y,direct mapping
+285645000,Disseminated malignancy of unknown primary (disorder),y,direct mapping
+39896009,"Malignant melanoma, regressing (morphologic abnormality)",y,direct mapping
+254484001,Malignant tumor of posterior margin of nasal septum and choanae (disorder),y,direct mapping
+80727009,Water-clear cell adenocarcinoma (morphologic abnormality),y,direct mapping
+187833006,"Malignant neoplasm of auditory tube, middle ear and mastoid air cells (disorder)",y,direct mapping
+55320002,Superficial spreading melanoma (morphologic abnormality),y,direct mapping
+253096008,Peripheral neuroectodermal tumor (disorder),y,direct mapping
+187702003,Malignant tumor of nasopharyngeal soft palate surface (disorder),y,direct mapping
+187972006,Malignant neoplasm of navicular (disorder),y,direct mapping
+372101000,Carcinoma of extrahepatic bile duct (disorder),y,direct mapping
+188153009,Malignant neoplasm of lower-inner quadrant of female breast (disorder),y,direct mapping
+363410008,Malignant tumor of sigmoid colon (disorder),y,direct mapping
+50007008,Chordoma (morphologic abnormality),y,direct mapping
+312104005,Cholangiocarcinoma of biliary tract (disorder),y,direct mapping
+255083005,Malignant tumor of anus and anal canal (disorder),y,direct mapping
+372141009,Carcinoma of vocal cord (disorder),y,direct mapping
+254838004,Carcinoma of breast (disorder),y,direct mapping
+449627008,Malignant neoplasm of long bone of lower limb (disorder),y,direct mapping
+188290004,Malignant neoplasm of uncus (disorder),y,direct mapping
+254559002,Carcinoma of pyloric antrum (disorder),y,direct mapping
+2092003,"Malignant melanoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+94283001,Secondary malignant neoplasm of epididymis (disorder),y,direct mapping
+1090941000000104,Malignant neoplasm of inguinal region (disorder),y,direct mapping
+314968009,Local recurrence of malignant tumor of urinary bladder (disorder),y,direct mapping
+307219002,Retroperitoneal sarcoma (disorder),y,direct mapping
+187644001,Malignant tumor of junctional zone of tongue (disorder),y,direct mapping
+62064005,"Mesothelioma, malignant (morphologic abnormality)",y,direct mapping
+915007,Malignant melanoma in junctional nevus (morphologic abnormality),y,direct mapping
+188193007,Malignant neoplasm of myometrium of corpus uteri (disorder),y,direct mapping
+363421004,Malignant neoplasm of omentum (disorder),y,direct mapping
+276419004,Malignant tumor of corpus spongiosum (disorder),y,direct mapping
+363458004,Malignant tumor of ureter (disorder),y,direct mapping
+315000005,Metastasis from malignant tumor of liver (disorder),y,direct mapping
+285634003,Metastasis to breast of unknown primary (disorder),y,direct mapping
+884601000000103,Bowel scope (flexible sigmoidoscopy) screen: cancer detected (finding),y,direct mapping
+128916007,Medullary carcinoma with amyloid stroma (morphologic abnormality),y,direct mapping
+187798008,Malignant neoplasm of ectopic pancreatic tissue (disorder),y,direct mapping
+93759001,Primary malignant neoplasm of coccygeal body (disorder),y,direct mapping
+187738005,Malignant neoplasm of pyloric canal of stomach (disorder),y,direct mapping
+109837002,Overlapping malignant neoplasm of small intestine (disorder),y,direct mapping
+363411007,Malignant tumor of appendix (disorder),y,direct mapping
+9618003,Epithelial-myoepithelial carcinoma (morphologic abnormality),y,direct mapping
+55045006,Neuroepithelioma (morphologic abnormality),y,direct mapping
+94612008,Secondary malignant neoplasm of superficial inguinal lymph nodes (disorder),y,direct mapping
+187925006,Malignant neoplasm of costal cartilage (disorder),y,direct mapping
+94357009,Secondary malignant neoplasm of jejunum (disorder),y,direct mapping
+94297009,Secondary malignant neoplasm of female breast (disorder),y,direct mapping
+370967009,Retinoblastoma (disorder),y,direct mapping
+255069008,"Carcinoma of lip, oral cavity and/or pharynx (disorder)",y,direct mapping
+187734007,Malignant neoplasm of cardioesophageal junction of stomach (disorder),y,direct mapping
+94513006,Secondary malignant neoplasm of rectum (disorder),y,direct mapping
+285607001,Metastasis to mediastinum of unknown primary (disorder),y,direct mapping
+1090171000000108,Secondary malignant neoplasm of sacral lymph nodes (disorder),y,direct mapping
+372156000,Malignant melanoma - category (morphologic abnormality),y,direct mapping
+67830002,Teratocarcinoma (morphologic abnormality),y,direct mapping
+37206003,"Synovial sarcoma, spindle cell (morphologic abnormality)",y,direct mapping
+13875003,Glomangiosarcoma (morphologic abnormality),y,direct mapping
+363489000,Malignant tumor of neck (disorder),y,direct mapping
+188253000,Malignant tumor of pelviureteric junction (disorder),y,direct mapping
+72907003,"Seminoma, anaplastic (morphologic abnormality)",y,direct mapping
+286890004,Carcinoma of lower limb bones (disorder),y,direct mapping
+254918001,Sarcoma of kidney (disorder),y,direct mapping
+187786003,Malignant neoplasm of sphincter of Oddi (disorder),y,direct mapping
+109848009,Overlapping malignant neoplasm of pancreas (disorder),y,direct mapping
+19906005,Retinoblastoma (morphologic abnormality),y,direct mapping
+30546008,Clear cell adenocarcinoma (morphologic abnormality),y,direct mapping
+363397008,Malignant tumor of roof of nasopharynx (disorder),y,direct mapping
+254863004,Granulosa cell tumor of ovary (disorder),y,direct mapping
+314994000,Metastasis from malignant tumor of prostate (disorder),y,direct mapping
+73348003,"Oligodendroglioma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+363504005,Malignant tumor of lower limb (disorder),y,direct mapping
+254730000,Superficial spreading malignant melanoma of skin (disorder),y,direct mapping
+187777008,Malignant neoplasm of intrahepatic gall duct (disorder),y,direct mapping
+187929000,Malignant neoplasm of scapula and long bones of upper arm (disorder),y,direct mapping
+55937004,Neuroendocrine tumor (morphologic abnormality),y,direct mapping
+109830000,Overlapping malignant neoplasm of floor of mouth (disorder),y,direct mapping
+93817006,Primary malignant neoplasm of great vessels (disorder),y,direct mapping
+187793004,Malignant tumor of pancreatic duct (disorder),y,direct mapping
+254877001,Sarcoma of uterus (disorder),y,direct mapping
+24604009,Medullomyoblastoma (morphologic abnormality),y,direct mapping
+255128001,Malignant infiltration of peripheral nerve (disorder),y,direct mapping
+363500001,Multiple malignancy (disorder),y,direct mapping
+363465007,Malignant tumor of retina (disorder),y,direct mapping
+187920001,Malignant neoplasm of ribs and/or sternum and/or clavicle (disorder),y,direct mapping
+254570009,Carcinoma of duodenum (disorder),y,direct mapping
+177281002,Excision of melanoma (procedure),y,direct mapping
+285614004,Metastasis to pancreas of unknown primary (disorder),y,direct mapping
+94455000,Secondary malignant neoplasm of ovary (disorder),y,direct mapping
+721567004,Primary malignant neoplasm of placenta (disorder),y,direct mapping
+94515004,Secondary malignant neoplasm of respiratory tract (disorder),y,direct mapping
+109844006,Angiosarcoma of liver (disorder),y,direct mapping
+35232005,Infiltrating duct and lobular carcinoma (morphologic abnormality),y,direct mapping
+30713000,Hypernephroid tumor (morphologic abnormality),y,direct mapping
+254996003,Malignant fibrous histiocytoma of orbit (disorder),y,direct mapping
+276826005,Malignant glioma of brain (disorder),y,direct mapping
+188293002,Malignant neoplasm of floor of cerebral ventricle (disorder),y,direct mapping
+77659000,Paraneoplastic neuropathy (disorder),y,direct mapping
+187740000,Malignant tumor of pyloric antrum (disorder),y,direct mapping
+312949007,Retinal pigment epithelial adenocarcinoma (disorder),y,direct mapping
+304545002,Adenocarcinoma of ileum (disorder),y,direct mapping
+187653008,Malignant tumor of lateral floor of mouth (disorder),y,direct mapping
+94181007,Secondary malignant neoplasm of axillary lymph nodes (disorder),y,direct mapping
+363412000,Malignant tumor of ascending colon (disorder),y,direct mapping
+449254004,Malignant epithelial neoplasm of pharynx (disorder),y,direct mapping
+363507003,Malignant neoplasm of pharynx (disorder),y,direct mapping
+254734009,Malignant melanoma arising in congenital nevus (disorder),y,direct mapping
+276962007,Squamous cell carcinoma of palate (disorder),y,direct mapping
+449420002,Malignant neoplasm of cerebellum (disorder),y,direct mapping
+93924008,Primary malignant neoplasm of nipple of female breast (disorder),y,direct mapping
+188183000,Malignant neoplasm of cervical stump (disorder),y,direct mapping
+254390001,Carcinoma of vermilion border of lower lip (disorder),y,direct mapping
+188184006,Malignant neoplasm of squamocolumnar junction of cervix (disorder),y,direct mapping
+363430007,Malignant tumor of subglottis (disorder),y,direct mapping
+188230001,Malignant tumor of body of penis (disorder),y,direct mapping
+9903002,"Paraganglioma, malignant (morphologic abnormality)",y,direct mapping
+94409002,Secondary malignant neoplasm of mediastinum (disorder),y,direct mapping
+189826001,Malignant cystosarcoma phyllodes (morphologic abnormality),y,direct mapping
+255112006,Malignant tumor of pituitary and hypothalamus (disorder),y,direct mapping
+94416001,Secondary malignant neoplasm of mouth (disorder),y,direct mapping
+314961003,Local recurrence of malignant tumor of stomach (disorder),y,direct mapping
+188319001,Malignant neoplasm of spinal pia mater (disorder),y,direct mapping
+255074000,Malignant tumor of nasal cavity and nasopharynx (disorder),y,direct mapping
+93757004,Primary malignant neoplasm of clavicle (disorder),y,direct mapping
+187992004,Malignant neoplasm of connective and soft tissue of shoulder (disorder),y,direct mapping
+188021002,Malignant neoplasm of connective and soft tissue of inguinal region (disorder),y,direct mapping
+314963000,Local recurrence of malignant tumor of liver (disorder),y,direct mapping
+187760008,"Malignant neoplasm of rectum, rectosigmoid junction and anus (disorder)",y,direct mapping
+56565002,Mesenchymal chondrosarcoma (morphologic abnormality),y,direct mapping
+363477002,Malignant neoplasm of cauda equina (disorder),y,direct mapping
+363416002,Malignant tumor of extrahepatic bile duct (disorder),y,direct mapping
+254567005,Carcinoma of greater curve of stomach (disorder),y,direct mapping
+94260004,Secondary malignant neoplasm of colon (disorder),y,direct mapping
+254393004,Carcinoma of frenum of lip (disorder),y,direct mapping
+372063002,Malignant neoplasm of nervous system (disorder),y,direct mapping
+254478004,Malignant tumor of inferior turbinate (disorder),y,direct mapping
+86049000,"Malignant neoplasm, primary (morphologic abnormality)",y,direct mapping
+189923008,Monstrocellular sarcoma (morphologic abnormality),y,direct mapping
+255109008,Transitional cell carcinoma of bladder (disorder),y,direct mapping
+93995000,Primary malignant neoplasm of sacrococcygeal region (disorder),y,direct mapping
+187943005,Malignant neoplasm of carpal bone - capitate (disorder),y,direct mapping
+87364003,Neuroblastoma (morphologic abnormality),y,direct mapping
+188263008,Malignant tumor of ciliary body (disorder),y,direct mapping
+363434003,Malignant tumor of thymus (disorder),y,direct mapping
+255114007,Kaposi's sarcoma of conjunctiva (disorder),y,direct mapping
+66515009,"Glucagonoma, malignant (morphologic abnormality)",y,direct mapping
+277993001,Olfactory neuroendocrine carcinoma (morphologic abnormality),y,direct mapping
+254586002,Malignant tumor of anorectal junction (disorder),y,direct mapping
+31186001,Chondroma (morphologic abnormality),y,direct mapping
+255072001,Malignant tumor of salivary gland (disorder),y,direct mapping
+1090911000000100,Chondroma (disorder),y,direct mapping
+363389001,Malignant tumor of uvula (disorder),y,direct mapping
+187947006,Malignant neoplasm of third metacarpal bone (disorder),y,direct mapping
+188063003,Malignant melanoma of hand (disorder),y,direct mapping
+285637005,Metastasis to ovary of unknown primary (disorder),y,direct mapping
+94491007,Secondary malignant neoplasm of pituitary gland (disorder),y,direct mapping
+187970003,Malignant neoplasm of lateral cuneiform (disorder),y,direct mapping
+12302002,Small cell osteosarcoma (morphologic abnormality),y,direct mapping
+254445006,Carcinoma of lower buccal sulcus (disorder),y,direct mapping
+712525007,Malignant neoplasm of short bone of lower limb (disorder),y,direct mapping
+439740005,Postoperative follow-up visit (procedure),y,direct mapping
+112679004,Pseudomyxoma peritonei (morphologic abnormality),y,direct mapping
+363419009,Malignant tumor of head of pancreas (disorder),y,direct mapping
+94335002,Secondary malignant neoplasm of ileum (disorder),y,direct mapping
+187842004,Malignant tumor of supraglottis (disorder),y,direct mapping
+188072006,Malignant melanoma of lower leg (disorder),y,direct mapping
+254526000,Malignant tumor of laryngeal ventricle (disorder),y,direct mapping
+363368005,Carcinoma of body of pancreas (disorder),y,direct mapping
+187767006,Malignant neoplasm of liver and intrahepatic bile ducts (disorder),y,direct mapping
+187939006,Malignant neoplasm of carpal bone - triquetrum (disorder),y,direct mapping
+94393006,Secondary malignant neoplasm of lymph nodes of face (disorder),y,direct mapping
+83217000,"Medulloblastoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+187811009,Malignant neoplasm of mesorectum (disorder),y,direct mapping
+93806005,Primary malignant neoplasm of frontal bone (disorder),y,direct mapping
+314970000,Local recurrence of malignant tumor of cervix (disorder),y,direct mapping
+32913002,Medullary carcinoma (morphologic abnormality),y,direct mapping
+26211003,Juxtacortical chondrosarcoma (morphologic abnormality),y,direct mapping
+109367000,Overlapping malignant neoplasm of nasopharynx (disorder),y,direct mapping
+188308004,Malignant neoplasm of olfactory bulb (disorder),y,direct mapping
+187652003,Malignant tumor of anterior floor of mouth (disorder),y,direct mapping
+269580008,Malignant melanoma of upper limb (disorder),y,direct mapping
+188176007,Malignant neoplasm of endocervical canal (disorder),y,direct mapping
+188235006,Malignant tumor of tunica vaginalis (disorder),y,direct mapping
+187692001,Malignant tumor of nasopharynx (disorder),y,direct mapping
+363449006,Malignant tumor of testis (disorder),y,direct mapping
+188285002,Malignant neoplasm of globus pallidus (disorder),y,direct mapping
+1090931000000108,Malignant neoplasm of multiple endocrine glands (disorder),y,direct mapping
+68358000,Adenocarcinoma with spindle cell metaplasia (morphologic abnormality),y,direct mapping
+13238004,"Granular cell tumor, malignant (morphologic abnormality)",y,direct mapping
+48952003,Astroblastoma (morphologic abnormality),y,direct mapping
+363387004,Malignant tumor of hard palate (disorder),y,direct mapping
+188050009,Malignant melanoma of breast (disorder),y,direct mapping
+187835004,Malignant tumor of tympanic cavity (disorder),y,direct mapping
+77870005,"Leydig cell tumor, malignant (morphologic abnormality)",y,direct mapping
+93925009,Primary malignant neoplasm of nipple of male breast (disorder),y,direct mapping
+363402007,Malignant tumor of esophagus (disorder),y,direct mapping
+1090161000000101,Secondary malignant neoplasm of diaphragmatic lymph nodes (disorder),y,direct mapping
+1090221000000100,Secondary malignant neoplasm of internal iliac lymph nodes (disorder),y,direct mapping
+363488008,Malignant tumor of false cord (disorder),y,direct mapping
+255129009,Malignant infiltration of peripheral nerve plexus (disorder),y,direct mapping
+94350006,Secondary malignant neoplasm of intrapelvic lymph nodes (disorder),y,direct mapping
+6219000,"Neoplasm, malignant, uncertain whether primary or metastatic (morphologic abnormality)",y,direct mapping
+94609005,Secondary malignant neoplasm of submandibular lymph nodes (disorder),y,direct mapping
+74409009,Endodermal sinus tumor (morphologic abnormality),y,direct mapping
+307226002,Metastatic adenocarcinoma of unknown origin (disorder),y,direct mapping
+187903000,Malignant neoplasm of malar bone (disorder),y,direct mapping
+88252006,Choroid plexus carcinoma (morphologic abnormality),y,direct mapping
+93888008,Primary malignant neoplasm of maxilla (disorder),y,direct mapping
+187927003,Malignant neoplasm of xiphoid process (disorder),y,direct mapping
+76312009,Chondroblastic osteosarcoma (morphologic abnormality),y,direct mapping
+363364007,Malignant tumor of soft tissue of hip (disorder),y,direct mapping
+188019007,Malignant neoplasm of connective and soft tissue of pelvis (disorder),y,direct mapping
+187637005,"Malignant neoplasm of tongue, tip and lateral border (disorder)",y,direct mapping
+275396004,Carcinoma of anterior two-thirds of tongue - dorsal surface (disorder),y,direct mapping
+187987001,Malignant neoplasm of cartilage of ear (disorder),y,direct mapping
+128918008,Parosteal osteosarcoma (morphologic abnormality),y,direct mapping
+363408006,Malignant tumor of transverse colon (disorder),y,direct mapping
+94081005,Primary malignant neoplasm of sweat gland (disorder),y,direct mapping
+188154003,Malignant neoplasm of upper-outer quadrant of female breast (disorder),y,direct mapping
+187829004,Malignant neoplasm of cartilage of nose (disorder),y,direct mapping
+109875002,Overlapping malignant neoplasm of penis (disorder),y,direct mapping
+187722004,Malignant tumor of cervical part of esophagus (disorder),y,direct mapping
+277530005,Malignant melanoma of meninges (disorder),y,direct mapping
+1090281000000104,Malignant neoplasm of genital labia (disorder),y,direct mapping
+94449005,Secondary malignant neoplasm of occipital lymph nodes (disorder),y,direct mapping
+93770008,Primary malignant neoplasm of cystic duct (disorder),y,direct mapping
+399326009,Malignant tumor of urinary bladder (disorder),y,direct mapping
+62681000,Nonencapsulated sclerosing carcinoma (morphologic abnormality),y,direct mapping
+94233006,Secondary malignant neoplasm of bronchus (disorder),y,direct mapping
+956531000000104,Malignant melanoma stage IV M1b (finding),y,direct mapping
+188157005,"Malignant neoplasm, overlapping lesion of breast (disorder)",y,direct mapping
+314973003,Local recurrence of malignant tumor of bone (disorder),y,direct mapping
+363367000,Malignant tumor of vulva (disorder),y,direct mapping
+187608006,Malignant tumor of frenum of upper lip (disorder),y,direct mapping
+447883002,Malignant neoplasm of carotid body (disorder),y,direct mapping
+275419009,Primary vulval cancer (disorder),y,direct mapping
+187659007,Malignant tumor of upper buccal sulcus (disorder),y,direct mapping
+254457002,Carcinoma of retromolar area (disorder),y,direct mapping
+254436005,Carcinoma of uvula (disorder),y,direct mapping
+187844003,Malignant neoplasm of cricoid cartilage (disorder),y,direct mapping
+81920005,Solid carcinoma (morphologic abnormality),y,direct mapping
+83292005,"Malignant teratoma, undifferentiated (morphologic abnormality)",y,direct mapping
+187773007,Malignant neoplasm of interlobular bile ducts (disorder),y,direct mapping
+253018005,Fibrolamellar hepatocellular carcinoma (disorder),y,direct mapping
+363399006,Malignant tumor of hypopharynx (disorder),y,direct mapping
+269459004,Malignant tumor of lesser curve of stomach (disorder),y,direct mapping
+188009001,Malignant neoplasm of connective and soft tissue of thorax (disorder),y,direct mapping
+188286001,Malignant tumor of hypothalamus (disorder),y,direct mapping
+416769008,Malignant teratoma of testis (disorder),y,direct mapping
+285631006,Metastasis to skin of unknown primary (disorder),y,direct mapping
+187814001,Malignant neoplasm of the pouch of Douglas (disorder),y,direct mapping
+188052001,Malignant melanoma of groin (disorder),y,direct mapping
+17264009,Carcinoma ex pleomorphic adenoma (morphologic abnormality),y,direct mapping
+276821000,Malignant melanoma of anus (disorder),y,direct mapping
+254886006,Squamous cell carcinoma of cervix (disorder),y,direct mapping
+363428005,Malignant tumor of sphenoid sinus (disorder),y,direct mapping
+29792007,Trabecular adenocarcinoma (morphologic abnormality),y,direct mapping
+93955002,Primary malignant neoplasm of periadrenal tissue (disorder),y,direct mapping
+188074007,Malignant melanoma of heel (disorder),y,direct mapping
+278050001,Sarcoma of breast (disorder),y,direct mapping
+188240003,Malignant tumor of vault of bladder (disorder),y,direct mapping
+20380000,Ameloblastic odontosarcoma (morphologic abnormality),y,direct mapping
+187733001,Malignant neoplasm of cardiac orifice of stomach (disorder),y,direct mapping
+94248000,Secondary malignant neoplasm of cerebrum (disorder),y,direct mapping
+887521000000104,Cervical smear - high grade dyskaryosis with features of invasive squamous carcinoma (finding),y,direct mapping
+38958001,Mixed cell adenocarcinoma (morphologic abnormality),y,direct mapping
+187836003,Malignant tumor of tympanic antrum (disorder),y,direct mapping
+187757001,"Malignant neoplasm, overlapping lesion of colon (disorder)",y,direct mapping
+37138001,Epithelioid cell melanoma (morphologic abnormality),y,direct mapping
+363445000,Malignant tumor of vagina (disorder),y,direct mapping
+188340000,Malignant tumor of craniopharyngeal duct (disorder),y,direct mapping
+30924005,"Rhabdomyosarcoma, no subtype (morphologic abnormality)",y,direct mapping
+109348004,Overlapping malignant neoplasm of bone and articular cartilage of limbs (disorder),y,direct mapping
+1090101000000100,Secondary malignant neoplasm of supratrochlear lymph nodes (disorder),y,direct mapping
+443679004,Malignant neoplasm of skeletal system (disorder),y,direct mapping
+27849002,Myxoid liposarcoma (morphologic abnormality),y,direct mapping
+276808007,Carcinoid tumor of stomach (disorder),y,direct mapping
+19897006,Malignant peripheral nerve sheath tumor (morphologic abnormality),y,direct mapping
+417570003,Gestational choriocarcinoma (disorder),y,direct mapping
+254975005,Malignant meningioma of optic nerve sheath (disorder),y,direct mapping
+363497007,Malignant tumor of meninges (disorder),y,direct mapping
+254934003,Malignant tumor of urethral stump (disorder),y,direct mapping
+87737001,Signet ring cell carcinoma (morphologic abnormality),y,direct mapping
+255066001,Carcinoma of genitourinary organ (disorder),y,direct mapping
+255035007,Adrenal carcinoma (disorder),y,direct mapping
+2985005,"Paget's disease, mammary (morphologic abnormality)",y,direct mapping
+93680004,Primary malignant neoplasm of areola of female breast (disorder),y,direct mapping
+285635002,Metastasis to uterus of unknown primary (disorder),y,direct mapping
+94280003,Secondary malignant neoplasm of endocrine gland (disorder),y,direct mapping
+187700006,Malignant tumor of anterior wall of nasopharynx (disorder),y,direct mapping
+187956003,Malignant neoplasm of sacral vertebra (disorder),y,direct mapping
+371972005,Malignant neoplasm of body of uterus (disorder),y,direct mapping
+31671006,Pineoblastoma (morphologic abnormality),y,direct mapping
+303201005,Metastasis to multiple lymph nodes (disorder),y,direct mapping
+363466008,Malignant tumor of choroid (disorder),y,direct mapping
+187784000,Malignant neoplasm of hepatic duct (disorder),y,direct mapping
+188301005,Malignant neoplasm of corpus callosum (disorder),y,direct mapping
+94579000,Secondary malignant neoplasm of skin (disorder),y,direct mapping
+128462008,Secondary malignant neoplastic disease (disorder),y,direct mapping
+94626004,Secondary malignant neoplasm of omentum (disorder),y,direct mapping
+314953008,Local recurrence of malignant tumor of thyroid gland (disorder),y,direct mapping
+254601002,Sarcoma of liver (disorder),y,direct mapping
+57141000,Apocrine adenocarcinoma (morphologic abnormality),y,direct mapping
+1090201000000109,Secondary malignant neoplasm of deep inguinal lymph nodes (disorder),y,direct mapping
+188325002,Malignant neoplasm of peripheral nerve of thorax (disorder),y,direct mapping
+1090251000000105,Malignant neoplasm of nose (disorder),y,direct mapping
+255031003,Anaplastic thyroid carcinoma (disorder),y,direct mapping
+188321006,Malignant neoplasm of peripheral nerves and autonomic nervous system (disorder),y,direct mapping
+74532006,"Glioma, malignant (morphologic abnormality)",y,direct mapping
+188353002,"Malignant neoplasm of head, neck and face (disorder)",y,direct mapping
+188272000,Malignant tumor of lacrimal gland (disorder),y,direct mapping
+73506006,Small cell sarcoma (morphologic abnormality),y,direct mapping
+363438000,Malignant tumor of vertebral column (disorder),y,direct mapping
+254839007,Scirrhous carcinoma of breast (disorder),y,direct mapping
+188315007,Malignant neoplasm of cerebral pia mater (disorder),y,direct mapping
+363352004,Malignant tumor of anal canal (disorder),y,direct mapping
+22217002,Mixed glioma (morphologic abnormality),y,direct mapping
+254912000,Regressed malignant testicular tumor (disorder),y,direct mapping
+93782004,Primary malignant neoplasm of epicardium (disorder),y,direct mapping
+93957005,Primary malignant neoplasm of pericardium (disorder),y,direct mapping
+187709007,Malignant neoplasm of posterior pharynx (disorder),y,direct mapping
+371979001,Malignant neoplasm of clitoris (disorder),y,direct mapping
+74279005,"Chondroblastoma, malignant (morphologic abnormality)",y,direct mapping
+94494004,Secondary malignant neoplasm of popliteal lymph nodes (disorder),y,direct mapping
+274084007,Palate carcinoma (disorder),y,direct mapping
+187938003,Malignant neoplasm of carpal bone - lunate (disorder),y,direct mapping
+94292003,Secondary malignant neoplasm of eye (disorder),y,direct mapping
+363494000,Malignant tumor of mediastinum (disorder),y,direct mapping
+443565000,Oligodendroglioma - category (morphologic abnormality),y,direct mapping
+363492001,Malignant tumor of peritoneum (disorder),y,direct mapping
+94338000,Secondary malignant neoplasm of infraclavicular lymph nodes (disorder),y,direct mapping
+253077009,Melanocytic medullomyoblastoma (morphologic abnormality),y,direct mapping
+109836006,Overlapping malignant neoplasm of stomach (disorder),y,direct mapping
+88334008,Teratoma with malignant transformation (morphologic abnormality),y,direct mapping
+372140005,Carcinoma of gallbladder (disorder),y,direct mapping
+93677000,Primary malignant neoplasm of aortic body (disorder),y,direct mapping
+254993006,Liposarcoma of orbit (disorder),y,direct mapping
+187841006,Malignant tumor of glottis (disorder),y,direct mapping
+188034001,Malignant melanoma of external auditory meatus (disorder),y,direct mapping
+363363001,Malignant tumor of soft tissue of shoulder (disorder),y,direct mapping
+429033009,Malignant neoplasm of cerebrum (disorder),y,direct mapping
+278055006,Malignant Leydig cell tumor of testis (disorder),y,direct mapping
+18450009,Malignant melanoma in precancerous melanosis (morphologic abnormality),y,direct mapping
+413743008,Cancer rehabilitation and readaption (regime/therapy),y,direct mapping
+187834000,Malignant tumor of Eustachian tube (disorder),y,direct mapping
+16974005,"Acral lentiginous melanoma, malignant (morphologic abnormality)",y,direct mapping
+54443001,"Fibrous mesothelioma, malignant (morphologic abnormality)",y,direct mapping
+285644001,Metastasis to lymph node of unknown primary (disorder),y,direct mapping
+93772000,Primary malignant neoplasm of diaphragm (disorder),y,direct mapping
+231834005,Malignant melanoma of eyelid (disorder),y,direct mapping
+94395004,Secondary malignant neoplasm of lymph nodes of lower limb (disorder),y,direct mapping
+363414004,Malignant tumor of rectosigmoid junction (disorder),y,direct mapping
+187725002,Malignant tumor of upper third of esophagus (disorder),y,direct mapping
+188190005,Malignant neoplasm of cornu of corpus uteri (disorder),y,direct mapping
+93842002,Primary malignant neoplasm of ischium (disorder),y,direct mapping
+315008003,Metastasis from malignant tumor of buccal cavity (disorder),y,direct mapping
+399068003,Malignant tumor of prostate (disorder),y,direct mapping
+363484005,Malignant tumor of pelvis (disorder),y,direct mapping
+52178006,Combined hepatocellular carcinoma and cholangiocarcinoma (morphologic abnormality),y,direct mapping
+269578002,Malignant melanoma of head and neck (disorder),y,direct mapping
+4305004,Metastatic signet ring cell carcinoma (morphologic abnormality),y,direct mapping
+82711006,Infiltrating duct carcinoma (morphologic abnormality),y,direct mapping
+254828009,Malignant lipomatous tumor (disorder),y,direct mapping
+188295009,Malignant neoplasm of cerebral peduncle (disorder),y,direct mapping
+254995004,Malignant hemangiopericytoma of orbit (disorder),y,direct mapping
+94083008,Primary malignant neoplasm of talus (disorder),y,direct mapping
+94161006,Secondary malignant neoplasm of adrenal gland (disorder),y,direct mapping
+26138003,Gliomatosis cerebri (morphologic abnormality),y,direct mapping
+254915003,Clear cell carcinoma of kidney (disorder),y,direct mapping
+315002002,Metastasis from malignant tumor of stomach (disorder),y,direct mapping
+94085001,Primary malignant neoplasm of temporal bone (disorder),y,direct mapping
+2227007,Adrenal cortical carcinoma (morphologic abnormality),y,direct mapping
+78453009,Telangiectatic osteosarcoma (morphologic abnormality),y,direct mapping
+286899003,Carcinoma of genital organ (disorder),y,direct mapping
+93643005,Malignant melanoma of skin of nose (disorder),y,direct mapping
+285611007,Metastasis to colon of unknown primary (disorder),y,direct mapping
+314989000,Metastasis from malignant tumor of soft tissues (disorder),y,direct mapping
+395099008,Cancer confirmed (situation),y,direct mapping
+188076009,Malignant melanoma of toe (disorder),y,direct mapping
+254869000,Malignant germ cell tumor of ovary (disorder),y,direct mapping
+93728003,Primary malignant neoplasm of broad ligament (disorder),y,direct mapping
+93979000,Primary malignant neoplasm of radius (disorder),y,direct mapping
+363505006,Malignant tumor of oral cavity (disorder),y,direct mapping
+4797003,Papillary adenocarcinoma (morphologic abnormality),y,direct mapping
+88195001,Alveolar soft part sarcoma (morphologic abnormality),y,direct mapping
+188462001,Secondary malignant neoplasm of brain and spinal cord (disorder),y,direct mapping
+187916000,Malignant neoplasm of cervical vertebra (disorder),y,direct mapping
+26019009,"Retinoblastoma, differentiated (morphologic abnormality)",y,direct mapping
+188077000,Malignant melanoma of great toe (disorder),y,direct mapping
+188147009,Malignant neoplasm of nipple and areola of female breast (disorder),y,direct mapping
+363405009,Malignant tumor of ileum (disorder),y,direct mapping
+271568003,Malignant tumor of lower labial mucosa (disorder),y,direct mapping
+109378008,"Mesothelioma (malignant, clinical disorder) (disorder)",y,direct mapping
+187831008,Malignant tumor of nasal vestibule (disorder),y,direct mapping
+86562005,Cystic mesothelioma (morphologic abnormality),y,direct mapping
+1090081000000106,Secondary malignant neoplasm of paratracheal lymph nodes (disorder),y,direct mapping
+93947009,Primary malignant neoplasm of parietal peritoneum (disorder),y,direct mapping
+50813003,Mixed epithelioid and spindle cell melanoma (morphologic abnormality),y,direct mapping
+314191009,Cystadenocarcinoma of ovary (disorder),y,direct mapping
+253039003,Round cell sarcoma (morphologic abnormality),y,direct mapping
+448674007,Malignant neoplasm of parametrium (disorder),y,direct mapping
+315005000,Metastasis from malignant tumor of bronchus (disorder),y,direct mapping
+363446004,Malignant neoplasm of labia majora (disorder),y,direct mapping
+314987003,Metastasis from malignant melanoma of skin (disorder),y,direct mapping
+281562007,Adrenal neuroblastoma (disorder),y,direct mapping
+302835009,Pheochromocytoma (disorder),y,direct mapping
+72495009,Mucinous adenocarcinoma (morphologic abnormality),y,direct mapping
+363396004,Malignant tumor of branchial cleft (disorder),y,direct mapping
+342561000000102,Siewert type III adenocarcinoma (disorder),y,direct mapping
+254561006,Carcinoma of pylorus (disorder),y,direct mapping
+93950007,Primary malignant neoplasm of patella (disorder),y,direct mapping
+70179006,Cholangiocarcinoma (morphologic abnormality),y,direct mapping
+354002,Malignant peripheral nerve sheath tumor with rhabdomyoblastic differentiation (morphologic abnormality),y,direct mapping
+363418001,Malignant tumor of pancreas (disorder),y,direct mapping
+314952003,Local recurrence of malignant tumor of buccal cavity (disorder),y,direct mapping
+363496003,Malignant tumor of soft tissue of abdomen (disorder),y,direct mapping
+60346004,Islet cell carcinoma (morphologic abnormality),y,direct mapping
+254517003,Malignant tumor of suprahyoid epiglottis (disorder),y,direct mapping
+187937008,Malignant neoplasm of carpal bone - scaphoid (disorder),y,direct mapping
+394932008,Gleason prostate grade 5-7 (medium) (finding),y,direct mapping
+187830009,Malignant neoplasm of nasal conchae (disorder),y,direct mapping
+363391009,Malignant tumor of retromolar area (disorder),y,direct mapping
+188155002,Malignant neoplasm of lower-outer quadrant of female breast (disorder),y,direct mapping
+110013004,Overlapping malignant neoplasm of tonsil (disorder),y,direct mapping
+80091008,Sertoli cell carcinoma (morphologic abnormality),y,direct mapping
+109853004,Malignant mesothelioma of peritoneum (disorder),y,direct mapping
+254973003,Malignant astrocytoma of optic nerve (disorder),y,direct mapping
+94514000,Secondary malignant neoplasm of renal pelvis (disorder),y,direct mapping
+78197004,"Comedocarcinoma, noninfiltrating (morphologic abnormality)",y,direct mapping
+254543002,Carcinoma of abdominal part of esophagus (disorder),y,direct mapping
+363498002,Malignant tumor of optic nerve (disorder),y,direct mapping
+276829003,Glioblastoma multiforme of spinal cord (disorder),y,direct mapping
+187685006,Malignant neoplasm of junctional region of epiglottis (disorder),y,direct mapping
+281563002,Thoracic neuroblastoma (disorder),y,direct mapping
+1443001,Chromophobe carcinoma (morphologic abnormality),y,direct mapping
+187727005,Malignant tumor of lower third of esophagus (disorder),y,direct mapping
+253042009,Myxoid dermatofibrosarcoma protuberans (disorder),y,direct mapping
+94099002,Primary malignant neoplasm of tibia (disorder),y,direct mapping
+277985001,Nonteratoid medulloepithelioma (morphologic abnormality),y,direct mapping
+94503003,Secondary malignant neoplasm of prostate (disorder),y,direct mapping
+254837009,Malignant neoplasm of breast (disorder),y,direct mapping
+188326001,Malignant neoplasm of peripheral nerve of abdomen (disorder),y,direct mapping
+34360000,"Fibrous histiocytoma, malignant (morphologic abnormality)",y,direct mapping
+371964008,Malignant neoplasm of adrenal cortex (disorder),y,direct mapping
+94227002,Secondary malignant neoplasm of bronchopulmonary lymph nodes (disorder),y,direct mapping
+94392001,Secondary malignant neoplasm of lymph node (disorder),y,direct mapping
+285633009,Metastasis to soft tissue of unknown primary (disorder),y,direct mapping
+94225005,Secondary malignant neoplasm of brain (disorder),y,direct mapping
+187941007,Malignant neoplasm of carpal bone - trapezium (disorder),y,direct mapping
+187838002,"Malignant neoplasm, overlapping lesion of accessory sinuses (disorder)",y,direct mapping
+363457009,Malignant tumor of renal pelvis (disorder),y,direct mapping
+94638008,Secondary malignant neoplasm of tongue (disorder),y,direct mapping
+187601000,"Malignant neoplasm of upper lip, lipstick area (disorder)",y,direct mapping
+187776004,Malignant neoplasm of intrahepatic canaliculi (disorder),y,direct mapping
+77455004,Pleomorphic rhabdomyosarcoma (morphologic abnormality),y,direct mapping
+254412006,Malignant tumor of tip of tongue (disorder),y,direct mapping
+115232000,Mesothelial neoplasm (morphologic abnormality),y,direct mapping
+188046002,Malignant melanoma of neck (disorder),y,direct mapping
+276827001,Malignant glioma of spinal cord (disorder),y,direct mapping
+188042000,Malignant melanoma of temple (disorder),y,direct mapping
+187697007,Malignant tumor of pharyngeal recess (disorder),y,direct mapping
+363383000,Malignant tumor of upper gingiva (disorder),y,direct mapping
+254917006,Papillary cystadenocarcinoma of kidney (disorder),y,direct mapping
+94410007,Secondary malignant neoplasm of mesenteric lymph nodes (disorder),y,direct mapping
+712837004,Active surveillance of prostate cancer (regime/therapy),y,direct mapping
+419052002,Malignant tumor of urinary system (disorder),y,direct mapping
+188198003,Malignant neoplasm of overlapping lesion of corpus uteri (disorder),y,direct mapping
+254861002,Malignant granulosa cell tumor of ovary (disorder),y,direct mapping
+188204000,Malignant neoplasm of round ligament (disorder),y,direct mapping
+7010000,Carcinomatosis (morphologic abnormality),y,direct mapping
+275399006,Malignant tumor of lipstick area of lip (disorder),y,direct mapping
+372087000,Primary malignant neoplasm (disorder),y,direct mapping
+188327005,Malignant neoplasm of peripheral nerve of pelvis (disorder),y,direct mapping
+83118000,Malignant rhabdoid tumor (morphologic abnormality),y,direct mapping
+301036008,Disseminated adenocarcinoma (morphologic abnormality),y,direct mapping
+363515000,Malignant tumor of male genital organ (disorder),y,direct mapping
+255119002,Lymphangitis carcinomatosa (disorder),y,direct mapping
+94493005,Secondary malignant neoplasm of pleura (disorder),y,direct mapping
+51549004,"Leiomyosarcoma, no subtype (morphologic abnormality)",y,direct mapping
+109823006,Overlapping malignant neoplasm of tongue (disorder),y,direct mapping
+255087006,Malignant polyp of biliary tract (disorder),y,direct mapping
+187845002,Malignant neoplasm of cuneiform cartilage (disorder),y,direct mapping
+285604008,Metastasis to lung of unknown primary (disorder),y,direct mapping
+93990005,Primary malignant neoplasm of rib (disorder),y,direct mapping
+47107000,Basophil carcinoma (morphologic abnormality),y,direct mapping
+188243001,Malignant neoplasm of posterior wall of urinary bladder (disorder),y,direct mapping
+363461003,Malignant tumor of eye (disorder),y,direct mapping
+21912003,"Malignant teratoma, intermediate (morphologic abnormality)",y,direct mapping
+253071005,Mixed oligoastrocytoma (morphologic abnormality),y,direct mapping
+188189001,"Malignant neoplasm of corpus uteri, excluding isthmus (disorder)",y,direct mapping
+188180002,"Malignant neoplasm, overlapping lesion of cervix uteri (disorder)",y,direct mapping
+363443007,Malignant tumor of ovary (disorder),y,direct mapping
+900006,Mucin-producing adenocarcinoma (morphologic abnormality),y,direct mapping
+187809000,Malignant neoplasm of mesocolon (disorder),y,direct mapping
+254829001,Liposarcoma (disorder),y,direct mapping
+255004001,Malignant melanoma of conjunctiva (disorder),y,direct mapping
+255078002,"Malignant tumor of esophagus, stomach and duodenum (disorder)",y,direct mapping
+363463000,Malignant tumor of conjunctiva (disorder),y,direct mapping
+1090261000000108,Malignant neoplasm of descended testis (disorder),y,direct mapping
+255052006,Malignant tumor of unknown origin (disorder),y,direct mapping
+18861007,"Granulosa cell tumor, malignant (morphologic abnormality)",y,direct mapping
+310526005,Malignant tumor of soft tissue of back (disorder),y,direct mapping
+188273005,Malignant neoplasm of lacrimal sac (disorder),y,direct mapping
+269460009,Malignant tumor of greater curve of stomach (disorder),y,direct mapping
+63373002,Lymphangiosarcoma (morphologic abnormality),y,direct mapping
+94254004,Secondary malignant neoplasm of choroid (disorder),y,direct mapping
+255016007,Adenocarcinoma of pigmented epithelium of ciliary body (disorder),y,direct mapping
+255015006,Malignant melanoma of ciliary body (disorder),y,direct mapping
+187791002,Malignant tumor of body of pancreas (disorder),y,direct mapping
+188280007,Malignant neoplasm of cerebrum (excluding lobes and ventricles) (disorder),y,direct mapping
+363348004,Malignant tumor of lip (disorder),y,direct mapping
+63449009,Alveolar rhabdomyosarcoma (morphologic abnormality),y,direct mapping
+93225001,Malignant melanoma of skin of face (disorder),y,direct mapping
+271468000,Malignant neoplasm of genitourinary organ (disorder),y,direct mapping
+278024000,Rhabdomyosarcoma of bladder (disorder),y,direct mapping
+94642006,Secondary malignant neoplasm of tracheobronchial lymph nodes (disorder),y,direct mapping
+25370001,Hepatocellular carcinoma (morphologic abnormality),y,direct mapping
+254434008,Carcinoma of hard palate (disorder),y,direct mapping
+81622000,Carcinoid tumor no International Classification of Diseases for Oncology subtype (morphologic abnormality),y,direct mapping
+188247000,"Malignant neoplasm, overlapping lesion of bladder (disorder)",y,direct mapping
+16090008,Myxoid leiomyosarcoma (morphologic abnormality),y,direct mapping
+421249001,Malignant tumor of vermilion border of lip (disorder),y,direct mapping
+187810005,Malignant neoplasm of mesocecum (disorder),y,direct mapping
+363491008,Malignant tumor of cloacogenic zone (disorder),y,direct mapping
+237252008,Placental site trophoblastic tumor (disorder),y,direct mapping
+286887005,Carcinoma liver and/or biliary system (disorder),y,direct mapping
+188067002,Malignant melanoma of lower limb and hip (disorder),y,direct mapping
+187660002,Malignant tumor of lower buccal sulcus (disorder),y,direct mapping
+254547001,Carcinoma of upper third of esophagus (disorder),y,direct mapping
+286900008,Carcinoma of epididymis/spermatic cord (disorder),y,direct mapping
+254459004,Malignant tumor of anterior pillar of fauces (disorder),y,direct mapping
+188220005,Malignant tumor of ectopic testis (disorder),y,direct mapping
+109878000,Overlapping malignant neoplasm of female genital organs (disorder),y,direct mapping
+188281006,Malignant neoplasm of basal ganglia (disorder),y,direct mapping
+315004001,Metastasis from malignant tumor of breast (disorder),y,direct mapping
+187968007,Malignant neoplasm of medial cuneiform (disorder),y,direct mapping
+21589007,"Ependymoma, anaplastic (morphologic abnormality)",y,direct mapping
+109948008,"Overlapping malignant neoplasm of eye and adnexa, primary (disorder)",y,direct mapping
+188241004,Malignant neoplasm of lateral wall of urinary bladder (disorder),y,direct mapping
+187736009,Malignant tumor of pylorus (disorder),y,direct mapping
+41607009,Renal cell carcinoma (morphologic abnormality),y,direct mapping
+188266000,Malignant neoplasm of sclera (disorder),y,direct mapping
+363459007,Malignant tumor of urethra (disorder),y,direct mapping
+956511000000107,Malignant melanoma stage IV M1a (finding),y,direct mapping
+187606005,Malignant tumor of upper labial mucosa (disorder),y,direct mapping
+1090091000000108,Secondary malignant neoplasm of internal mammary lymph nodes (disorder),y,direct mapping
+67280001,Dedifferentiated liposarcoma (morphologic abnormality),y,direct mapping
+49937004,"Kaposi's sarcoma, morphology (morphologic abnormality)",y,direct mapping
+372151005,Sarcoma - category (morphologic abnormality),y,direct mapping
+94531007,Secondary malignant neoplasm of scrotum (disorder),y,direct mapping
+1090971000000105,Malignant neoplasm of posterior wall of stomach (disorder),y,direct mapping
+372062007,Malignant neoplasm of central nervous system (disorder),y,direct mapping
+93814004,Primary malignant neoplasm of glomus jugulare (disorder),y,direct mapping
+363359008,Malignant tumor of middle ear (disorder),y,direct mapping
+188071004,Malignant melanoma of popliteal fossa area (disorder),y,direct mapping
+363464006,Malignant tumor of cornea (disorder),y,direct mapping
+254539001,Carcinoma of thoracic part of esophagus (disorder),y,direct mapping
+26888009,"Odontogenic tumor, malignant (morphologic abnormality)",y,direct mapping
+363384006,Malignant tumor of lower gingiva (disorder),y,direct mapping
+42392001,Epithelioid leiomyosarcoma (morphologic abnormality),y,direct mapping
+2142002,Nodular melanoma (morphologic abnormality),y,direct mapping
+255093003,Malignant skin tumor with adnexal differentiation (disorder),y,direct mapping
+254969001,Malignant tumor of olfactory tract (disorder),y,direct mapping
+956411000000108,Malignant melanoma stage IIC (finding),y,direct mapping
+302849000,Nephroblastoma (disorder),y,direct mapping
+187801002,Malignant tumor of peritoneum and retroperitoneum (disorder),y,direct mapping
+109347009,Overlapping malignant neoplasm of bone and articular cartilage (disorder),y,direct mapping
+188177003,Malignant neoplasm of endocervical gland (disorder),y,direct mapping
+372108006,Malignant neoplasm of bone of lower limb (disorder),y,direct mapping
+21008007,Cystadenocarcinoma (morphologic abnormality),y,direct mapping
+44474009,Malignant melanoma in Hutchinson's melanotic freckle (morphologic abnormality),y,direct mapping
+314960002,Local recurrence of malignant tumor of esophagus (disorder),y,direct mapping
+713572001,Malignant neoplastic disease co-occurrent with human immunodeficiency virus infection (disorder),y,direct mapping
+94391008,Secondary malignant neoplasm of lung (disorder),y,direct mapping
+423973006,"Carcinoma of uterine cervix, invasive (disorder)",y,direct mapping
+254553001,Carcinoma of cardia (disorder),y,direct mapping
+188274004,Malignant neoplasm of nasolacrimal duct (disorder),y,direct mapping
+187752007,Malignant tumor of Meckel's diverticulum (disorder),y,direct mapping
+363487003,Malignant tumor of aryepiglottic fold - laryngeal aspect (disorder),y,direct mapping
+309245001,Adenocarcinoma of uterus (disorder),y,direct mapping
+254900004,Carcinoma of prostate (disorder),y,direct mapping
+187633009,Malignant neoplasm of dorsal surface of tongue (disorder),y,direct mapping
+109388009,Kaposi's sarcoma of palate (disorder),y,direct mapping
+94452002,Secondary malignant neoplasm of optic nerve (disorder),y,direct mapping
+188302003,Malignant neoplasm of tapetum (disorder),y,direct mapping
+363407001,Malignant tumor of hepatic flexure (disorder),y,direct mapping
+363509000,Malignant tumor of small intestine (disorder),y,direct mapping
+400011005,Leiomyosarcoma - category (morphologic abnormality),y,direct mapping
+4590003,"Adenocarcinoma, metastatic (morphologic abnormality)",y,direct mapping
+307601000,Pseudomyxoma peritonei (disorder),y,direct mapping
+413742003,Cancer pain and symptom management (procedure),y,direct mapping
+254530002,Malignant tumor of parapharyngeal space (disorder),y,direct mapping
+28047004,Embryonal carcinoma (morphologic abnormality),y,direct mapping
+702391001,Renal cell carcinoma (disorder),y,direct mapping
+363355002,Malignant tumor of adrenal gland (disorder),y,direct mapping
+255086002,Carcinoma common bile duct (disorder),y,direct mapping
+372244006,Malignant melanoma (disorder),y,direct mapping
+188478004,Malignant neoplasms of independent (primary) multiple sites (disorder),y,direct mapping
+428905002,Malignant neoplasm of gastrointestinal tract (disorder),y,direct mapping
+253094006,Melanotic malignant peripheral nerve sheath tumor (morphologic abnormality),y,direct mapping
+188013008,Malignant neoplasm of connective and soft tissues of thoracic spine (disorder),y,direct mapping
+449066004,Malignant neoplasm of upper respiratory tract (disorder),y,direct mapping
+301756000,Adenocarcinoma of sigmoid colon (disorder),y,direct mapping
+363495004,Malignant tumor of muscle (disorder),y,direct mapping
+187682009,"Malignant neoplasm of epiglottis, free border (disorder)",y,direct mapping
+94575006,Secondary malignant neoplasm of skin of trunk (disorder),y,direct mapping
+112683004,Pleomorphic liposarcoma (morphologic abnormality),y,direct mapping
+255090000,Malignant neoplasm of carpal bones (disorder),y,direct mapping
+72174007,"Follicular adenocarcinoma, trabecular (morphologic abnormality)",y,direct mapping
+71985006,Carcinomatous myopathic syndrome (disorder),y,direct mapping
+188292007,Malignant tumor of choroid plexus (disorder),y,direct mapping
+109847004,Overlapping malignant neoplasm of biliary tract (disorder),y,direct mapping
+405843009,Widespread metastatic malignant neoplastic disease (disorder),y,direct mapping
+255030002,Mixed follicular and papillary thyroid carcinoma (disorder),y,direct mapping
+188038003,Malignant melanoma of chin (disorder),y,direct mapping
+90282004,Papillary serous cystadenocarcinoma (morphologic abnormality),y,direct mapping
+274902006,Combined hepatocellular carcinoma and cholangiocarcinoma (disorder),y,direct mapping
+281560004,Neuroblastoma of brain (disorder),y,direct mapping
+315003007,Metastasis from malignant tumor of esophagus (disorder),y,direct mapping
+187732006,Malignant tumor of cardia (disorder),y,direct mapping
+369748008,Diffusely infiltrative (linitis plastica) tumor configuration (finding),y,direct mapping
+187698002,Malignant tumor of opening of auditory tube (disorder),y,direct mapping
+285643007,Metastasis to adrenal gland of unknown primary (disorder),y,direct mapping
+285598005,Metastasis to trachea of unknown primary (disorder),y,direct mapping
+254564003,Carcinoma in situ of lesser curve of stomach (disorder),y,direct mapping
+1090271000000101,Malignant neoplasm of ventral surface of tongue (disorder),y,direct mapping
+187944004,Malignant neoplasm of carpal bone - hamate (disorder),y,direct mapping
+1090871000000102,Malignant neoplasm of bone and articular cartilage of limb (disorder),y,direct mapping
+363460002,Malignant tumor of paraurethral gland (disorder),y,direct mapping
+314976006,Local recurrence of malignant melanoma of skin (disorder),y,direct mapping
+14269005,Embryonal rhabdomyosarcoma (morphologic abnormality),y,direct mapping
+93651008,Malignant melanoma of skin of trunk (disorder),y,direct mapping
+134421000,Pathological fracture due to metastatic bone disease (disorder),y,direct mapping
+93769007,Primary malignant neoplasm of cuboid (disorder),y,direct mapping
+48460009,Malignant giant cell tumor of soft parts (morphologic abnormality),y,direct mapping
+94475009,Secondary malignant neoplasm of parotid lymph nodes (disorder),y,direct mapping
+94432003,Secondary malignant neoplasm of muscle (disorder),y,direct mapping
+269579005,Malignant melanoma of trunk (disorder),y,direct mapping
+51757004,"Desmoplastic melanoma, malignant (morphologic abnormality)",y,direct mapping
+94628003,Secondary malignant neoplasm of retroperitoneum (disorder),y,direct mapping
+75622000,Myxoid chondrosarcoma (morphologic abnormality),y,direct mapping
+188051008,Malignant melanoma of buttock (disorder),y,direct mapping
+188070003,Malignant melanoma of knee (disorder),y,direct mapping
+276975007,Carcinoma of larynx (disorder),y,direct mapping
+254895003,Squamous cell carcinoma of vulva (disorder),y,direct mapping
+188459004,Secondary malignant neoplasm of skin of hip and leg (disorder),y,direct mapping
+94459006,Secondary malignant neoplasm of pancreas (disorder),y,direct mapping
+363398003,Malignant tumor of lateral wall of nasopharynx (disorder),y,direct mapping
+443677002,Seminoma - category (morphologic abnormality),y,direct mapping
+39000009,Hemangiosarcoma (morphologic abnormality),y,direct mapping
+363486007,Malignant tumor of vocal cord (disorder),y,direct mapping
+20955008,"Insulinoma, malignant (morphologic abnormality)",y,direct mapping
+188458007,Secondary malignant neoplasm of skin of shoulder and arm (disorder),y,direct mapping
+49430005,"Liposarcoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+307599002,Sebaceous adenocarcinoma (disorder),y,direct mapping
+187681002,Malignant neoplasm of anterior epiglottis (disorder),y,direct mapping
+255124004,Metastasis to peripheral nerve (disorder),y,direct mapping
+285605009,Metastasis to pleura of unknown primary (disorder),y,direct mapping
+187701005,Malignant neoplasm of floor of nasopharynx (disorder),y,direct mapping
+254874008,Dysgerminoma of ovary (disorder),y,direct mapping
+64059005,Spongioneuroblastoma (morphologic abnormality),y,direct mapping
+254940005,Oligodendroglioma of brain (disorder),y,direct mapping
+254733003,Malignant melanoma arising in intradermal nevus (disorder),y,direct mapping
+94566009,Secondary malignant neoplasm of skin of neck (disorder),y,direct mapping
+187694000,Malignant tumor of adenoid (disorder),y,direct mapping
+275266006,Metastasis to digestive organs (disorder),y,direct mapping
+253093000,Epithelioid malignant nerve sheath tumor (morphologic abnormality),y,direct mapping
+286896005,"Carcinoma breast - lower, outer quadrant (disorder)",y,direct mapping
+278044006,Malignant neuroma of mediastinum (disorder),y,direct mapping
+50422007,Bile duct cystadenocarcinoma (morphologic abnormality),y,direct mapping
+94000008,Primary malignant neoplasm of sebaceous gland (disorder),y,direct mapping
+188297001,Malignant neoplasm of midbrain (disorder),y,direct mapping
+712750007,Malignant neoplasm of chest wall (disorder),y,direct mapping
+254980001,Malignant tumor of acoustic vestibular nerve (disorder),y,direct mapping
+6492006,Klatskin's tumor (morphologic abnormality),y,direct mapping
+109358000,Overlapping malignant neoplasm of ill-defined site (disorder),y,direct mapping
+255008003,Squamous cell carcinoma of cornea (disorder),y,direct mapping
+254908006,Malignant tumor of skin of penis (disorder),y,direct mapping
+363454002,Malignant tumor of scrotum (disorder),y,direct mapping
+254427006,Carcinoma of anterior part of floor of mouth (disorder),y,direct mapping
+254897006,Sarcoma of vulva (disorder),y,direct mapping
+1090121000000109,Secondary malignant neoplasm of deep cervical lymph nodes (disorder),y,direct mapping
+188064009,Malignant melanoma of finger (disorder),y,direct mapping
+187658004,Malignant tumor of vestibule of mouth (disorder),y,direct mapping
+63264007,Carcinosarcoma (morphologic abnormality),y,direct mapping
+94336001,Secondary malignant neoplasm of iliac lymph nodes (disorder),y,direct mapping
+363471001,Malignant neoplasm of cerebral ventricles (disorder),y,direct mapping
+188469005,Secondary malignant neoplasm of cervix uteri (disorder),y,direct mapping
+27461004,Immunoproliferative small intestinal disease (morphologic abnormality),y,direct mapping
+720006006,Cancer care review (procedure),y,direct mapping
+403946000,Paget's disease of nipple (disorder),y,direct mapping
+255108000,Carcinoma of bladder (disorder),y,direct mapping
+93223008,Malignant melanoma of skin of eyebrow (disorder),y,direct mapping
+187997005,Malignant neoplasm of connective and soft tissue of thumb (disorder),y,direct mapping
+45410002,Acinar cell carcinoma (morphologic abnormality),y,direct mapping
+28325008,Polyembryoma (morphologic abnormality),y,direct mapping
+294301000000103,Bowel cancer detected by national screening programme (disorder),y,direct mapping
+2221008,"Mesonephroma, malignant (morphologic abnormality)",y,direct mapping
+253014007,Malignant endometrioid tumor (morphologic abnormality),y,direct mapping
+94361000000105,Breast cancer detected by national screening programme (disorder),y,direct mapping
+187996001,Malignant neoplasm of connective and soft tissue of finger (disorder),y,direct mapping
+254417000,Carcinoma of frenum linguae (disorder),y,direct mapping
+254916002,Cystadenocarcinoma of kidney (disorder),y,direct mapping
+188296005,Malignant neoplasm of medulla oblongata (disorder),y,direct mapping
+93973004,Primary malignant neoplasm of presacral region (disorder),y,direct mapping
+1014611000000103,Squamous cell carcinoma antigen level (observable entity),y,direct mapping
+276828006,Glioblastoma multiforme of brain (disorder),y,direct mapping
+363409003,Malignant tumor of descending colon (disorder),y,direct mapping
+94327000,Secondary malignant neoplasm of heart (disorder),y,direct mapping
+78303004,"Meningioma, malignant (morphologic abnormality)",y,direct mapping
+315007008,Metastasis from malignant tumor of thyroid (disorder),y,direct mapping
+369775001,Gleason Score 2-4: Well differentiated (finding),y,direct mapping
+254404003,Carcinoma of commissure of lip (disorder),y,direct mapping
+94351005,Secondary malignant neoplasm of intrathoracic lymph nodes (disorder),y,direct mapping
+254872007,Embryonal carcinoma of ovary (disorder),y,direct mapping
+447949005,Malignant epithelial neoplasm of cheek (disorder),y,direct mapping
+275397008,Carcinoma of midline of tongue (disorder),y,direct mapping
+188073001,Malignant melanoma of ankle (disorder),y,direct mapping
+94408005,Secondary malignant neoplasm of mediastinal lymph nodes (disorder),y,direct mapping
+188192002,Malignant neoplasm of endometrium of corpus uteri (disorder),y,direct mapping
+188256008,Malignant neoplasm of overlapping lesion of urinary organs (disorder),y,direct mapping
+285310000,Carcinoma of anal canal (disorder),y,direct mapping
+187828007,"Malignant neoplasm of nasal cavities, middle ear and accessory sinuses (disorder)",y,direct mapping
+254972008,Malignant tumor of optic nerve and sheath (disorder),y,direct mapping
+188151006,Malignant neoplasm of central part of female breast (disorder),y,direct mapping
+956351000000100,Malignant melanoma stage IB (finding),y,direct mapping
+8145008,"Mixed tumor, malignant (morphologic abnormality)",y,direct mapping
+62383007,Mixed type rhabdomyosarcoma (morphologic abnormality),y,direct mapping
+363475005,Malignant tumor of spinal cord (disorder),y,direct mapping
+187995002,Malignant neoplasm of connective and soft tissue of hand (disorder),y,direct mapping
+254383006,International Federation of Gynecology and Obstetrics staging system of gynecological malignancy (tumor staging),y,direct mapping
+1090981000000107,Malignant neoplasm of anterior wall of stomach (disorder),y,direct mapping
+1090191000000107,Secondary malignant neoplasm of coeliac lymph nodes (disorder),y,direct mapping
+255075004,Malignant tumor of lateral nasal wall (disorder),y,direct mapping
+89623007,"Mesenchymoma, malignant (morphologic abnormality)",y,direct mapping
+188022009,Malignant neoplasm of connective and soft tissue of perineum (disorder),y,direct mapping
+754351000000100,Grade 1 (Stage pTa) papillary urothelial/transitional cell carcinoma (morphologic abnormality),y,direct mapping
+363451005,Malignant tumor of glans penis (disorder),y,direct mapping
+93916003,Primary malignant neoplasm of nasal bone (disorder),y,direct mapping
+285608006,Metastasis to thymus of unknown primary (disorder),y,direct mapping
+1090891000000103,Malignant neoplasm of connective and soft tissues of trunk (disorder),y,direct mapping
+286891000,Carcinoma of skin of head/neck (disorder),y,direct mapping
+767047005,Melanotic neuroectodermal tumor of infancy (disorder),y,direct mapping
+254555008,Carcinoma of fundus of stomach (disorder),y,direct mapping
+363403002,Malignant tumor of duodenum (disorder),y,direct mapping
+187634003,Malignant tumor of anterior two-thirds of tongue - dorsal surface (disorder),y,direct mapping
+188269007,Malignant neoplasm of extraocular muscle of orbit (disorder),y,direct mapping
+254904008,Carcinoma of glans penis (disorder),y,direct mapping
+188159008,Malignant neoplasm of ectopic site of female breast (disorder),y,direct mapping
+65646006,"Malignant teratoma, trophoblastic (morphologic abnormality)",y,direct mapping
+278054005,Lobular carcinoma of breast (disorder),y,direct mapping
+188168005,Malignant neoplasm of ectopic site of male breast (disorder),y,direct mapping
+303194003,Metastasis to head and neck lymph node (disorder),y,direct mapping
+269469005,Malignant neoplasm of soft tissue (disorder),y,direct mapping
+128783001,Askin tumor (morphologic abnormality),y,direct mapping
+12323008,"Androblastoma, malignant (morphologic abnormality)",y,direct mapping
+95214007,Primary malignant neoplasm of liver (disorder),y,direct mapping
+363370001,Malignant neoplasm of mesentery (disorder),y,direct mapping
+94477001,Secondary malignant neoplasm of pectoral axillary lymph nodes (disorder),y,direct mapping
+254582000,Adenocarcinoma of rectum (disorder),y,direct mapping
+276954004,Squamous cell carcinoma of floor of mouth (disorder),y,direct mapping
+189643000,Papillary and follicular adenocarcinoma (morphologic abnormality),y,direct mapping
+238636003,Malignant acanthosis nigricans (disorder),y,direct mapping
+312111009,Carcinoma of ascending colon (disorder),y,direct mapping
+189849004,Dermoid cyst with malignant transformation (morphologic abnormality),y,direct mapping
+278053004,Intraductal carcinoma of breast (disorder),y,direct mapping
+275395000,Carcinoma anterior 2/3 tongue ventrum (disorder),y,direct mapping
+188061001,Malignant melanoma of upper arm (disorder),y,direct mapping
+363351006,Malignant tumor of rectum (disorder),y,direct mapping
+69515008,Ganglioneuroblastoma (morphologic abnormality),y,direct mapping
+109368005,Overlapping malignant neoplasm of hypopharynx (disorder),y,direct mapping
+276953005,Squamous cell carcinoma of gum (disorder),y,direct mapping
+314966008,Local recurrence of malignant tumor of rectum (disorder),y,direct mapping
+314955001,Local recurrence of malignant tumor of breast (disorder),y,direct mapping
+278042005,Malignant teratoma of mediastinum (disorder),y,direct mapping
+285606005,Metastasis to heart of unknown primary (disorder),y,direct mapping
+188163001,Malignant neoplasm of nipple and areola of male breast (disorder),y,direct mapping
+363506007,Malignant tumor of nasal sinuses (disorder),y,direct mapping
+956431000000100,Malignant melanoma stage IIIA (finding),y,direct mapping
+285638000,Metastasis to vagina of unknown primary (disorder),y,direct mapping
+363431006,Malignant tumor of laryngeal cartilage (disorder),y,direct mapping
+54124005,"Epithelioid hemangioendothelioma, malignant (morphologic abnormality)",y,direct mapping
+276876007,Carcinoma of Bartholin's gland (disorder),y,direct mapping
+28655007,"Liposarcoma, well differentiated (morphologic abnormality)",y,direct mapping
+1090321000000107,Malignant neoplasm of back (disorder),y,direct mapping
+188361007,Malignant neoplasm of thorax (disorder),y,direct mapping
+385377005,Gleason grade finding for prostatic cancer (finding),y,direct mapping
+65278006,"Epithelioid mesothelioma, malignant (morphologic abnormality)",y,direct mapping
+276860003,Squamous cell carcinoma of scrotum (disorder),y,direct mapping
+342511000000104,Siewert type II adenocarcinoma (disorder),y,direct mapping
+255003007,Squamous cell carcinoma of conjunctiva (disorder),y,direct mapping
+371965009,Malignant neoplasm of adrenal medulla (disorder),y,direct mapping
+254852002,Endometrioid carcinoma ovary (disorder),y,direct mapping
+187604008,"Malignant neoplasm of lower lip, external (disorder)",y,direct mapping
+188268004,Malignant neoplasm of connective tissue of orbit (disorder),y,direct mapping
+254423005,Carcinoma of lingual tonsil (disorder),y,direct mapping
+999000,Mixed islet cell and exocrine adenocarcinoma (morphologic abnormality),y,direct mapping
+253017000,Klatskin's tumor (disorder),y,direct mapping
+302840001,Giant cell sarcoma (morphologic abnormality),y,direct mapping
+28173006,"Follicular adenocarcinoma, well differentiated (morphologic abnormality)",y,direct mapping
+188317004,Malignant neoplasm of spinal dura mater (disorder),y,direct mapping
+314951005,Local recurrence of malignant tumor of tongue (disorder),y,direct mapping
+255077007,Malignant tumor of digestive organ (disorder),y,direct mapping
+956391000000108,Malignant melanoma stage IIB (finding),y,direct mapping
+69028005,Granular cell carcinoma (morphologic abnormality),y,direct mapping
+187807003,Overlapping malignant lesion of retroperitoneum and peritoneum (disorder),y,direct mapping
+109824000,Overlapping malignant neoplasm of major salivary gland (disorder),y,direct mapping
+188261005,"Malignant neoplasm of eyeball excluding conjunctiva, cornea, retina and choroid (disorder)",y,direct mapping
+93833009,Primary malignant neoplasm of ilium (disorder),y,direct mapping
+94481001,Secondary malignant neoplasm of penis (disorder),y,direct mapping
+187622006,Malignant tumor of labial mucosa (disorder),y,direct mapping
+363516004,Malignant tumor of penis (disorder),y,direct mapping
+94681006,Secondary malignant neoplasm of vulva (disorder),y,direct mapping
+8734000,Choriocarcinoma combined with other germ cell elements (morphologic abnormality),y,direct mapping
+448670003,Malignant neoplasm of posterior mediastinum (disorder),y,direct mapping
+57596004,Oxyphilic adenocarcinoma (morphologic abnormality),y,direct mapping
+84427001,Mullerian mixed tumor (morphologic abnormality),y,direct mapping
+35868009,Carcinoid syndrome (disorder),y,direct mapping
+187945003,Malignant neoplasm of first metacarpal bone (disorder),y,direct mapping
+254611009,Malignant tumor of endocrine pancreas (disorder),y,direct mapping
+187723009,Malignant tumor of thoracic part of esophagus (disorder),y,direct mapping
+64524002,Intraductal papillary adenocarcinoma with invasion (morphologic abnormality),y,direct mapping
+24653009,"Spindle cell melanoma, type A (morphologic abnormality)",y,direct mapping
+254503007,Malignant tumor of inferior surface of soft palate (disorder),y,direct mapping
+271467005,"Malignant neoplasm of bone, connective tissue, skin and breast (disorder)",y,direct mapping
+363425008,Malignant tumor of maxillary sinus (disorder),y,direct mapping
+94544002,Secondary malignant neoplasm of skin of breast (disorder),y,direct mapping
+1090181000000105,Secondary malignant neoplasm of inferior epigastric lymph nodes (disorder),y,direct mapping
+307726001,Anemia in ovarian carcinoma (disorder),y,direct mapping
+88253001,"Ameloblastoma, malignant (morphologic abnormality)",y,direct mapping
+363420003,Malignant retroperitoneal tumor (disorder),y,direct mapping
+68827007,Spindle cell melanoma (morphologic abnormality),y,direct mapping
+372143007,Carcinoma of stomach (disorder),y,direct mapping
+277782009,Malignant peritoneal local recurrence (disorder),y,direct mapping
+363490009,Malignant tumor of anus (disorder),y,direct mapping
+126906006,Neoplasm of prostate (disorder),y,direct mapping
+254990009,Mucoepidermoid tumor of lacrimal gland (disorder),y,direct mapping
+187976009,Malignant neoplasm of fourth metatarsal bone (disorder),y,direct mapping
+188000002,Malignant neoplasm of connective and soft tissue of hip (disorder),y,direct mapping
+12354007,"Retinoblastoma, undifferentiated (morphologic abnormality)",y,direct mapping
+314992001,Metastasis from malignant tumor of cervix (disorder),y,direct mapping
+28953002,Angiomyosarcoma (morphologic abnormality),y,direct mapping
+94264008,Secondary malignant neoplasm of soft tissues (disorder),y,direct mapping
+188030005,Malignant melanoma of lip (disorder),y,direct mapping
+187969004,Malignant neoplasm of intermediate cuneiform (disorder),y,direct mapping
+188339002,Malignant neoplasm of pituitary gland and craniopharyngeal duct (disorder),y,direct mapping
+187804005,Malignant neoplasm of retrocecal tissue (disorder),y,direct mapping
+363390005,Malignant tumor of palate (disorder),y,direct mapping
+255084004,Squamous cell carcinoma of anal margin (disorder),y,direct mapping
+371982006,Malignant neoplasm of endocrine gland (disorder),y,direct mapping
+443520009,Chondrosarcoma (disorder),y,direct mapping
+369777009,Gleason Score 8-10: Poorly differentiated (finding),y,direct mapping
+363350007,Malignant tumor of cecum (disorder),y,direct mapping
+86293007,Adenocarcinoid tumor (morphologic abnormality),y,direct mapping
+285610008,Metastasis to large intestine of unknown primary (disorder),y,direct mapping
+94073009,Primary malignant neoplasm of sternum (disorder),y,direct mapping
+363476006,Malignant neoplasm of spinal meninges (disorder),y,direct mapping
+285641009,Metastasis to brain of unknown primary (disorder),y,direct mapping
+255073006,"Malignant tumor of ear, nose and throat (disorder)",y,direct mapping
+94641004,Secondary malignant neoplasm of trachea (disorder),y,direct mapping
+314967004,Local recurrence of malignant tumor of kidney (disorder),y,direct mapping
+187993009,"Malignant neoplasm of connective and soft tissue, upper arm (disorder)",y,direct mapping
+254462001,Carcinoma of parotid gland (disorder),y,direct mapping
+166851000000104,Date cancer diagnosis received in primary care (observable entity),y,direct mapping
+363378008,Malignant tumor of major salivary gland (disorder),y,direct mapping
+187640005,Malignant tumor of anterior two-thirds of tongue - ventral surface (disorder),y,direct mapping
+754361000000102,Grade 2 (Stage pTa) papillary urothelial/transitional cell carcinoma (morphologic abnormality),y,direct mapping
+187726001,Malignant tumor of middle third of esophagus (disorder),y,direct mapping
+11671000,Adenoid cystic carcinoma (morphologic abnormality),y,direct mapping
+188015001,Malignant neoplasm of connective and soft tissue of abdomen (disorder),y,direct mapping
+109383000,Malignant mesothelioma of pericardium (disorder),y,direct mapping
+254994000,Rhabdomyosarcoma of orbit (disorder),y,direct mapping
+112685006,"Carcinosarcoma, embryonal (morphologic abnormality)",y,direct mapping
+255028004,Follicular thyroid carcinoma (disorder),y,direct mapping
+187693006,Malignant tumor of posterior wall of nasopharynx (disorder),y,direct mapping
+15619004,"Hepatocellular carcinoma, fibrolamellar (morphologic abnormality)",y,direct mapping
+109369002,Overlapping malignant neoplasm of larynx (disorder),y,direct mapping
+254860001,Malignant sex cord tumor of ovary (disorder),y,direct mapping
+188191009,Malignant neoplasm of fundus of corpus uteri (disorder),y,direct mapping
+255067005,Sarcoma of bone and connective tissue (disorder),y,direct mapping
+187949009,Malignant neoplasm of fifth metacarpal bone (disorder),y,direct mapping
+38549000,"Carcinoma, undifferentiated (morphologic abnormality)",y,direct mapping
+1090151000000104,Secondary malignant neoplasm of mastoid lymph nodes (disorder),y,direct mapping
+254878006,Endometrial carcinoma (disorder),y,direct mapping
+94446003,Secondary malignant neoplasm of obturator lymph nodes (disorder),y,direct mapping
+187708004,Malignant tumor aryepiglottic fold - hypopharyngeal aspect (disorder),y,direct mapping
+254551004,Carcinoma of lower third of esophagus (disorder),y,direct mapping
+254909003,Carcinoma of foreskin (disorder),y,direct mapping
+188283009,Malignant neoplasm of corpus striatum (disorder),y,direct mapping
+254431000,Carcinoma of lateral part of floor of mouth (disorder),y,direct mapping
+416712009,Clear cell (mesonephric) neoplasm of ovary (disorder),y,direct mapping
+416901002,Malignant medulloepithelioma of ciliary body (disorder),y,direct mapping
+109885001,Overlapping malignant neoplasm of vulva (disorder),y,direct mapping
+255081007,Carcinoma of cecum (disorder),y,direct mapping
+187975008,Malignant neoplasm of third metatarsal bone (disorder),y,direct mapping
+187742008,Malignant tumor of body of stomach (disorder),y,direct mapping
+93209006,Malignant melanoma of perianal skin (disorder),y,direct mapping
+31131002,"Vipoma, malignant (morphologic abnormality)",y,direct mapping
+94627008,Secondary malignant neoplasm of peritoneum (disorder),y,direct mapping
+17302008,Cerebellar sarcoma (morphologic abnormality),y,direct mapping
+58248003,"Carcinoma, anaplastic (morphologic abnormality)",y,direct mapping
+254764001,Peripheral neuroepithelioma (disorder),y,direct mapping
+188001003,Malignant neoplasm of connective and soft tissue of thigh and upper leg (disorder),y,direct mapping
+187946002,Malignant neoplasm of second metacarpal bone (disorder),y,direct mapping
+254950006,Oligodendroglioma of spinal cord (disorder),y,direct mapping
+187662005,Malignant tumor of lower labial sulcus (disorder),y,direct mapping
+276870001,Carcinoma of fallopian tube (disorder),y,direct mapping
+237833006,Carcinoid crisis (disorder),y,direct mapping
+428322007,Malignant neoplasm of uterine adnexa (disorder),y,direct mapping
+255032005,Medullary thyroid carcinoma (disorder),y,direct mapping
+187918004,Malignant neoplasm of lumbar vertebra (disorder),y,direct mapping
+189607006,Carcinoid tumor - morphology (morphologic abnormality),y,direct mapping
+276799004,Dermatofibrosarcoma protuberans (disorder),y,direct mapping
+187926007,Malignant neoplasm of costovertebral joint (disorder),y,direct mapping
+1090211000000106,Secondary malignant neoplasm of circumflex iliac lymph nodes (disorder),y,direct mapping
+363468009,Malignant neoplasm of temporal lobe (disorder),y,direct mapping
+188282004,Malignant neoplasm of cerebral cortex (disorder),y,direct mapping
+276822007,Malignant melanoma of rectum (disorder),y,direct mapping
+372016004,Primary malignant neoplasm of the peritoneum (disorder),y,direct mapping
+278043000,Malignant seminoma of mediastinum (disorder),y,direct mapping
+271323007,"Malignant neoplasm of lip, oral cavity and/or pharynx (disorder)",y,direct mapping
+254481009,Malignant tumor of middle turbinate (disorder),y,direct mapping
+278060005,Endometrioid carcinoma of prostate (disorder),y,direct mapping
+254609000,Carcinoma of ampulla of Vater (disorder),y,direct mapping
+363417006,Malignant tumor of ampulla of Vater (disorder),y,direct mapping
+254450000,Carcinoma of upper labial sulcus (disorder),y,direct mapping
+312115000,Carcinoma of splenic flexure (disorder),y,direct mapping
+363436001,Malignant tumor of endocardium (disorder),y,direct mapping
+253000007,Neuroendocrine carcinoma (disorder),y,direct mapping
+187824009,"Malignant neoplasm, overlapping lesion of digestive system (disorder)",y,direct mapping
+363429002,Malignant tumor of larynx (disorder),y,direct mapping
+363501002,Malignant tumor of face (disorder),y,direct mapping
+372138000,Carcinoma of esophagus (disorder),y,direct mapping
+58069009,Ceruminous adenocarcinoma (morphologic abnormality),y,direct mapping
+363502009,Malignant tumor of axilla (disorder),y,direct mapping
+94396003,Secondary malignant neoplasm of lymph nodes of multiple sites (disorder),y,direct mapping
+188298006,Malignant neoplasm of pons (disorder),y,direct mapping
+363467004,Malignant neoplasm of frontal lobe (disorder),y,direct mapping
+188245008,Malignant tumor of ureteric orifice (disorder),y,direct mapping
+31470003,Adenosarcoma (morphologic abnormality),y,direct mapping
+363375006,Malignant tumor of tongue (disorder),y,direct mapping
+187716008,Malignant tumor of Waldeyer's ring (disorder),y,direct mapping
+188068007,Malignant melanoma of hip (disorder),y,direct mapping
+2424003,"Sarcoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+302851001,Synovial sarcoma (disorder),y,direct mapping
+254535007,Carcinoma of cervical part of esophagus (disorder),y,direct mapping
+94344001,Secondary malignant neoplasm of intercostal lymph nodes (disorder),y,direct mapping
+83950009,"Malignant tumor, giant cell type (morphologic abnormality)",y,direct mapping
+187675005,Malignant tumor of tonsillar pillar (disorder),y,direct mapping
+94186002,Secondary malignant neoplasm of bladder (disorder),y,direct mapping
+363349007,Malignant tumor of stomach (disorder),y,direct mapping
+300988009,Transitional cell carcinoma of ureter (disorder),y,direct mapping
+187661003,Malignant tumor of upper labial sulcus (disorder),y,direct mapping
+187948001,Malignant neoplasm of fourth metacarpal bone (disorder),y,direct mapping
+187988006,Malignant neoplasm of tarsus of eyelid (disorder),y,direct mapping
+254557000,Carcinoma of body of stomach (disorder),y,direct mapping
+94222008,Secondary malignant neoplasm of bone (disorder),y,direct mapping
+363444001,Malignant tumor of fallopian tube (disorder),y,direct mapping
+363379000,Malignant tumor of parotid gland (disorder),y,direct mapping
+276952000,Squamous cell carcinoma of tongue (disorder),y,direct mapping
+188152004,Malignant neoplasm of upper-inner quadrant of female breast (disorder),y,direct mapping
+253026002,Adenocarcinoma with metaplasia (morphologic abnormality),y,direct mapping
+109912006,Overlapping malignant neoplasm of brain (disorder),y,direct mapping
+188156001,Malignant neoplasm of axillary tail of female breast (disorder),y,direct mapping
+88897007,"Malignant tumor, fusiform cell type (morphologic abnormality)",y,direct mapping
+109264009,Overlapping malignant neoplasm of skin (disorder),y,direct mapping
+312114001,Carcinoma of hepatic flexure (disorder),y,direct mapping
+94442001,Secondary malignant neoplasm of nervous system (disorder),y,direct mapping
+94145009,Primary malignant neoplasm of zygomatic bone (disorder),y,direct mapping
+19134004,Fascial fibrosarcoma (morphologic abnormality),y,direct mapping
+188239000,Malignant tumor of trigone of urinary bladder (disorder),y,direct mapping
+254549003,Carcinoma of middle third of esophagus (disorder),y,direct mapping
+109919002,Overlapping malignant neoplasm of peripheral nerves and autonomic nervous system (disorder),y,direct mapping
+314995004,Metastasis from malignant tumor of bladder (disorder),y,direct mapping
+302816009,"Malignant tumor of soft tissue of head, face and neck (disorder)",y,direct mapping
+187900002,Malignant neoplasm of bones of skull and face (disorder),y,direct mapping
+48554007,Enterochromaffin cell carcinoid (morphologic abnormality),y,direct mapping
+188045003,Malignant melanoma of scalp (disorder),y,direct mapping
+2735009,Papillary cystadenocarcinoma (morphologic abnormality),y,direct mapping
+188265001,Malignant neoplasm of crystalline lens (disorder),y,direct mapping
+68614005,Esthesioneuroepithelioma (morphologic abnormality),y,direct mapping
+188318009,Malignant neoplasm of spinal arachnoid mater (disorder),y,direct mapping
+187989003,Malignant neoplasm soft tissues of cervical spine (disorder),y,direct mapping
+372064008,Malignant neoplasm of female breast (disorder),y,direct mapping
+188004006,Malignant neoplasm of connective and soft tissue of foot (disorder),y,direct mapping
+87992000,"Giant cell sarcoma (except of Bone, M-92503) (morphologic abnormality)",y,direct mapping
+37373007,Meckel's diverticulum (disorder),y,direct mapping
+363503004,Malignant tumor of upper limb (disorder),y,direct mapping
+254955001,Pituitary carcinoma (disorder),y,direct mapping
+277505007,Medulloblastoma of cerebellum (disorder),y,direct mapping
+255037004,Parathyroid carcinoma (disorder),y,direct mapping
+363415003,Malignant tumor of biliary tract (disorder),y,direct mapping
+286897001,Carcinoma of breast - axillary tail (disorder),y,direct mapping
+363394001,Malignant tumor of tonsillar fossa (disorder),y,direct mapping
+19467007,"Teratoma, malignant, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+302817000,Malignant tumor of unknown origin or ill-defined site (disorder),y,direct mapping
+428281000,Malignant neoplasm of bone (disorder),y,direct mapping
+253075001,Sympathicoblastoma (morphologic abnormality),y,direct mapping
+255068000,"Carcinoma of bone, connective tissue, skin and breast (disorder)",y,direct mapping
+109267002,Overlapping malignant melanoma of skin (disorder),y,direct mapping
+187940008,Malignant neoplasm of carpal bone - pisiform (disorder),y,direct mapping
+187974007,Malignant neoplasm of second metatarsal bone (disorder),y,direct mapping
+252999006,Malignant endocrine tumor morphology (morphologic abnormality),y,direct mapping
+53618008,Pancreatoblastoma (morphologic abnormality),y,direct mapping
+79143006,Mucinous cystadenocarcinoma (morphologic abnormality),y,direct mapping
+254402004,Carcinoma of frenum of lower lip (disorder),y,direct mapping
+18588008,"Synovial sarcoma, biphasic (morphologic abnormality)",y,direct mapping
+363380002,Malignant tumor of submandibular gland (disorder),y,direct mapping
+314993006,Metastasis from malignant tumor of uterus (disorder),y,direct mapping
+363424007,Malignant tumor of mastoid air cells (disorder),y,direct mapping
+253072003,Anaplastic oligoastrocytoma (morphologic abnormality),y,direct mapping
+93945001,Primary malignant neoplasm of parietal bone (disorder),y,direct mapping
+315001009,Metastasis from malignant tumor of gallbladder (disorder),y,direct mapping
+6250003,Fibromyxosarcoma (morphologic abnormality),y,direct mapping
+94573004,Secondary malignant neoplasm of skin of thigh (disorder),y,descendant of concept mapped from leaf
+403895004,Squamous cell carcinoma of foot (disorder),y,descendant of concept mapped from leaf
+109996008,"Myelodysplastic syndrome: Refractory anemia, without ringed sideroblasts, without excess blasts (disorder)",y,descendant of concept mapped from leaf
+187870002,Malignant neoplasm of lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+93201009,Malignant mast cell tumor of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+372115003,"Primary malignant neoplasm of pelvic bones, sacrum and coccyx (disorder)",y,descendant of concept mapped from leaf
+94647000,Secondary malignant neoplasm of trigone of urinary bladder (disorder),y,descendant of concept mapped from leaf
+91161000119101,Primary adenocarcinoma of chest wall (disorder),y,descendant of concept mapped from leaf
+372111007,"Carcinoma of lower lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+93748005,Primary malignant neoplasm of cerebral ventricle (disorder),y,descendant of concept mapped from leaf
+720346009,Primary seminoma (morphologic abnormality),y,descendant of concept mapped from leaf
+372123001,Primary malignant neoplasm of skin head and neck (disorder),y,descendant of concept mapped from leaf
+363433009,Malignant tumor of pleura (disorder),y,descendant of concept mapped from leaf
+717968005,Melanoma and neural system tumor syndrome (disorder),y,descendant of concept mapped from leaf
+93868009,Primary malignant neoplasm of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+1080111000119108,Infiltrating ductal carcinoma of central portion of left female breast (disorder),y,descendant of concept mapped from leaf
+93967000,Primary malignant neoplasm of postcricoid region (disorder),y,descendant of concept mapped from leaf
+94448002,Secondary malignant neoplasm of occipital lobe (disorder),y,descendant of concept mapped from leaf
+447708000,Malignant germ cell neoplasm of anterior mediastinum (disorder),y,descendant of concept mapped from leaf
+93704000,Primary malignant neoplasm of blood vessel of neck (disorder),y,descendant of concept mapped from leaf
+188736006,Subacute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+423987006,"Primary malignant neoplasm of vulva, with widespread metastatic disease (disorder)",y,descendant of concept mapped from leaf
+425749006,Subacute myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+94314004,Secondary malignant neoplasm of gingival mucosa (disorder),y,descendant of concept mapped from leaf
+369503006,Malignant tumor involving vagina by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+94454001,Secondary malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+254652000,Clear cell squamous cell carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+93501005,"Hodgkin's disease, lymphocytic-histiocytic predominance of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+94333009,Secondary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+713609000,Invasive carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+94168000,Secondary malignant neoplasm of anterior portion of floor of mouth (disorder),y,descendant of concept mapped from leaf
+1081781000119105,Primary seminoma of left testis (disorder),y,descendant of concept mapped from leaf
+369550002,Malignant tumor involving right fallopian tube by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+109887009,Overlapping malignant neoplasm of male breast (disorder),y,descendant of concept mapped from leaf
+404077005,Extraskeletal osteosarcoma (disorder),y,descendant of concept mapped from leaf
+94256002,Secondary malignant neoplasm of clavicle (disorder),y,descendant of concept mapped from leaf
+94610000,Secondary malignant neoplasm of submaxillary gland (disorder),y,descendant of concept mapped from leaf
+93194002,Malignant lymphoma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+703626001,"Anaplastic large cell lymphoma, T/Null cell, primary systemic type (disorder)",y,descendant of concept mapped from leaf
+109374005,Overlapping malignant neoplasm of mediastinum and pleura (disorder),y,descendant of concept mapped from leaf
+399934007,Basal cell carcinoma of preauricular skin (disorder),y,descendant of concept mapped from leaf
+373091001,Primary malignant neoplasm of breast lower outer quadrant (disorder),y,descendant of concept mapped from leaf
+94458003,Secondary malignant neoplasm of tonsil (disorder),y,descendant of concept mapped from leaf
+187865009,Malignant neoplasm of middle lobe bronchus (disorder),y,descendant of concept mapped from leaf
+128875000,Primary cutaneous CD30 antigen positive large T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+187862007,Malignant neoplasm of upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+93492006,"Hodgkin's disease, lymphocytic depletion of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+94032008,Primary malignant neoplasm of skin of lip (disorder),y,descendant of concept mapped from leaf
+94476005,Secondary malignant neoplasm of patella (disorder),y,descendant of concept mapped from leaf
+94319009,Secondary malignant neoplasm of great vessels (disorder),y,descendant of concept mapped from leaf
+721671006,Primary neuroendocrine carcinoma of small intestine (disorder),y,descendant of concept mapped from leaf
+721621008,Primary squamous cell carcinoma of overlapping lesion of esophagus (disorder),y,descendant of concept mapped from leaf
+254703005,Fibroepithelioma of Pinkus (disorder),y,descendant of concept mapped from leaf
+94375005,Secondary malignant neoplasm of left lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+715904005,Pineal parenchymal tumor of intermediate differentiation (disorder),y,descendant of concept mapped from leaf
+93135004,Letterer-Siwe disease of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+448559003,Malignant teratoma of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+184891000119109,Primary adenocarcinoma of small intestine (disorder),y,descendant of concept mapped from leaf
+402507001,Basal cell carcinoma of cheek (disorder),y,descendant of concept mapped from leaf
+724060008,Malignant neoplasm of right upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+735385007,Microsatellite instability-high solid malignant tumor (disorder),y,descendant of concept mapped from leaf
+94716000,Myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+94041003,Primary malignant neoplasm of skin of thigh (disorder),y,descendant of concept mapped from leaf
+107781000119109,Primary papillary serous cystadenocarcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+99111000119103,Primary adenocarcinoma of intestinal tract (disorder),y,descendant of concept mapped from leaf
+422691006,Squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+11010461000119101,Small cell carcinoma (disorder),y,descendant of concept mapped from leaf
+93663003,Primary malignant neoplasm of skin with adnexal differentiation (disorder),y,descendant of concept mapped from leaf
+448254007,Non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+231829006,Malignant neoplasm of eyelid (disorder),y,descendant of concept mapped from leaf
+417554000,Malignant teratoma of descended testis (disorder),y,descendant of concept mapped from leaf
+724650000,Primary follicular dendritic cell sarcoma (disorder),y,descendant of concept mapped from leaf
+369521009,Secondary malignant neoplasm of right fallopian tube (disorder),y,descendant of concept mapped from leaf
+93550004,Hodgkin's sarcoma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+128465005,Secondary malignant neoplasm of articular cartilage (disorder),y,descendant of concept mapped from leaf
+94576007,Secondary malignant neoplasm of skin of umbilicus (disorder),y,descendant of concept mapped from leaf
+94605004,Secondary malignant neoplasm of sternum (disorder),y,descendant of concept mapped from leaf
+721644006,Primary malignant neuroendocrine neoplasm of duodenum (disorder),y,descendant of concept mapped from leaf
+94192008,Secondary malignant neoplasm of blood vessel of finger (disorder),y,descendant of concept mapped from leaf
+1078901000119100,Primary adenocarcinoma of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+403986008,Lymphangiosarcoma (disorder),y,descendant of concept mapped from leaf
+1098981000119101,Recurrent malignant neoplasm of prostate (disorder),y,descendant of concept mapped from leaf
+94133000,Primary malignant neoplasm of vas deferens (disorder),y,descendant of concept mapped from leaf
+94052009,Primary malignant neoplasm of soft tissues of buttock (disorder),y,descendant of concept mapped from leaf
+118600007,Malignant lymphoma (disorder),y,descendant of concept mapped from leaf
+307625008,Malignant lymphoma - centrocytic (disorder),y,descendant of concept mapped from leaf
+699658004,Glandular malignant peripheral nerve sheath tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+92683008,Carcinoma in situ of pituitary gland (disorder),y,descendant of concept mapped from leaf
+372018003,Malignant neoplasm of thoracic vertebral column (disorder),y,descendant of concept mapped from leaf
+449637003,Malignant melanoma of skin of upper arm (disorder),y,descendant of concept mapped from leaf
+93943008,Primary malignant neoplasm of parathyroid gland (disorder),y,descendant of concept mapped from leaf
+721618006,Primary squamous cell carcinoma of upper third of esophagus (disorder),y,descendant of concept mapped from leaf
+93204001,"Malignant mast cell tumor of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+359640008,"Acute myeloid leukemia without maturation, FAB M1 (disorder)",y,descendant of concept mapped from leaf
+402529002,Basal cell carcinoma - micronodular (disorder),y,descendant of concept mapped from leaf
+448214005,Malignant epithelial neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+721620009,Primary squamous cell carcinoma of lower third of esophagus (disorder),y,descendant of concept mapped from leaf
+188589009,"Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla and upper limb (disorder)",y,descendant of concept mapped from leaf
+94278009,Secondary malignant neoplasm of endocardium (disorder),y,descendant of concept mapped from leaf
+94420002,Secondary malignant neoplasm of muscle of face (disorder),y,descendant of concept mapped from leaf
+722425009,Reactive oxygen species 1 positive non-small cell lung cancer (disorder),y,descendant of concept mapped from leaf
+94587004,Secondary malignant neoplasm of soft tissues of hip (disorder),y,descendant of concept mapped from leaf
+93971002,Primary malignant neoplasm of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+721562005,Primary adenocarcinoma overlapping lesion of retroperitoneum peritoneum and omentum (disorder),y,descendant of concept mapped from leaf
+404039004,Melanotic malignant nerve sheath tumor (disorder),y,descendant of concept mapped from leaf
+721575005,Primary angiosarcoma of heart (disorder),y,descendant of concept mapped from leaf
+94523002,Secondary malignant neoplasm of right middle lobe of lung (disorder),y,descendant of concept mapped from leaf
+402494003,Basal cell carcinoma of lower eyelid (disorder),y,descendant of concept mapped from leaf
+371987000,Primary malignant neoplasm of fallopian tube (disorder),y,descendant of concept mapped from leaf
+94473002,Secondary malignant neoplasm of parietal pleura (disorder),y,descendant of concept mapped from leaf
+188138001,Malignant neoplasm of skin of great toe (disorder),y,descendant of concept mapped from leaf
+188505000,Lymphosarcoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93816002,Primary malignant neoplasm of glottis (disorder),y,descendant of concept mapped from leaf
+733361001,Primary mucinous adenocarcinoma of ovary (disorder),y,descendant of concept mapped from leaf
+733834006,Invasive carcinoma of uterine cervix co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+93865007,Primary malignant neoplasm of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+707453008,Primary clear cell squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+277629008,Diffuse malignant lymphoma - large non-cleaved cell (disorder),y,descendant of concept mapped from leaf
+703577000,Papillary carcinoma of the breast (morphologic abnormality),y,descendant of concept mapped from leaf
+94594001,Secondary malignant neoplasm of soft tissues of thorax (disorder),y,descendant of concept mapped from leaf
+721308005,Acute leukemia of ambiguous lineage (disorder),y,descendant of concept mapped from leaf
+93659005,Primary malignant neoplasm of accessory sinus (disorder),y,descendant of concept mapped from leaf
+116381000119105,Ganglioneuroblastoma (disorder),y,descendant of concept mapped from leaf
+443488001,Malignant neoplasm of anorectum (disorder),y,descendant of concept mapped from leaf
+94645008,Secondary malignant neoplasm of trapezoid bone (disorder),y,descendant of concept mapped from leaf
+67821000119109,"Primary small cell malignant neoplasm of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+721569001,Primary adenocarcinoma of uterine ligament (disorder),y,descendant of concept mapped from leaf
+371988005,Primary malignant neoplasm of false vocal cord (disorder),y,descendant of concept mapped from leaf
+423294001,Idiopathic hypereosinophilic syndrome (disorder),y,descendant of concept mapped from leaf
+707473003,Primary mucinous adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+369480009,Malignant tumor involving bladder by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94087009,Primary malignant neoplasm of testis (disorder),y,descendant of concept mapped from leaf
+231833004,Sebaceous adenocarcinoma of eyelid (disorder),y,descendant of concept mapped from leaf
+721305008,Acute myeloid leukemia due to recurrent genetic abnormality (disorder),y,descendant of concept mapped from leaf
+709471005,Periodontitis co-occurrent with leukemia (disorder),y,descendant of concept mapped from leaf
+94348003,Secondary malignant neoplasm of intra-abdominal organs (disorder),y,descendant of concept mapped from leaf
+722530005,Primary squamous cell carcinoma of pharyngeal tonsil (disorder),y,descendant of concept mapped from leaf
+188649008,Leukemic reticuloendotheliosis of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+722682001,Primary small cell carcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+847651000000100,Follicular lymphoma grade 3 (disorder),y,descendant of concept mapped from leaf
+733598001,Acute myeloid leukemia with t(6;9)(p23;q34) translocation (disorder),y,descendant of concept mapped from leaf
+94291005,Secondary malignant neoplasm of extrahepatic bile ducts (disorder),y,descendant of concept mapped from leaf
+402509003,Basal cell carcinoma of neck (disorder),y,descendant of concept mapped from leaf
+94397007,Secondary malignant neoplasm of lymph nodes of neck (disorder),y,descendant of concept mapped from leaf
+722529000,Primary malignant epithelial neoplasm of nasopharynx (disorder),y,descendant of concept mapped from leaf
+449077005,Malignant epithelial neoplasm of maxilla (disorder),y,descendant of concept mapped from leaf
+763666008,Splenic marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94139001,Primary malignant neoplasm of vestibule of nose (disorder),y,descendant of concept mapped from leaf
+94457008,Secondary malignant neoplasm of palatine bone (disorder),y,descendant of concept mapped from leaf
+188493000,Reticulosarcoma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+446022000,Malignant epithelial neoplasm of uterus (disorder),y,descendant of concept mapped from leaf
+703609007,Myxofibrosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448554008,Liposarcoma of connective tissue (disorder),y,descendant of concept mapped from leaf
+403913006,Morpheic basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+426071002,Hodgkin's disease in remission (disorder),y,descendant of concept mapped from leaf
+254655003,Plantar verrucous carcinoma (disorder),y,descendant of concept mapped from leaf
+714463003,Primary effusion lymphoma co-occurrent with infection caused by Human herpesvirus 8 (disorder),y,descendant of concept mapped from leaf
+109937001,Primary malignant neoplasm of peripheral nerves of lower limb (disorder),y,descendant of concept mapped from leaf
+94687005,Mixed cell type lymphosarcoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93644004,Malignant melanoma of skin of perineum (disorder),y,descendant of concept mapped from leaf
+277628000,Diffuse malignant lymphoma - large cleaved cell (disorder),y,descendant of concept mapped from leaf
+94479003,Secondary malignant neoplasm of pelvic peritoneum (disorder),y,descendant of concept mapped from leaf
+94490008,Secondary malignant neoplasm of pisiform bone of hand (disorder),y,descendant of concept mapped from leaf
+109945006,Primary malignant neoplasm of peripheral nerves of pelvis region (disorder),y,descendant of concept mapped from leaf
+443757001,Lobular carcinoma in situ with microinvasion (morphologic abnormality),y,descendant of concept mapped from leaf
+404142007,Primary cutaneous plasmacytoma (disorder),y,descendant of concept mapped from leaf
+707490009,Primary verrucous carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93755007,"Primary malignant neoplasm of choroid, primary (disorder)",y,descendant of concept mapped from leaf
+109978004,T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+254645002,Malignant mesothelioma of pleura (disorder),y,descendant of concept mapped from leaf
+94353008,Secondary malignant neoplasm of ischium (disorder),y,descendant of concept mapped from leaf
+93867004,Primary malignant neoplasm of lesser curvature of stomach (disorder),y,descendant of concept mapped from leaf
+93525002,Hodgkin's disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+766248004,Primitive neuroectodermal tumor of cervix uteri (disorder),y,descendant of concept mapped from leaf
+93638003,Malignant melanoma of skin of knee (disorder),y,descendant of concept mapped from leaf
+277570003,Lymphoma with spill (disorder),y,descendant of concept mapped from leaf
+369464004,Malignant tumor involving ureter by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+423447006,Malignant melanoma of skin of lower eyelid (disorder),y,descendant of concept mapped from leaf
+93665005,Primary malignant neoplasm of adrenal gland (disorder),y,descendant of concept mapped from leaf
+716857003,Hereditary pheochromocytoma and paraganglioma (disorder),y,descendant of concept mapped from leaf
+93548007,Hodgkin's sarcoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+448408001,Sarcoma of upper inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+310599006,Malignant neoplasm of canthus (disorder),y,descendant of concept mapped from leaf
+118612006,Malignant histiocytosis (disorder),y,descendant of concept mapped from leaf
+721574009,Primary rhabdomyosarcoma of male genital organ (disorder),y,descendant of concept mapped from leaf
+1078961000119104,Primary adenocarcinoma of upper lobe of right lung (disorder),y,descendant of concept mapped from leaf
+403922007,Balloon cell malignant melanoma (disorder),y,descendant of concept mapped from leaf
+448867004,Diffuse non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+402526009,Basal cell carcinoma - follicular (disorder),y,descendant of concept mapped from leaf
+369473007,Malignant tumor involving bladder by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+369468001,Malignant tumor involving urethra by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+707593008,Primary salivary gland-type tumour of oropharynx (disorder),y,descendant of concept mapped from leaf
+94654006,Secondary malignant neoplasm of upper limb (disorder),y,descendant of concept mapped from leaf
+449636007,Malignant melanoma of skin of lower leg (disorder),y,descendant of concept mapped from leaf
+93640008,Malignant melanoma of skin of lip (disorder),y,descendant of concept mapped from leaf
+415112005,Plasmacytoma (disorder),y,descendant of concept mapped from leaf
+188562004,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of multiple sites (disorder)",y,descendant of concept mapped from leaf
+763408003,Rhabdomyosarcoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+735332000,Primary cutaneous diffuse large cell B-cell lymphoma of lower extremity (disorder),y,descendant of concept mapped from leaf
+369527008,Malignant tumor involving left ovary by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94261000,Secondary malignant neoplasm of commissure of lip (disorder),y,descendant of concept mapped from leaf
+93808006,Primary malignant neoplasm of frontal sinus (disorder),y,descendant of concept mapped from leaf
+698255000,Noninvasive carcinoma ex pleomorphic adenoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94371001,Secondary malignant neoplasm of lateral portion of floor of mouth (disorder),y,descendant of concept mapped from leaf
+448319002,Diffuse non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+187864008,"Malignant neoplasm of middle lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+726652005,Malignant carcinoid tumor of thymus (disorder),y,descendant of concept mapped from leaf
+449072004,Lymphoma of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+703615007,Low grade myofibroblastic sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+424334007,"Malignant tumor of spinal cord, intramedullary (disorder)",y,descendant of concept mapped from leaf
+188586002,"Hodgkin's disease, lymphocytic depletion of intrathoracic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+733602004,Tubulocystic renal cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+372027002,Primary malignant neoplasm of vermilion border of upper lip (disorder),y,descendant of concept mapped from leaf
+93137007,"Letterer-Siwe disease of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+93914000,Primary malignant neoplasm of myocardium (disorder),y,descendant of concept mapped from leaf
+721633003,Primary adenocarcinoma of overlapping lesion of stomach (disorder),y,descendant of concept mapped from leaf
+302837001,Lentigo maligna melanoma (disorder),y,descendant of concept mapped from leaf
+721607006,Primary undifferentiated carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+448863000,Malignant epithelial neoplasm of pineal gland (disorder),y,descendant of concept mapped from leaf
+707487003,Primary giant cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+413441006,"Acute monocytic leukemia, FAB M5b (disorder)",y,descendant of concept mapped from leaf
+734015000,Clear cell papillary renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+369451000,Malignant tumor involving rectum by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+372014001,Primary malignant neoplasm of stomach (disorder),y,descendant of concept mapped from leaf
+94621009,Secondary malignant neoplasm of temporal bone (disorder),y,descendant of concept mapped from leaf
+423494003,Malignant melanoma of skin of upper eyelid (disorder),y,descendant of concept mapped from leaf
+415286005,Refractory cytopenia with multilineage dysplasia and ringed sideroblasts (disorder),y,descendant of concept mapped from leaf
+721716004,Primary cholangiocarcinoma of intrahepatic biliary tract (disorder),y,descendant of concept mapped from leaf
+766045006,Acute myeloid leukemia and myelodysplastic syndrome related to alkylating agent (disorder),y,descendant of concept mapped from leaf
+369557004,Malignant tumor involving right fallopian tube by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+188516007,Burkitt's lymphoma of spleen (disorder),y,descendant of concept mapped from leaf
+1079161000119106,Primary basal cell carcinoma of right ear (disorder),y,descendant of concept mapped from leaf
+94140004,Primary malignant neoplasm of visceral pleura (disorder),y,descendant of concept mapped from leaf
+403713003,Psoralen and long-wave ultraviolet radiation therapy-associated squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+372025005,Primary malignant neoplasm of vagina (disorder),y,descendant of concept mapped from leaf
+1082291000119108,Transitional cell carcinoma of left ureter (disorder),y,descendant of concept mapped from leaf
+94253005,Secondary malignant neoplasm of chest wall (disorder),y,descendant of concept mapped from leaf
+94578008,Secondary malignant neoplasm of skin of wrist (disorder),y,descendant of concept mapped from leaf
+402522006,Basal cell carcinoma of lower extremity (disorder),y,descendant of concept mapped from leaf
+118606001,Hodgkin's sarcoma (disorder),y,descendant of concept mapped from leaf
+440525003,Primary small cell neoplasm of thymus (disorder),y,descendant of concept mapped from leaf
+765740002,Adenosarcoma of corpus uteri (disorder),y,descendant of concept mapped from leaf
+188666005,Mast cell malignancy of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+94232001,Secondary malignant neoplasm of bronchus of right upper lobe (disorder),y,descendant of concept mapped from leaf
+404131003,CD-30 negative T-immunoblastic cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+369479006,Malignant tumor involving bladder by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+91854005,Acute leukemia in remission (disorder),y,descendant of concept mapped from leaf
+93884005,Primary malignant neoplasm of male breast (disorder),y,descendant of concept mapped from leaf
+424190005,Malignant melanoma of unknown origin (disorder),y,descendant of concept mapped from leaf
+188669003,Mast cell malignancy of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+733344004,Primary squamous cell carcinoma of lip (disorder),y,descendant of concept mapped from leaf
+707697002,Primary squamous cell carcinoma of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+94219006,Secondary malignant neoplasm of bone of lower limb (disorder),y,descendant of concept mapped from leaf
+403742006,Arsenic-induced skin malignancy (disorder),y,descendant of concept mapped from leaf
+93892001,Primary malignant neoplasm of metacarpal bone (disorder),y,descendant of concept mapped from leaf
+423284006,Squamous cell carcinoma of skin of neck (disorder),y,descendant of concept mapped from leaf
+722673007,Primary squamous cell carcinoma of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+721578007,Primary liposarcoma of male genital organ (disorder),y,descendant of concept mapped from leaf
+404137004,Precursor B-cell lymphoblastic lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+404121005,Generalized pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+372028007,Primary malignant neoplasm of vertebral column (disorder),y,descendant of concept mapped from leaf
+94640003,Secondary malignant neoplasm of tonsillar pillar (disorder),y,descendant of concept mapped from leaf
+93546006,Hodgkin's paragranuloma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+449100005,Sarcoma of bone of pelvis (disorder),y,descendant of concept mapped from leaf
+423032007,Leukemic infiltration of orbit (disorder),y,descendant of concept mapped from leaf
+133881000119100,Merkel cell carcinoma of lower limb (disorder),y,descendant of concept mapped from leaf
+707576008,Primary squamous cell carcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+447804006,Leiomyosarcoma of connective tissue (disorder),y,descendant of concept mapped from leaf
+94671007,Secondary malignant neoplasm of vas deferens (disorder),y,descendant of concept mapped from leaf
+93889000,Primary malignant neoplasm of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+1082281000119105,Transitional cell carcinoma of left renal pelvis (disorder),y,descendant of concept mapped from leaf
+733627006,Primary cutaneous gamma-delta-positive T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94433008,Secondary malignant neoplasm of myocardium (disorder),y,descendant of concept mapped from leaf
+404079008,Extraskeletal myxoid chondrosarcoma (disorder),y,descendant of concept mapped from leaf
+359782004,Metastatic malignant neoplasm to apex of urinary bladder (disorder),y,descendant of concept mapped from leaf
+94021008,Primary malignant neoplasm of skin of eyelid (disorder),y,descendant of concept mapped from leaf
+404088004,Low-grade fibromyxoid sarcoma (disorder),y,descendant of concept mapped from leaf
+307623001,Malignant lymphoma - lymphoplasmacytic (disorder),y,descendant of concept mapped from leaf
+94008001,Primary malignant neoplasm of skin of ankle (disorder),y,descendant of concept mapped from leaf
+707686002,Primary squamous cell carcinoma of posterior wall of hypopharynx (disorder),y,descendant of concept mapped from leaf
+733352001,Primary mucinous cystic neoplasm with associated invasive carcinoma of biliary tract (disorder),y,descendant of concept mapped from leaf
+397011009,Mast cell malignancy of lymph nodes (disorder),y,descendant of concept mapped from leaf
+93850006,Primary malignant neoplasm of labia majora (disorder),y,descendant of concept mapped from leaf
+93830007,Primary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+399521000,Necrotic melanoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94113004,Primary malignant neoplasm of undescended testis (disorder),y,descendant of concept mapped from leaf
+449220000,Diffuse follicle center lymphoma (disorder),y,descendant of concept mapped from leaf
+94266005,Secondary malignant neoplasm of cranial nerve (disorder),y,descendant of concept mapped from leaf
+93854002,Primary malignant neoplasm of large intestine (disorder),y,descendant of concept mapped from leaf
+402544001,Basal cell carcinoma - first recurrence (disorder),y,descendant of concept mapped from leaf
+93697005,Primary malignant neoplasm of blood vessel of forearm (disorder),y,descendant of concept mapped from leaf
+403910009,Circumscribed solid basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+703693004,Post-radiation osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+276836002,Primary cerebral lymphoma (disorder),y,descendant of concept mapped from leaf
+94467003,Secondary malignant neoplasm of parathyroid gland (disorder),y,descendant of concept mapped from leaf
+94244003,Secondary malignant neoplasm of central portion of female breast (disorder),y,descendant of concept mapped from leaf
+281702006,Tibial adamantinoma (disorder),y,descendant of concept mapped from leaf
+93996004,Primary malignant neoplasm of sacrum (disorder),y,descendant of concept mapped from leaf
+402820007,Basal cell carcinoma of ear (disorder),y,descendant of concept mapped from leaf
+698048006,Undifferentiated nonkeratinizing squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+1078931000119107,Primary adenocarcinoma of lower lobe of right lung (disorder),y,descendant of concept mapped from leaf
+449632009,Secondary malignant neoplasm of lower leg (disorder),y,descendant of concept mapped from leaf
+423295000,"Squamous cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+369582004,Malignant tumor involving vagina by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+447757002,Angiosarcoma of cheek (disorder),y,descendant of concept mapped from leaf
+93193008,Malignant lymphoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94049001,Primary malignant neoplasm of soft palate (disorder),y,descendant of concept mapped from leaf
+303057009,"Malignant lymphoma, follicular center cell, non-cleaved (disorder)",y,descendant of concept mapped from leaf
+402881008,Primary cutaneous B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+763479005,Metaplastic carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+369528003,Malignant tumor involving left ovary by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+707426009,Primary papillary squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+404155008,Granulocytic sarcoma affecting skin (disorder),y,descendant of concept mapped from leaf
+448555009,Lymphoma of body of stomach (disorder),y,descendant of concept mapped from leaf
+404105000,Lymphomatoid papulosis type C (anaplastic large-cell lymphoma-like) (disorder),y,descendant of concept mapped from leaf
+110006004,Prolymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+698646006,Acute monoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+369554006,Malignant tumor involving right fallopian tube by separate metastasis from left fallopian tube (disorder),y,descendant of concept mapped from leaf
+721627007,Malignant melanoma of esophagus (disorder),y,descendant of concept mapped from leaf
+372124007,Malignant neoplasm of skin of lower limb (disorder),y,descendant of concept mapped from leaf
+93880001,Primary malignant neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+93554008,Hodgkin's sarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+698287002,Malignant melanoma of gum (disorder),y,descendant of concept mapped from leaf
+408648004,Squamous cell carcinoma of epiglottis (disorder),y,descendant of concept mapped from leaf
+99131000119108,Astrocytoma of cerebrum (disorder),y,descendant of concept mapped from leaf
+403923002,Spindle cell malignant melanoma (disorder),y,descendant of concept mapped from leaf
+94284007,Secondary malignant neoplasm of epiglottis (disorder),y,descendant of concept mapped from leaf
+707664003,Primary squamous cell carcinoma of glottis (disorder),y,descendant of concept mapped from leaf
+443489009,Chondrosarcoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+719952009,Primary sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+707471001,Primary clear cell adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+720587009,Donor derived melanoma (disorder),y,descendant of concept mapped from leaf
+430621000,Malignant neoplasm of lower respiratory tract (disorder),y,descendant of concept mapped from leaf
+413445002,Adenocarcinoma of appendix (disorder),y,descendant of concept mapped from leaf
+724058006,Malignant neoplasm of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+707406005,Primary mucoepidermoid carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+94301000,Secondary malignant neoplasm of fibula (disorder),y,descendant of concept mapped from leaf
+707355002,Primary squamous cell carcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+448258005,Sarcoma of mesentery (disorder),y,descendant of concept mapped from leaf
+93487009,"Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+703694005,Low grade central osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+707628004,Overlapping squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707588005,Primary epithelial-myoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94337005,Secondary malignant neoplasm of ilium (disorder),y,descendant of concept mapped from leaf
+94205006,Secondary malignant neoplasm of blood vessel of shoulder (disorder),y,descendant of concept mapped from leaf
+404090003,Malignant infiltration of oral cavity by underlying tumor (disorder),y,descendant of concept mapped from leaf
+708979005,Poorly differentiated sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94598003,Secondary malignant neoplasm of sphenoid bone (disorder),y,descendant of concept mapped from leaf
+404091004,Malignant infiltration of skin by underlying tumor (disorder),y,descendant of concept mapped from leaf
+425535000,Synovial sarcoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+94175004,Secondary malignant neoplasm of appendix (disorder),y,descendant of concept mapped from leaf
+94413009,Secondary malignant neoplasm of middle ear (disorder),y,descendant of concept mapped from leaf
+403920004,Minimal deviation malignant melanoma (disorder),y,descendant of concept mapped from leaf
+404147001,Follicular center B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+188632001,Sézary's disease of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+446939001,Chordoma of clivus (disorder),y,descendant of concept mapped from leaf
+723851008,Primary osteosarcoma of articular cartilage of limb (disorder),y,descendant of concept mapped from leaf
+94138009,Primary malignant neoplasm of vestibule of mouth (disorder),y,descendant of concept mapped from leaf
+94615005,Secondary malignant neoplasm of supraclavicular region (disorder),y,descendant of concept mapped from leaf
+93205000,Malignant mast cell tumor of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+722954005,B-cell lymphoma unclassifiable with features intermediate between classical Hodgkin lymphoma and diffuse large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+93792007,Primary malignant neoplasm of face (disorder),y,descendant of concept mapped from leaf
+369453002,Malignant tumor involving rectum by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+109915008,Primary malignant neoplasm of meninges (disorder),y,descendant of concept mapped from leaf
+93797001,Primary malignant neoplasm of female genital organ (disorder),y,descendant of concept mapped from leaf
+94187006,Secondary malignant neoplasm of blood vessel of abdomen (disorder),y,descendant of concept mapped from leaf
+373080008,Malignant neoplasm of breast lower inner quadrant (disorder),y,descendant of concept mapped from leaf
+369482001,Malignant tumor involving bladder by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+94224009,Secondary malignant neoplasm of brain stem (disorder),y,descendant of concept mapped from leaf
+94166001,Secondary malignant neoplasm of anterior aspect of epiglottis (disorder),y,descendant of concept mapped from leaf
+369609004,Malignant tumor involving an organ by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+128815007,Interdigitating dendritic cell sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94030000,Primary malignant neoplasm of skin of knee (disorder),y,descendant of concept mapped from leaf
+372026006,Primary malignant neoplasm of vermilion border of lower lip (disorder),y,descendant of concept mapped from leaf
+188770007,Subacute myelomonocytic leukemia (disorder),y,descendant of concept mapped from leaf
+447989004,Non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+707345001,Primary carcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+109969005,"Diffuse non-Hodgkin's lymphoma, large cell (disorder)",y,descendant of concept mapped from leaf
+94195005,Secondary malignant neoplasm of blood vessel of hand (disorder),y,descendant of concept mapped from leaf
+94330007,Secondary malignant neoplasm of hypogastric lymph nodes (disorder),y,descendant of concept mapped from leaf
+722681008,Primary mixed adenocarcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+402502007,Basal cell carcinoma of tip of nose (disorder),y,descendant of concept mapped from leaf
+716654007,Non-polyposis Turcot syndrome (disorder),y,descendant of concept mapped from leaf
+707493006,Primary lymphoepithelial carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94421003,Secondary malignant neoplasm of muscle of head (disorder),y,descendant of concept mapped from leaf
+93907002,Primary malignant neoplasm of muscle of pelvis (disorder),y,descendant of concept mapped from leaf
+369500009,Malignant tumor involving uterine cervix by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+449631002,Secondary malignant neoplasm of skin of upper arm (disorder),y,descendant of concept mapped from leaf
+723281005,Primary malignant melanoma of anus (disorder),y,descendant of concept mapped from leaf
+762315004,Therapy related acute myeloid leukemia due to and following administration of antineoplastic agent (disorder),y,descendant of concept mapped from leaf
+277567002,T-cell prolymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+707378008,Primary myoepithelial carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+277572006,Pre B-cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+94102002,Primary malignant neoplasm of tonsillar fossa (disorder),y,descendant of concept mapped from leaf
+94343007,Secondary malignant neoplasm of inner aspect of upper lip (disorder),y,descendant of concept mapped from leaf
+448675008,Malignant neoplasm of digestive system (disorder),y,descendant of concept mapped from leaf
+94086000,Primary malignant neoplasm of temporal lobe (disorder),y,descendant of concept mapped from leaf
+722832009,Primary solid papillary carcinoma with invasion of breast (disorder),y,descendant of concept mapped from leaf
+722671009,Metastatic malignant neoplasm of meninges (disorder),y,descendant of concept mapped from leaf
+94078000,Primary malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+724648008,Plasmablastic lymphoma (disorder),y,descendant of concept mapped from leaf
+302845006,"Nodular malignant lymphoma, lymphocytic - well differentiated (disorder)",y,descendant of concept mapped from leaf
+93676009,Primary malignant neoplasm of anus (disorder),y,descendant of concept mapped from leaf
+733144006,Malignant epithelial neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+724056005,Malignant neoplasm of lower lobe of right lung (disorder),y,descendant of concept mapped from leaf
+443648003,Malignant neoplasm of ear (disorder),y,descendant of concept mapped from leaf
+448775003,Sarcoma of radius (disorder),y,descendant of concept mapped from leaf
+187854004,Malignant neoplasm of mucosa of trachea (disorder),y,descendant of concept mapped from leaf
+188503007,Lymphosarcoma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+403949007,Apocrine adenocarcinoma of skin (disorder),y,descendant of concept mapped from leaf
+255131000,"Carcinoma in situ of oral cavity, lips, salivary glands (disorder)",y,descendant of concept mapped from leaf
+94063007,Primary malignant neoplasm of soft tissues of trunk (disorder),y,descendant of concept mapped from leaf
+371995001,Primary malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+441559006,Mantle cell lymphoma of spleen (disorder),y,descendant of concept mapped from leaf
+93872008,Primary malignant neoplasm of long bone of upper limb (disorder),y,descendant of concept mapped from leaf
+707466008,Primary adenoid cystic carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+369470005,Malignant tumor involving bladder by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+93887003,Primary malignant neoplasm of mastoid air cells (disorder),y,descendant of concept mapped from leaf
+723854000,Primary Ewing sarcoma of articular cartilage of limb (disorder),y,descendant of concept mapped from leaf
+93185008,Malignant histiocytosis of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+713897006,Burkitt lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+188513004,Burkitt's lymphoma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+721311006,Systemic Epstein-Barr virus positive T-cell lymphoproliferative disease of childhood (disorder),y,descendant of concept mapped from leaf
+94512001,Secondary malignant neoplasm of rectovesical septum (disorder),y,descendant of concept mapped from leaf
+93489007,"Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+94504009,Secondary malignant neoplasm of pubis (disorder),y,descendant of concept mapped from leaf
+404151004,Leukemic infiltration of skin in myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+402546004,Basal cell carcinoma - third recurrence (disorder),y,descendant of concept mapped from leaf
+94649002,Secondary malignant neoplasm of trunk (disorder),y,descendant of concept mapped from leaf
+369476004,Malignant tumor involving bladder by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+423468007,"Squamous cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+718200007,Primary pulmonary lymphoma (disorder),y,descendant of concept mapped from leaf
+448930008,Squamous cell carcinoma of nose (disorder),y,descendant of concept mapped from leaf
+188580008,"Hodgkin's disease, mixed cellularity of intrapelvic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+707357005,Primary squamous cell carcinoma of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+94006002,Primary malignant neoplasm of sigmoid colon (disorder),y,descendant of concept mapped from leaf
+94196006,Secondary malignant neoplasm of blood vessel of head (disorder),y,descendant of concept mapped from leaf
+109831001,Overlapping malignant neoplasm of palate (disorder),y,descendant of concept mapped from leaf
+372098004,Carcinoma of endocervix (disorder),y,descendant of concept mapped from leaf
+1090881000000100,Malignant neoplasm of bronchus or lung (disorder),y,descendant of concept mapped from leaf
+94228007,Secondary malignant neoplasm of bronchus of left lower lobe (disorder),y,descendant of concept mapped from leaf
+93451002,"Erythroleukemia, FAB M6 (disorder)",y,descendant of concept mapped from leaf
+404143002,Primary cutaneous follicular center B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94559008,Secondary malignant neoplasm of skin of groin (disorder),y,descendant of concept mapped from leaf
+448250003,Malignant teratoma of pineal region (disorder),y,descendant of concept mapped from leaf
+107581000119103,Astrocytoma of brain stem (disorder),y,descendant of concept mapped from leaf
+94715001,Mycosis fungoides of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+276750003,Malignant tumor of skin with pilar differentiation (disorder),y,descendant of concept mapped from leaf
+107771000119106,Primary malignant clear cell neoplasm of endometrium (disorder),y,descendant of concept mapped from leaf
+707581004,Primary papillary squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+400001003,Primary cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+93742006,Primary malignant neoplasm of cartilage of nose (disorder),y,descendant of concept mapped from leaf
+93886007,Primary malignant neoplasm of mandible (disorder),y,descendant of concept mapped from leaf
+448560008,Diffuse non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+403714009,Psoralen and long-wave ultraviolet radiation therapy-associated malignant melanoma (disorder),y,descendant of concept mapped from leaf
+94707004,Mycosis fungoides of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+369526004,Malignant tumor involving left ovary by direct extension from right ovary (disorder),y,descendant of concept mapped from leaf
+765094003,Renal medullary carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+354351000119105,Primary malignant neoplasm of left kidney (disorder),y,descendant of concept mapped from leaf
+93827000,Primary malignant neoplasm of hilus of lung (disorder),y,descendant of concept mapped from leaf
+128772005,Periosteal osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+277575008,T-cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+93701008,Primary malignant neoplasm of blood vessel of inguinal region (disorder),y,descendant of concept mapped from leaf
+722672002,Primary squamous cell carcinoma of base of tongue (disorder),y,descendant of concept mapped from leaf
+87111000119109,Malignant glioma of hypothalamus (disorder),y,descendant of concept mapped from leaf
+93861003,Primary malignant neoplasm of lateral wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94120006,Primary malignant neoplasm of urachus (disorder),y,descendant of concept mapped from leaf
+94179005,Secondary malignant neoplasm of ascending colon (disorder),y,descendant of concept mapped from leaf
+404080006,Extraskeletal mesenchymal chondrosarcoma (disorder),y,descendant of concept mapped from leaf
+423700001,Squamous cell carcinoma of auricle of ear (disorder),y,descendant of concept mapped from leaf
+707586009,Primary myoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94062002,Primary malignant neoplasm of soft tissues of thorax (disorder),y,descendant of concept mapped from leaf
+133531000119104,Malignant neuroendocrine tumor (disorder),y,descendant of concept mapped from leaf
+423829008,Invasive vulval Paget's disease (disorder),y,descendant of concept mapped from leaf
+371986009,Primary malignant neoplasm of eye (disorder),y,descendant of concept mapped from leaf
+94571002,Secondary malignant neoplasm of skin of shoulder (disorder),y,descendant of concept mapped from leaf
+93807001,Primary malignant neoplasm of frontal lobe (disorder),y,descendant of concept mapped from leaf
+94358004,Secondary malignant neoplasm of junctional region of epiglottis (disorder),y,descendant of concept mapped from leaf
+94428009,Secondary malignant neoplasm of muscle of shoulder (disorder),y,descendant of concept mapped from leaf
+721645007,Primary neuroendocrine carcinoma of duodenum (disorder),y,descendant of concept mapped from leaf
+399897004,Basal cell carcinoma of postauricular skin (disorder),y,descendant of concept mapped from leaf
+188591001,"Hodgkin's disease, lymphocytic depletion of intrapelvic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+254626006,Adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+402516002,Basal cell carcinoma of abdomen (disorder),y,descendant of concept mapped from leaf
+1079191000119104,Primary basal cell carcinoma of right lower limb (disorder),y,descendant of concept mapped from leaf
+448609001,Diffuse non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+702446006,Core binding factor acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+699358009,High grade endometrial stromal sarcoma (disorder),y,descendant of concept mapped from leaf
+733162002,Primary malignant neuroendocrine neoplasm of anus (disorder),y,descendant of concept mapped from leaf
+721698005,Primary malignant neuroendocrine neoplasm of colon (disorder),y,descendant of concept mapped from leaf
+300987004,Disseminated squamous cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+109918005,Primary malignant neoplasm of peripheral nerves and peripheral autonomic nervous system (disorder),y,descendant of concept mapped from leaf
+707465007,Primary mucoepidermoid carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+118613001,Hairy cell leukemia (disorder),y,descendant of concept mapped from leaf
+253003009,Carcinoid bronchial adenoma (disorder),y,descendant of concept mapped from leaf
+255101006,Sézary disease of skin (disorder),y,descendant of concept mapped from leaf
+721709000,Primary cloacogenic carcinoma of anal canal (disorder),y,descendant of concept mapped from leaf
+363517008,Malignant tumor of urinary tract proper (disorder),y,descendant of concept mapped from leaf
+94028002,Primary malignant neoplasm of skin of hand (disorder),y,descendant of concept mapped from leaf
+93215006,Malignant melanoma of skin of breast (disorder),y,descendant of concept mapped from leaf
+739301006,Osteoporosis co-occurrent and due to multiple myeloma (disorder),y,descendant of concept mapped from leaf
+372021001,Primary malignant neoplasm of trapezium (disorder),y,descendant of concept mapped from leaf
+372106005,Carcinoma of penis (disorder),y,descendant of concept mapped from leaf
+369508002,Malignant tumor involving vulva by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+94197002,Secondary malignant neoplasm of blood vessel of hip (disorder),y,descendant of concept mapped from leaf
+277984002,Embryonal neuroepithelial tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+393563007,Glioblastoma multiforme (disorder),y,descendant of concept mapped from leaf
+188627002,Mycosis fungoides of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+448388003,Sarcoma of lower outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+254634000,Squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+404017001,Inflammatory malignant fibrous histiocytoma of skin (disorder),y,descendant of concept mapped from leaf
+94499009,Secondary malignant neoplasm of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+449418000,Follicular non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+424779008,Primary Kaposi's sarcoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+94436000,Secondary malignant neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+735679005,Primary chondrosarcoma of bone (disorder),y,descendant of concept mapped from leaf
+403894000,Squamous cell carcinoma of skin of ear (disorder),y,descendant of concept mapped from leaf
+277614006,Prethymic and thymic T-cell lymphoma/leukemia (disorder),y,descendant of concept mapped from leaf
+93952004,Primary malignant neoplasm of pelvic peritoneum (disorder),y,descendant of concept mapped from leaf
+94202009,Secondary malignant neoplasm of blood vessel of pelvis (disorder),y,descendant of concept mapped from leaf
+721762007,Adult T-cell leukemia/lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+847741000000106,Diffuse large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+448248006,Malignant neoplasm of axial suprasellar region of brain (disorder),y,descendant of concept mapped from leaf
+93788000,Primary malignant neoplasm of eustachian tube (disorder),y,descendant of concept mapped from leaf
+369519004,Malignant tumor involving left fallopian tube by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+94708009,Mycosis fungoides of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94629006,Secondary malignant neoplasm of thigh (disorder),y,descendant of concept mapped from leaf
+847701000000108,Follicular lymphoma grade 3b (disorder),y,descendant of concept mapped from leaf
+372017008,Primary malignant neoplasm of thoracic esophagus (disorder),y,descendant of concept mapped from leaf
+93703006,Primary malignant neoplasm of blood vessel of lower limb (disorder),y,descendant of concept mapped from leaf
+94591009,Secondary malignant neoplasm of soft tissues of pelvis (disorder),y,descendant of concept mapped from leaf
+94208008,Secondary malignant neoplasm of blood vessel of toe (disorder),y,descendant of concept mapped from leaf
+716657000,Familial papillary thyroid carcinoma with renal papillary neoplasia syndrome (disorder),y,descendant of concept mapped from leaf
+369492009,Malignant tumor involving seminal vesicle by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+94540006,Secondary malignant neoplasm of skin of ankle (disorder),y,descendant of concept mapped from leaf
+397081004,"Mucoepidermoid carcinoma, high grade (morphologic abnormality)",y,descendant of concept mapped from leaf
+94683009,Secondary malignant neoplasm of zygomatic bone (disorder),y,descendant of concept mapped from leaf
+94586008,Secondary malignant neoplasm of soft tissues of head (disorder),y,descendant of concept mapped from leaf
+93741004,Primary malignant neoplasm of carpal bone (disorder),y,descendant of concept mapped from leaf
+29421000119105,Adenocarcinoma in adenomatous polyp (disorder),y,descendant of concept mapped from leaf
+369602008,Malignant tumor involving an organ by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+449059000,Follicular non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+422736007,Primary malignant neoplasm of peripheral nerve (disorder),y,descendant of concept mapped from leaf
+449309003,Malignant neoplasm of skin of scrotum (disorder),y,descendant of concept mapped from leaf
+718604008,Small cell neuroendocrine carcinoma of bladder (disorder),y,descendant of concept mapped from leaf
+707397008,Primary basal cell adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707398003,Primary polymorphous low grade adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+766930002,Glassy cell carcinoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+93520007,Hodgkin's disease of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+188091006,Malignant neoplasm of skin of external auditory meatus (disorder),y,descendant of concept mapped from leaf
+447656001,Lymphoma of pylorus of stomach (disorder),y,descendant of concept mapped from leaf
+447886005,Adenocarcinoma of anorectum (disorder),y,descendant of concept mapped from leaf
+94026003,Primary malignant neoplasm of skin of forehead (disorder),y,descendant of concept mapped from leaf
+94545001,Secondary malignant neoplasm of skin of buttock (disorder),y,descendant of concept mapped from leaf
+707531008,Primary squamous cell carcinoma of branchial cleft (disorder),y,descendant of concept mapped from leaf
+415110002,Plasma cell myeloma/plasmacytoma (disorder),y,descendant of concept mapped from leaf
+15956181000119102,Secondary adenocarcinoma of bilateral lungs (disorder),y,descendant of concept mapped from leaf
+277545003,T-cell chronic lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+721625004,Primary neuroendocrine carcinoma of esophagus (disorder),y,descendant of concept mapped from leaf
+94158005,Secondary malignant neoplasm of adenoid (disorder),y,descendant of concept mapped from leaf
+369467006,Malignant tumor involving urethra by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+707674000,Primary malignant epithelial neoplasm of trachea (disorder),y,descendant of concept mapped from leaf
+735757008,Primary ganglioneuroblastoma of brain (disorder),y,descendant of concept mapped from leaf
+369586001,Malignant tumor involving vagina by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+128919000,Gangliocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+734099007,Neuroblastoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+448451002,Sarcoma upper outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+403904009,Verrucous squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94482008,Secondary malignant neoplasm of periadrenal tissue (disorder),y,descendant of concept mapped from leaf
+93662008,Primary malignant neoplasm of adenoid (disorder),y,descendant of concept mapped from leaf
+188125009,Malignant neoplasm of skin of thumb (disorder),y,descendant of concept mapped from leaf
+93764002,"Primary malignant neoplasm of conjunctiva, primary (disorder)",y,descendant of concept mapped from leaf
+94674004,Secondary malignant neoplasm of vermilion border of lower lip (disorder),y,descendant of concept mapped from leaf
+94103007,Primary malignant neoplasm of tonsillar pillar (disorder),y,descendant of concept mapped from leaf
+188675007,Malignant lymphoma - small cleaved cell (disorder),y,descendant of concept mapped from leaf
+448865007,Follicular non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+94245002,Secondary malignant neoplasm of cerebellum (disorder),y,descendant of concept mapped from leaf
+94325008,Secondary malignant neoplasm of head of pancreas (disorder),y,descendant of concept mapped from leaf
+93686005,Primary malignant neoplasm of back (disorder),y,descendant of concept mapped from leaf
+444596001,Malignant thymoma (disorder),y,descendant of concept mapped from leaf
+188737002,Chloroma (disorder),y,descendant of concept mapped from leaf
+369566000,Malignant tumor involving right ovary by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+91281000119103,Secondary adenocarcinoma of bone (disorder),y,descendant of concept mapped from leaf
+93732009,Primary malignant neoplasm of bronchus of right middle lobe (disorder),y,descendant of concept mapped from leaf
+449307001,Follicular non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+426217000,Aleukemic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+236513009,Lymphoma of kidney (disorder),y,descendant of concept mapped from leaf
+708937004,"Seminoma, metastatic (morphologic abnormality)",y,descendant of concept mapped from leaf
+707495004,Primary squamous cell adenoid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+703822002,Indeterminate dendritic cell tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+109991003,Acute myelofibrosis (disorder),y,descendant of concept mapped from leaf
+413442004,Acute monocytic/monoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+313353007,Squamous cell carcinoma of bronchus in left lower lobe (disorder),y,descendant of concept mapped from leaf
+94050001,Primary malignant neoplasm of soft tissues of abdomen (disorder),y,descendant of concept mapped from leaf
+402911002,Penile verrucous carcinoma of Buschke-Löwenstein (disorder),y,descendant of concept mapped from leaf
+107791000119107,Primary adenosquamous carcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+707346000,Primary carcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+128775007,Clear cell chondrosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+423607006,Adenocarcinoma of anus (disorder),y,descendant of concept mapped from leaf
+94019003,Primary malignant neoplasm of skin of external auditory canal (disorder),y,descendant of concept mapped from leaf
+847691000000108,Follicular lymphoma grade 3a (disorder),y,descendant of concept mapped from leaf
+109927006,Primary malignant neoplasm of peripheral nerves of neck (disorder),y,descendant of concept mapped from leaf
+415285009,Refractory cytopenia with multilineage dysplasia (disorder),y,descendant of concept mapped from leaf
+109359008,Primary malignant neoplasm of independent multiple sites (disorder),y,descendant of concept mapped from leaf
+94204005,Secondary malignant neoplasm of blood vessel of popliteal space (disorder),y,descendant of concept mapped from leaf
+58961005,Lethal midline granuloma (disorder),y,descendant of concept mapped from leaf
+426964009,"Non-small cell lung cancer, positive for epidermal growth factor receptor expression (disorder)",y,descendant of concept mapped from leaf
+308121000,Follicular non-Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+698043002,Malignant melanoma of floor of mouth (disorder),y,descendant of concept mapped from leaf
+93929003,Primary malignant neoplasm of oculomotor nerve (disorder),y,descendant of concept mapped from leaf
+425869007,"Acute promyelocytic leukemia, FAB M3, in remission (disorder)",y,descendant of concept mapped from leaf
+116811000119106,Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of lower limb (disorder),y,descendant of concept mapped from leaf
+420301000,"Follicular carcinoma, widely invasive (morphologic abnormality)",y,descendant of concept mapped from leaf
+94492000,Secondary malignant neoplasm of placenta (disorder),y,descendant of concept mapped from leaf
+128041000119107,Primary adenocarcinoma of distal third of esophagus (disorder),y,descendant of concept mapped from leaf
+422782004,"Primary malignant neoplasm of ovary, with widespread metastatic disease (disorder)",y,descendant of concept mapped from leaf
+726019003,Familial malignant melanoma of skin (disorder),y,descendant of concept mapped from leaf
+93824007,Primary malignant neoplasm of head (disorder),y,descendant of concept mapped from leaf
+707589002,Primary cystadenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707403002,Primary fetal adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94117003,Primary malignant neoplasm of upper outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+404129007,CD-30 negative anaplastic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+188590000,"Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region and lower limb (disorder)",y,descendant of concept mapped from leaf
+1080981000119104,Malignant melanoma of right choroid (disorder),y,descendant of concept mapped from leaf
+67811000119102,"Primary small cell malignant neoplasm of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+95187002,Nodular lymphoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+716593008,Carcinoma of salivary gland type of breast (disorder),y,descendant of concept mapped from leaf
+737313007,Primary malignant neuroendocrine neoplasm of ileum (disorder),y,descendant of concept mapped from leaf
+702467006,Malignant neoplasm of augmented bladder (disorder),y,descendant of concept mapped from leaf
+707356001,Primary squamous cell carcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+93151007,Hairy cell leukemia of spleen (disorder),y,descendant of concept mapped from leaf
+703596001,Tubulolobular carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93826009,Primary malignant neoplasm of hepatic flexure of colon (disorder),y,descendant of concept mapped from leaf
+12240991000119102,Squamous cell carcinoma of right lung (disorder),y,descendant of concept mapped from leaf
+94101009,Primary malignant neoplasm of tongue (disorder),y,descendant of concept mapped from leaf
+94508007,Secondary malignant neoplasm of radius (disorder),y,descendant of concept mapped from leaf
+94274006,Secondary malignant neoplasm of thoracic vertebral column (disorder),y,descendant of concept mapped from leaf
+420788006,Intraocular non-Hodgkin malignant lymphoma (disorder),y,descendant of concept mapped from leaf
+128773000,High grade surface osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93906006,Primary malignant neoplasm of muscle of neck (disorder),y,descendant of concept mapped from leaf
+371992003,Primary malignant neoplasm of intestinal tract (disorder),y,descendant of concept mapped from leaf
+722684000,Primary low grade serous adenocarcinoma of ovary (disorder),y,descendant of concept mapped from leaf
+713038003,Overlapping primary malignant neoplasm of bone and articular cartilage of upper limb (disorder),y,descendant of concept mapped from leaf
+702977001,Follicular non-Hodgkin's lymphoma diffuse follicle center cell sub-type grade 2 (disorder),y,descendant of concept mapped from leaf
+404073009,Spindle cell liposarcoma (disorder),y,descendant of concept mapped from leaf
+94577003,Secondary malignant neoplasm of skin of upper limb (disorder),y,descendant of concept mapped from leaf
+94013002,Primary malignant neoplasm of skin of buttock (disorder),y,descendant of concept mapped from leaf
+94418000,Secondary malignant neoplasm of muscle of abdomen (disorder),y,descendant of concept mapped from leaf
+93837005,Primary malignant neoplasm of inner aspect of upper lip (disorder),y,descendant of concept mapped from leaf
+93904009,Primary malignant neoplasm of muscle of inguinal region (disorder),y,descendant of concept mapped from leaf
+449173006,Diffuse non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+427658007,"Acute myelomonocytic leukemia, FAB M4, in remission (disorder)",y,descendant of concept mapped from leaf
+709830006,Malignant carcinoid tumor of stomach (disorder),y,descendant of concept mapped from leaf
+722679006,Primary mucinous adenocarcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+408649007,Squamous cell carcinoma of pharynx (disorder),y,descendant of concept mapped from leaf
+190030009,Compound leukemias (disorder),y,descendant of concept mapped from leaf
+94359007,Secondary malignant neoplasm of junctional zone of tongue (disorder),y,descendant of concept mapped from leaf
+404008001,Dermatofibrosarcoma protuberans with myoid differentiation (disorder),y,descendant of concept mapped from leaf
+94526005,Secondary malignant neoplasm of sacrococcygeal region (disorder),y,descendant of concept mapped from leaf
+93197009,Malignant lymphoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+94460001,Secondary malignant neoplasm of pancreatic duct (disorder),y,descendant of concept mapped from leaf
+405546008,Pericardial effusion co-occurrent and due to malignant neoplasm of pericardium (disorder),y,descendant of concept mapped from leaf
+93959008,Primary malignant neoplasm of phalanx of foot (disorder),y,descendant of concept mapped from leaf
+449497006,Sarcoma of pelvic peritoneum (disorder),y,descendant of concept mapped from leaf
+94434002,Secondary malignant neoplasm of myometrium (disorder),y,descendant of concept mapped from leaf
+721558004,Primary adenocarcinoma of cystic duct (disorder),y,descendant of concept mapped from leaf
+93723007,Primary malignant neoplasm of bone of skull (disorder),y,descendant of concept mapped from leaf
+369542006,Malignant tumor involving left fallopian tube by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+93227009,Malignant melanoma of skin of foot (disorder),y,descendant of concept mapped from leaf
+93849006,Primary malignant neoplasm of kidney (disorder),y,descendant of concept mapped from leaf
+188648000,Leukemic reticuloendotheliosis of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+449628003,Malignant neoplasm of long bone of lower leg (disorder),y,descendant of concept mapped from leaf
+188510001,"Burkitt's lymphoma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+707528007,Primary squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+93820003,Primary malignant neoplasm of hamate bone (disorder),y,descendant of concept mapped from leaf
+372020000,Primary malignant neoplasm of tonsil (disorder),y,descendant of concept mapped from leaf
+93747000,Primary malignant neoplasm of cerebral meninges (disorder),y,descendant of concept mapped from leaf
+188095002,"Malignant neoplasm of skin of cheek, external (disorder)",y,descendant of concept mapped from leaf
+403915004,Basal cell carcinoma of scalp (disorder),y,descendant of concept mapped from leaf
+449075002,Lymphoma of cardioesophageal junction (disorder),y,descendant of concept mapped from leaf
+369469009,Malignant tumor involving bladder by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+707596000,Primary carcinosarcoma of lung (disorder),y,descendant of concept mapped from leaf
+188578002,"Hodgkin's disease, mixed cellularity of lymph nodes of axilla and upper limb (disorder)",y,descendant of concept mapped from leaf
+713718006,Diffuse non-Hodgkin immunoblastic lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+371969003,Primary malignant neoplasm of apex of urinary bladder (disorder),y,descendant of concept mapped from leaf
+404010004,Dermatofibrosarcoma protuberans with giant cell fibroblastoma (disorder),y,descendant of concept mapped from leaf
+419842002,Squamous cell carcinoma of oral mucous membrane (disorder),y,descendant of concept mapped from leaf
+723889003,B lymphoblastic leukemia lymphoma with t(9:22) (q34;q11.2); BCR-ABL 1 (disorder),y,descendant of concept mapped from leaf
+93781006,Primary malignant neoplasm of endometrium (disorder),y,descendant of concept mapped from leaf
+371012000,"Acute lymphoblastic leukemia, transitional pre-B-cell (disorder)",y,descendant of concept mapped from leaf
+277651000,Peripheral T-cell lymphoma - pleomorphic small cell (disorder),y,descendant of concept mapped from leaf
+94069006,Primary malignant neoplasm of spinal meninges (disorder),y,descendant of concept mapped from leaf
+448377009,Sarcoma of sacrum (disorder),y,descendant of concept mapped from leaf
+707468009,Primary mixed mucinous and non-mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93684008,Primary malignant neoplasm of axilla (disorder),y,descendant of concept mapped from leaf
+94238002,Secondary malignant neoplasm of carina (disorder),y,descendant of concept mapped from leaf
+128814006,Langerhans cell sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+733359005,Primary squamous cell carcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+402536001,Basal cell carcinoma - primary (disorder),y,descendant of concept mapped from leaf
+188660004,Malignant mast cell tumors (disorder),y,descendant of concept mapped from leaf
+94528006,Secondary malignant neoplasm of scalene lymph nodes (disorder),y,descendant of concept mapped from leaf
+1081021000119109,Malignant melanoma of skin of left lower limb (disorder),y,descendant of concept mapped from leaf
+94046008,Primary malignant neoplasm of skin of wrist (disorder),y,descendant of concept mapped from leaf
+372007003,Primary malignant neoplasm of retrocecal tissue (disorder),y,descendant of concept mapped from leaf
+371963002,Primary malignant neoplasm of adrenal cortex (disorder),y,descendant of concept mapped from leaf
+449630001,Secondary malignant neoplasm of skin of lower leg (disorder),y,descendant of concept mapped from leaf
+94155008,Secondary malignant neoplasm of accessory sinus (disorder),y,descendant of concept mapped from leaf
+404116007,Mycosis fungoides with systemic infiltration (disorder),y,descendant of concept mapped from leaf
+277623009,Monocytoid B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94624001,Secondary malignant neoplasm of the mesentery (disorder),y,descendant of concept mapped from leaf
+449176003,Diffuse non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+188679001,Diffuse non-Hodgkin's lymphoma undifferentiated (diffuse) (disorder),y,descendant of concept mapped from leaf
+94412004,Secondary malignant neoplasm of metatarsal bone (disorder),y,descendant of concept mapped from leaf
+369523007,Secondary malignant neoplasm of left ovary (disorder),y,descendant of concept mapped from leaf
+369452007,Malignant tumor involving rectum by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+269464000,"Malignant neoplasm of upper lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+302841002,Malignant lymphoma - small lymphocytic (disorder),y,descendant of concept mapped from leaf
+93968005,Primary malignant neoplasm of posterior hypopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+93683002,Primary malignant neoplasm of ascending colon (disorder),y,descendant of concept mapped from leaf
+423005002,Primary malignant neoplasm of lacrimal gland duct (disorder),y,descendant of concept mapped from leaf
+94329002,Secondary malignant neoplasm of hilus of lung (disorder),y,descendant of concept mapped from leaf
+707354003,Primary squamous cell carcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+92526009,Carcinoma in situ of adrenal cortex (disorder),y,descendant of concept mapped from leaf
+403919005,Basal cell carcinoma of upper eyelid (disorder),y,descendant of concept mapped from leaf
+76564002,Catecholamine secretion by pheochromocytoma (disorder),y,descendant of concept mapped from leaf
+448401007,Choriocarcinoma of placenta (disorder),y,descendant of concept mapped from leaf
+424052001,Small cell carcinoma carcinomatosis (disorder),y,descendant of concept mapped from leaf
+93961004,Primary malignant neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+721619003,Primary squamous cell carcinoma of middle third of esophagus (disorder),y,descendant of concept mapped from leaf
+93648001,Malignant melanoma of skin of temporal region (disorder),y,descendant of concept mapped from leaf
+93522004,Hodgkin's disease of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+707383000,Primary mucinous cystadenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+704152002,Metastatic neuroblastoma (disorder),y,descendant of concept mapped from leaf
+733926004,Ganglioneuroblastoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+94115006,Primary malignant neoplasm of upper inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+109371002,Overlapping malignant neoplasm of bronchus and lung (disorder),y,descendant of concept mapped from leaf
+109980005,Malignant immunoproliferative disease (disorder),y,descendant of concept mapped from leaf
+423812005,Sarcoma of head and neck (disorder),y,descendant of concept mapped from leaf
+723852001,Primary osteosarcoma of articular cartilage of pelvis (disorder),y,descendant of concept mapped from leaf
+94718004,Myeloid sarcoma in remission (disorder),y,descendant of concept mapped from leaf
+707407001,Primary signet ring cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+369520005,Primary malignant neoplasm of right fallopian tube (disorder),y,descendant of concept mapped from leaf
+94411006,Secondary malignant neoplasm of metacarpal bone (disorder),y,descendant of concept mapped from leaf
+1082311000119107,Transitional cell carcinoma of right ureter (disorder),y,descendant of concept mapped from leaf
+707485006,Primary adenosquamous carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93878007,Primary malignant neoplasm of lumbar vertebral column (disorder),y,descendant of concept mapped from leaf
+371994002,Primary malignant neoplasm of laryngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+402496001,Basal cell carcinoma of lateral canthus (disorder),y,descendant of concept mapped from leaf
+723848001,Primary osteosarcoma of bone of jaw (disorder),y,descendant of concept mapped from leaf
+93800004,Primary malignant neoplasm of first cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+403955002,Undifferentiated adnexal carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+723853006,Primary Ewing sarcoma of bone of limb (disorder),y,descendant of concept mapped from leaf
+703816006,"Pancreatic endocrine tumor, nonfunctioning (morphologic abnormality)",y,descendant of concept mapped from leaf
+404152006,Leukemic infiltration of skin in acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+93218008,Malignant melanoma of skin of chest (disorder),y,descendant of concept mapped from leaf
+60620005,Epsilon heavy chain disease (disorder),y,descendant of concept mapped from leaf
+425231005,"Carcinoma of urinary bladder, superficial (disorder)",y,descendant of concept mapped from leaf
+93136003,Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+230156002,Malignant meningitis (disorder),y,descendant of concept mapped from leaf
+733346002,Primary mucinous cystic neoplasm with associated invasive carcinoma of perihilar bile duct (disorder),y,descendant of concept mapped from leaf
+372126009,Malignant neoplasm of skin of trunk (disorder),y,descendant of concept mapped from leaf
+371989002,Primary malignant neoplasm of glans penis (disorder),y,descendant of concept mapped from leaf
+404009009,Dermatofibrosarcoma protuberans with granular cell change (disorder),y,descendant of concept mapped from leaf
+404094007,Metastasis involving oral cavity (disorder),y,descendant of concept mapped from leaf
+403729006,Radiation-induced skin malignancy (disorder),y,descendant of concept mapped from leaf
+118610003,"Hodgkin's disease, lymphocytic depletion (disorder)",y,descendant of concept mapped from leaf
+307650006,Histiocytic medullary reticulosis (disorder),y,descendant of concept mapped from leaf
+423464009,Squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+449803009,Primary malignant neoplasm of dome of urinary bladder (disorder),y,descendant of concept mapped from leaf
+404068003,Sclerosing liposarcoma (disorder),y,descendant of concept mapped from leaf
+94084002,Primary malignant neoplasm of tarsal bone (disorder),y,descendant of concept mapped from leaf
+402540005,Basal cell carcinoma recurrent following Mohs' excision (disorder),y,descendant of concept mapped from leaf
+736322001,Pediatric follicular lymphoma (disorder),y,descendant of concept mapped from leaf
+93908007,Primary malignant neoplasm of muscle of perineum (disorder),y,descendant of concept mapped from leaf
+96981000119102,Malignant neoplasm of rectosigmoid junction metastatic to brain (disorder),y,descendant of concept mapped from leaf
+128883006,Fibroblastic liposarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+699657009,Hepatosplenic gamma-delta cell lymphoma (disorder),y,descendant of concept mapped from leaf
+188728002,Aleukemic lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+369540003,Malignant tumor involving right broad ligament by metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+313427003,Lambda light chain myeloma (disorder),y,descendant of concept mapped from leaf
+118607005,"Hodgkin lymphoma, lymphocyte-rich (disorder)",y,descendant of concept mapped from leaf
+187821001,Angiosarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+763309005,Acute myeloid leukemia with nucleophosmin 1 somatic mutation (disorder),y,descendant of concept mapped from leaf
+105121000119102,Squamous cell carcinoma of vagina (disorder),y,descendant of concept mapped from leaf
+93815003,Primary malignant neoplasm of glossopharyngeal nerve (disorder),y,descendant of concept mapped from leaf
+94643001,Secondary malignant neoplasm of transverse colon (disorder),y,descendant of concept mapped from leaf
+363358000,Malignant tumor of lung (disorder),y,descendant of concept mapped from leaf
+93920004,Primary malignant neoplasm of navicular bone of foot (disorder),y,descendant of concept mapped from leaf
+707486007,Primary basaloid carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+188498009,Lymphosarcoma (disorder),y,descendant of concept mapped from leaf
+93766000,"Primary malignant neoplasm of cornea, primary (disorder)",y,descendant of concept mapped from leaf
+763719001,Hydroa vacciniforme-like lymphoma (disorder),y,descendant of concept mapped from leaf
+307610008,Pilomatrix carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+403906006,Metastatic squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+93671004,Primary malignant neoplasm of anterior mediastinum (disorder),y,descendant of concept mapped from leaf
+707348004,Primary carcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+236512004,Leukemic infiltrate of kidney (disorder),y,descendant of concept mapped from leaf
+94220000,Secondary malignant neoplasm of bone of skull (disorder),y,descendant of concept mapped from leaf
+145831000119103,Primary malignant germ cell neoplasm (disorder),y,descendant of concept mapped from leaf
+737309000,Primary adenocarcinoma of submandibular gland (disorder),y,descendant of concept mapped from leaf
+707579001,Primary basaloid squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94604000,Secondary malignant neoplasm of splenic flexure of colon (disorder),y,descendant of concept mapped from leaf
+94431005,Secondary malignant neoplasm of muscle of upper limb (disorder),y,descendant of concept mapped from leaf
+447805007,Lymphoma of greater curvature of stomach (disorder),y,descendant of concept mapped from leaf
+71111000119109,Recurrent primary malignant neoplasm of vulva (disorder),y,descendant of concept mapped from leaf
+721602000,Primary embryonal carcinoma of testis (disorder),y,descendant of concept mapped from leaf
+765136002,Primary cutaneous CD8 positive aggressive epidermotropic cytotoxic T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+91031000119108,Primary chondrosarcoma of bone of upper limb (disorder),y,descendant of concept mapped from leaf
+369556008,Malignant tumor involving right fallopian tube by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+93674007,Primary malignant neoplasm of anterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707660007,Primary giant cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+92511007,Burkitt's tumor of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+402504008,Basal cell carcinoma of nasolabial groove (disorder),y,descendant of concept mapped from leaf
+703429003,Malignant optic glioma of adulthood (disorder),y,descendant of concept mapped from leaf
+94583000,Secondary malignant neoplasm of soft tissues of axilla (disorder),y,descendant of concept mapped from leaf
+422968005,"Non-small cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+94271003,Secondary malignant neoplasm of descending colon (disorder),y,descendant of concept mapped from leaf
+369457001,Malignant tumor involving rectum by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+413656006,Blastic phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+277543005,Malignant white blood cell disorder (disorder),y,descendant of concept mapped from leaf
+94394000,Secondary malignant neoplasm of lymph nodes of head (disorder),y,descendant of concept mapped from leaf
+94380001,Secondary malignant neoplasm of lip (disorder),y,descendant of concept mapped from leaf
+91151000119103,Primary squamous cell carcinoma of chest wall (disorder),y,descendant of concept mapped from leaf
+449223003,Malignant neoplasm of alveolus of maxilla (disorder),y,descendant of concept mapped from leaf
+254938000,Astrocytoma of brain (disorder),y,descendant of concept mapped from leaf
+307340003,Monosomy 7 syndrome (disorder),y,descendant of concept mapped from leaf
+733913003,Primary intraosseous squamous cell carcinoma derived from keratocystic odontogenic neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+254732008,Acral lentiginous malignant melanoma of skin (disorder),y,descendant of concept mapped from leaf
+724552002,Primary poorly differentiated carcinoma of thyroid gland (disorder),y,descendant of concept mapped from leaf
+93708002,Primary malignant neoplasm of blood vessel of shoulder (disorder),y,descendant of concept mapped from leaf
+109821008,Overlapping malignant neoplasm of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+285308002,Squamous cell carcinoma of skin of lower lip (disorder),y,descendant of concept mapped from leaf
+681621000119105,Primary adenocarcinoma of body of pancreas (disorder),y,descendant of concept mapped from leaf
+93738008,Primary malignant neoplasm of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+188587006,"Hodgkin's disease, lymphocytic depletion of intra-abdominal lymph nodes (disorder)",y,descendant of concept mapped from leaf
+94471000,Secondary malignant neoplasm of parietal lobe (disorder),y,descendant of concept mapped from leaf
+764938007,Lymphoepithelial carcinoma (disorder),y,descendant of concept mapped from leaf
+734086009,Oligodendroglioma with isocitrate dehydrogenase mutant and 1p/19q-codeleted (morphologic abnormality),y,descendant of concept mapped from leaf
+447658000,Lymphoma of fundus of stomach (disorder),y,descendant of concept mapped from leaf
+307624007,Diffuse malignant lymphoma - centroblastic-centrocytic (disorder),y,descendant of concept mapped from leaf
+94547009,Secondary malignant neoplasm of skin of chest (disorder),y,descendant of concept mapped from leaf
+396892009,Mixed ductal-endocrine carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94510009,Secondary malignant neoplasm of rectouterine pouch (disorder),y,descendant of concept mapped from leaf
+764951002,Carcinosarcoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+707538002,Primary squamous cell carcinoma of vallecula (disorder),y,descendant of concept mapped from leaf
+722827008,Primary synovial sarcoma of respiratory organ (disorder),y,descendant of concept mapped from leaf
+93953009,Primary malignant neoplasm of pelvis (disorder),y,descendant of concept mapped from leaf
+93488004,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+447416008,Primary malignant neoplasm of distal bile duct (disorder),y,descendant of concept mapped from leaf
+707386008,Primary acinar cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+354681000119109,Primary malignant neoplasm of bone of right lower limb (disorder),y,descendant of concept mapped from leaf
+93933005,Primary malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+188548006,Hodgkin's sarcoma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+448217003,Follicular non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+93713003,Primary malignant neoplasm of blood vessel of upper limb (disorder),y,descendant of concept mapped from leaf
+94033003,Primary malignant neoplasm of skin of lower limb (disorder),y,descendant of concept mapped from leaf
+109976000,Lymphoepithelioid lymphoma (disorder),y,descendant of concept mapped from leaf
+94567000,Secondary malignant neoplasm of skin of nose (disorder),y,descendant of concept mapped from leaf
+707457009,Primary spindle cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+707401000,Primary clear cell adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+723850009,Primary osteosarcoma of bone of limb (disorder),y,descendant of concept mapped from leaf
+707489000,Primary spindle cell squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+426336007,Solitary osseous myeloma (disorder),y,descendant of concept mapped from leaf
+372096000,Carcinoma of male breast (disorder),y,descendant of concept mapped from leaf
+133751000119102,Lymphoma of colon (disorder),y,descendant of concept mapped from leaf
+444712000,Mucinous carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+93692004,Primary malignant neoplasm of blood vessel of axilla (disorder),y,descendant of concept mapped from leaf
+277642008,Low grade T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+369552005,Malignant tumor involving right fallopian tube by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+1090241000000107,Angioimmunoblastic T-cell lymphoma with dysproteinaemia (disorder),y,descendant of concept mapped from leaf
+93658002,Primary malignant neoplasm of accessory nerve (disorder),y,descendant of concept mapped from leaf
+443250000,Malignant fibromatous neoplasm (disorder),y,descendant of concept mapped from leaf
+12301000132103,Acute lymphoid leukemia relapse (disorder),y,descendant of concept mapped from leaf
+93716006,Primary malignant neoplasm of body of penis (disorder),y,descendant of concept mapped from leaf
+93734005,Primary malignant neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+242951000119108,Primary squamous cell carcinoma of vermilion border of lip (disorder),y,descendant of concept mapped from leaf
+94366008,Secondary malignant neoplasm of laryngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+716788007,Epstein-Barr virus positive diffuse large B-cell lymphoma of elderly (disorder),y,descendant of concept mapped from leaf
+423280002,Malignant melanoma of skin of canthus of eye (disorder),y,descendant of concept mapped from leaf
+734068006,Embryonal central nervous system neoplasm with rhabdoid feature (morphologic abnormality),y,descendant of concept mapped from leaf
+402543007,Basal cell carcinoma recurrent following radiotherapy (disorder),y,descendant of concept mapped from leaf
+31047003,Lymphomatoid papulosis (disorder),y,descendant of concept mapped from leaf
+189815007,Pulmonary blastoma (disorder),y,descendant of concept mapped from leaf
+254635004,Epithelioid hemangioendothelioma of lung (disorder),y,descendant of concept mapped from leaf
+93493001,"Hodgkin's disease, lymphocytic-histiocytic predominance of intra-abdominal lymph nodes (disorder)",y,descendant of concept mapped from leaf
+724806004,Primary malignant neuroepitheliomatous neoplasm of autonomic nervous system (disorder),y,descendant of concept mapped from leaf
+109943004,Primary malignant neoplasm of peripheral nerves of abdomen (disorder),y,descendant of concept mapped from leaf
+95230004,Reticulosarcoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+93637008,Malignant melanoma of skin of hip (disorder),y,descendant of concept mapped from leaf
+449417005,Malignant epithelial neoplasm of nasal septum (disorder),y,descendant of concept mapped from leaf
+254871000,Immature teratoma of ovary (disorder),y,descendant of concept mapped from leaf
+94060005,Primary malignant neoplasm of soft tissues of perineum (disorder),y,descendant of concept mapped from leaf
+94488007,Secondary malignant neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+94025004,Primary malignant neoplasm of skin of forearm (disorder),y,descendant of concept mapped from leaf
+94299007,Secondary malignant neoplasm of femoral lymph nodes (disorder),y,descendant of concept mapped from leaf
+369590004,Malignant tumor involving vulva by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+425376008,"Squamous cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+94690004,"Mixed cell type lymphosarcoma of lymph nodes of head, face, and neck (disorder)",y,descendant of concept mapped from leaf
+277461004,Anaplastic astrocytoma of brain (disorder),y,descendant of concept mapped from leaf
+413842007,Chronic myeloid leukemia in lymphoid blast crisis (disorder),y,descendant of concept mapped from leaf
+722665003,Primary malignant melanoma of cornea (disorder),y,descendant of concept mapped from leaf
+94441008,Secondary malignant neoplasm of neck (disorder),y,descendant of concept mapped from leaf
+385478001,Adenoma malignum (disorder),y,descendant of concept mapped from leaf
+735917000,Primary malignant neoplasm of ocular adnexa (disorder),y,descendant of concept mapped from leaf
+93139005,Letterer-Siwe disease of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+707392002,Primary giant cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+93812000,Primary malignant neoplasm of gingival mucosa (disorder),y,descendant of concept mapped from leaf
+722687007,Primary mucinous carcinoma of uterine adnexa (disorder),y,descendant of concept mapped from leaf
+402513005,Basal cell carcinoma of tragus (disorder),y,descendant of concept mapped from leaf
+188582000,"Hodgkin's disease, mixed cellularity of lymph nodes of multiple sites (disorder)",y,descendant of concept mapped from leaf
+372003004,Primary malignant neoplasm of pancreas (disorder),y,descendant of concept mapped from leaf
+369595009,Malignant tumor involving an organ by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+94469000,Secondary malignant neoplasm of paravaginal lymph nodes (disorder),y,descendant of concept mapped from leaf
+448465000,Diffuse non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+713516007,Primary effusion lymphoma (disorder),y,descendant of concept mapped from leaf
+94289002,Secondary malignant neoplasm of eustachian tube (disorder),y,descendant of concept mapped from leaf
+93977003,Primary malignant neoplasm of pylorus (disorder),y,descendant of concept mapped from leaf
+93923002,Primary malignant neoplasm of nervous system (disorder),y,descendant of concept mapped from leaf
+423106003,Adenocarcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+723077004,Primary myosarcoma of uterus (disorder),y,descendant of concept mapped from leaf
+1091861000000100,"Follicular lymphoma, cutaneous follicle centre (disorder)",y,descendant of concept mapped from leaf
+404052009,Botryoid rhabdomyosarcoma (disorder),y,descendant of concept mapped from leaf
+369564002,Malignant tumor involving left ovary by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+277602003,Acute megakaryoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+188089003,Malignant neoplasm of skin of ear and external auditory canal (disorder),y,descendant of concept mapped from leaf
+94478006,Secondary malignant neoplasm of pelvic bone (disorder),y,descendant of concept mapped from leaf
+94451009,Secondary malignant neoplasm of olfactory nerve (disorder),y,descendant of concept mapped from leaf
+109966003,"Diffuse non-Hodgkin's lymphoma, immunoblastic (disorder)",y,descendant of concept mapped from leaf
+93818001,Primary malignant neoplasm of greater curvature of stomach (disorder),y,descendant of concept mapped from leaf
+724644005,Myeloid leukemia co-occurrent with Down syndrome (disorder),y,descendant of concept mapped from leaf
+404038007,Epithelioid malignant nerve sheath tumor (disorder),y,descendant of concept mapped from leaf
+254714008,Mucinous eccrine carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+721541009,Primary malignant sarcoma of skin (disorder),y,descendant of concept mapped from leaf
+882791000000109,Malignant neoplasm of foot and ankle (disorder),y,descendant of concept mapped from leaf
+425225007,Malignant mixed tumor of salivary gland (disorder),y,descendant of concept mapped from leaf
+254701007,Basal cell carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+707482009,Primary papillary squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93893006,Primary malignant neoplasm of metatarsal bone (disorder),y,descendant of concept mapped from leaf
+95188007,Nodular lymphoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94007006,Primary malignant neoplasm of skin of abdomen (disorder),y,descendant of concept mapped from leaf
+95186006,Nodular lymphoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+94235004,Secondary malignant neoplasm of cecum (disorder),y,descendant of concept mapped from leaf
+719052006,Recurrent squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+425127006,Carcinoma ex pleomorphic adenoma of parotid gland (disorder),y,descendant of concept mapped from leaf
+95263006,Sézary's disease of spleen (disorder),y,descendant of concept mapped from leaf
+707360003,Primary lymphoepithelial carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+734134003,Cerebellar liponeurocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94601008,Secondary malignant neoplasm of spinal meninges (disorder),y,descendant of concept mapped from leaf
+53801007,Ganglioneuroma (morphologic abnormality),y,descendant of concept mapped from leaf
+424151006,Anaplastic glioma of brain (disorder),y,descendant of concept mapped from leaf
+94177007,Secondary malignant neoplasm of areola of male breast (disorder),y,descendant of concept mapped from leaf
+93901001,Primary malignant neoplasm of muscle of face (disorder),y,descendant of concept mapped from leaf
+703700004,"Chondrosarcoma, grade 3 (morphologic abnormality)",y,descendant of concept mapped from leaf
+238637007,Acanthosis palmaris (disorder),y,descendant of concept mapped from leaf
+93928006,Primary malignant neoplasm of occipital lobe (disorder),y,descendant of concept mapped from leaf
+94688000,Mixed cell type lymphosarcoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+404072004,Dedifferentiated liposarcoma (disorder),y,descendant of concept mapped from leaf
+721577002,Primary liposarcoma of soft tissue of limb (disorder),y,descendant of concept mapped from leaf
+1080941000119109,Malignant melanoma of left choroid (disorder),y,descendant of concept mapped from leaf
+254708001,Eccrine porocarcinoma of skin (disorder),y,descendant of concept mapped from leaf
+91081000119109,Primary chondrosarcoma of bone of lower limb (disorder),y,descendant of concept mapped from leaf
+94405008,Secondary malignant neoplasm of maxilla (disorder),y,descendant of concept mapped from leaf
+732201008,Carcinosarcoma of endometrium (disorder),y,descendant of concept mapped from leaf
+188729005,Adult T-cell leukemia (disorder),y,descendant of concept mapped from leaf
+94404007,Secondary malignant neoplasm of mastoid air cells (disorder),y,descendant of concept mapped from leaf
+93720005,Primary malignant neoplasm of bone marrow (disorder),y,descendant of concept mapped from leaf
+423708008,Mucoepidermoid carcinoma of salivary gland (disorder),y,descendant of concept mapped from leaf
+254797000,Malignant hemangiopericytoma of skin (disorder),y,descendant of concept mapped from leaf
+703699000,"Chondrosarcoma, grade 2 (morphologic abnormality)",y,descendant of concept mapped from leaf
+707595001,Primary mucinous cystadenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94530008,Secondary malignant neoplasm of sclera (disorder),y,descendant of concept mapped from leaf
+426124006,"Acute myeloid leukemia with maturation, FAB M2, in remission (disorder)",y,descendant of concept mapped from leaf
+430338009,Smoldering chronic lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+402510008,Basal cell carcinoma of helix of ear (disorder),y,descendant of concept mapped from leaf
+94678001,Secondary malignant neoplasm of visceral pleura (disorder),y,descendant of concept mapped from leaf
+94276008,Secondary malignant neoplasm of ectopic female breast tissue (disorder),y,descendant of concept mapped from leaf
+93832004,Primary malignant neoplasm of ileum (disorder),y,descendant of concept mapped from leaf
+707404008,Primary mixed subtype adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+443333004,Medulloblastoma (disorder),y,descendant of concept mapped from leaf
+94051002,Primary malignant neoplasm of soft tissues of axilla (disorder),y,descendant of concept mapped from leaf
+371980003,Primary malignant neoplasm of clitoris (disorder),y,descendant of concept mapped from leaf
+448447004,Non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+734093008,Embryonal neoplasm with multilayered rosettes (morphologic abnormality),y,descendant of concept mapped from leaf
+447706001,Leiomyosarcoma of scalp (disorder),y,descendant of concept mapped from leaf
+725390002,Acute myeloid leukemia with t(8;16)(p11;p13) translocation (disorder),y,descendant of concept mapped from leaf
+721695008,Primary adenocarcinoma of ascending colon and right flexure (disorder),y,descendant of concept mapped from leaf
+94198007,Secondary malignant neoplasm of blood vessel of inguinal region (disorder),y,descendant of concept mapped from leaf
+303056000,"Malignant lymphoma, follicular center cell, cleaved (disorder)",y,descendant of concept mapped from leaf
+721556000,Primary adenocarcinoma of palate (disorder),y,descendant of concept mapped from leaf
+371998004,Primary malignant neoplasm of lower third of esophagus (disorder),y,descendant of concept mapped from leaf
+448231003,Follicular non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+709190005,Metastatic leiomyosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94317006,Secondary malignant neoplasm of glossopharyngeal nerve (disorder),y,descendant of concept mapped from leaf
+372139008,Primary malignant neoplasm of gallbladder (disorder),y,descendant of concept mapped from leaf
+94144008,Primary malignant neoplasm of Waldeyer's ring (disorder),y,descendant of concept mapped from leaf
+765095002,Renal medullary carcinoma (disorder),y,descendant of concept mapped from leaf
+94581003,Secondary malignant neoplasm of soft palate (disorder),y,descendant of concept mapped from leaf
+94110001,Primary malignant neoplasm of trochlear nerve (disorder),y,descendant of concept mapped from leaf
+254800003,Epithelioid cell sarcoma of skin (disorder),y,descendant of concept mapped from leaf
+94331006,Secondary malignant neoplasm of hypoglossal nerve (disorder),y,descendant of concept mapped from leaf
+94273000,Secondary malignant neoplasm of dorsal surface of tongue (disorder),y,descendant of concept mapped from leaf
+255096006,Malignant tumor of dermis (disorder),y,descendant of concept mapped from leaf
+721302006,Refractory anemia with ringed sideroblasts associated with marked thrombocytosis (disorder),y,descendant of concept mapped from leaf
+722670005,Primary thymic carcinoma (disorder),y,descendant of concept mapped from leaf
+188637007,Sézary's disease of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+708971008,Diffuse sclerosing papillary thyroid carcinoma (disorder),y,descendant of concept mapped from leaf
+404123008,Leukemic infiltration of skin (T-cell prolymphocytic leukemia) (disorder),y,descendant of concept mapped from leaf
+372012002,Primary malignant neoplasm of soft tissues of upper limb (disorder),y,descendant of concept mapped from leaf
+94306005,Secondary malignant neoplasm of forearm (disorder),y,descendant of concept mapped from leaf
+707494000,Primary verrucous carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+109356001,Primary malignant neoplasm of unspecified site (disorder),y,descendant of concept mapped from leaf
+724059003,Malignant neoplasm of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+188664008,Mast cell malignancy of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+733135005,Primary urothelial carcinoma of paraurethral gland (disorder),y,descendant of concept mapped from leaf
+93536009,Hodgkin's granuloma of spleen (disorder),y,descendant of concept mapped from leaf
+399634005,"Choroidal melanoma, diffuse (morphologic abnormality)",y,descendant of concept mapped from leaf
+94364006,Secondary malignant neoplasm of lacrimal gland (disorder),y,descendant of concept mapped from leaf
+707424007,Primary adenosquamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+369484000,Malignant tumor involving vasa deferentia by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+424952003,Sarcoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+721623006,Primary adenocarcinoma of middle third of esophagus (disorder),y,descendant of concept mapped from leaf
+707421004,Primary undifferentiated carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+722524005,Primary invasive pleomorphic lobular carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+449222008,Follicular non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+443936004,Oligodendroglioma (disorder),y,descendant of concept mapped from leaf
+93946000,Primary malignant neoplasm of parietal lobe (disorder),y,descendant of concept mapped from leaf
+359987004,Krukenberg tumor (disorder),y,descendant of concept mapped from leaf
+442537007,Non-Hodgkin lymphoma associated with Human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+94437009,Secondary malignant neoplasm of nasal concha (disorder),y,descendant of concept mapped from leaf
+94262007,Secondary malignant neoplasm of common bile duct (disorder),y,descendant of concept mapped from leaf
+92812005,"Chronic leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+699318007,Supratentorial primitive neuroectodermal tumor (disorder),y,descendant of concept mapped from leaf
+184741000119107,Primary adenocarcinoma of anus (disorder),y,descendant of concept mapped from leaf
+94295001,Secondary malignant neoplasm of fallopian tube (disorder),y,descendant of concept mapped from leaf
+188110009,Malignant neoplasm of skin of abdominal wall (disorder),y,descendant of concept mapped from leaf
+413587002,Smoldering myeloma (disorder),y,descendant of concept mapped from leaf
+404150003,Mantle cell B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+94242004,Secondary malignant neoplasm of cauda equina (disorder),y,descendant of concept mapped from leaf
+403909004,Pigmented basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94211009,Secondary malignant neoplasm of blood vessel (disorder),y,descendant of concept mapped from leaf
+722512003,Primary rhabdomyosarcoma of intrathoracic organ (disorder),y,descendant of concept mapped from leaf
+94378007,Secondary malignant neoplasm of lesser curvature of stomach (disorder),y,descendant of concept mapped from leaf
+698200003,Large cell Ewing sarcoma of bone (disorder),y,descendant of concept mapped from leaf
+94018006,Primary malignant neoplasm of skin of elbow (disorder),y,descendant of concept mapped from leaf
+93731002,Primary malignant neoplasm of bronchus of right lower lobe (disorder),y,descendant of concept mapped from leaf
+404144008,Primary cutaneous diffuse large cell B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+721576006,Primary angiosarcoma of breast (disorder),y,descendant of concept mapped from leaf
+94057003,Primary malignant neoplasm of soft tissues of lower limb (disorder),y,descendant of concept mapped from leaf
+233940007,Pulmonary tumor embolism (disorder),y,descendant of concept mapped from leaf
+721306009,Therapy related acute myeloid leukemia and myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+697993003,Undifferentiated carcinoma of nasal sinus (disorder),y,descendant of concept mapped from leaf
+109839004,"Overlapping malignant neoplasm of rectum, anus and anal canal (disorder)",y,descendant of concept mapped from leaf
+89880005,"Ganglioglioma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+188107002,Malignant neoplasm of skin of axillary fold (disorder),y,descendant of concept mapped from leaf
+404041003,Malignant granular cell tumor (disorder),y,descendant of concept mapped from leaf
+404093001,Sarcomatous metastasis in skin (disorder),y,descendant of concept mapped from leaf
+707456000,Primary undifferentiated carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94355001,Secondary malignant neoplasm of isthmus of uterus (disorder),y,descendant of concept mapped from leaf
+448882009,Malignant neoplasm of intraabdominal organ (disorder),y,descendant of concept mapped from leaf
+107591000119100,Primary squamous cell carcinoma of urethra (disorder),y,descendant of concept mapped from leaf
+399660006,Ring melanoma of ciliary body (disorder),y,descendant of concept mapped from leaf
+94362005,Secondary malignant neoplasm of labia minora (disorder),y,descendant of concept mapped from leaf
+109931000,Primary malignant neoplasm of peripheral nerves of upper limb (disorder),y,descendant of concept mapped from leaf
+93825008,Primary malignant neoplasm of heart (disorder),y,descendant of concept mapped from leaf
+93711001,Primary malignant neoplasm of blood vessel of toe (disorder),y,descendant of concept mapped from leaf
+188489006,"Reticulosarcoma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+94282006,Secondary malignant neoplasm of epicardium (disorder),y,descendant of concept mapped from leaf
+424276002,Malignant glioma of brainstem (disorder),y,descendant of concept mapped from leaf
+188534006,"Hodgkin's granuloma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+707582006,Primary spindle cell squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94290006,Secondary malignant neoplasm of exocervix (disorder),y,descendant of concept mapped from leaf
+422238009,"Papillary carcinoma, cribriform-morular (morphologic abnormality)",y,descendant of concept mapped from leaf
+735450006,Primary malignant neuroepitheliomatous neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+94487002,Secondary malignant neoplasm of phalanx of hand (disorder),y,descendant of concept mapped from leaf
+94374009,Secondary malignant neoplasm of lateral wall of urinary bladder (disorder),y,descendant of concept mapped from leaf
+94484009,Secondary malignant neoplasm of pericardium (disorder),y,descendant of concept mapped from leaf
+94093001,Primary malignant neoplasm of thigh (disorder),y,descendant of concept mapped from leaf
+707385007,Primary undifferentiated carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+188487008,Lymphosarcoma and reticulosarcoma (disorder),y,descendant of concept mapped from leaf
+722516000,Primary liposarcoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+726721002,Nodal marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94015009,Primary malignant neoplasm of skin of chest (disorder),y,descendant of concept mapped from leaf
+372135002,"Primary malignant neoplasm of upper lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+722103009,Hormone sensitive prostate cancer (disorder),y,descendant of concept mapped from leaf
+703230006,Non-small cell lung cancer without mutation in epidermal growth factor receptor (disorder),y,descendant of concept mapped from leaf
+94618007,Secondary malignant neoplasm of tail of pancreas (disorder),y,descendant of concept mapped from leaf
+94270002,Secondary malignant neoplasm of cystic duct (disorder),y,descendant of concept mapped from leaf
+93862005,Primary malignant neoplasm of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+93963001,Primary malignant neoplasm of pisiform bone of hand (disorder),y,descendant of concept mapped from leaf
+275265005,Epithelioma basal cell (disorder),y,descendant of concept mapped from leaf
+403901001,Acantholytic squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+1079131000119103,Primary basal cell carcinoma of left lower limb (disorder),y,descendant of concept mapped from leaf
+707627009,Primary salivary gland type carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+188745007,Chronic monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+707394001,Primary spindle cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+404139001,Leukemic infiltration of skin in hairy-cell leukemia (disorder),y,descendant of concept mapped from leaf
+359631009,"Acute myeloid leukemia, minimal differentiation, FAB M0 (disorder)",y,descendant of concept mapped from leaf
+449294002,Sarcoma of scapula (disorder),y,descendant of concept mapped from leaf
+721628002,Primary adenocarcinoma of esophagogastric junction (disorder),y,descendant of concept mapped from leaf
+712849003,Primary malignant neoplasm of prostate metastatic to bone (disorder),y,descendant of concept mapped from leaf
+425303004,Squamous cell carcinomatosis (disorder),y,descendant of concept mapped from leaf
+713290004,Malignant ameloblastoma of mandible (disorder),y,descendant of concept mapped from leaf
+94321004,Secondary malignant neoplasm of gum (disorder),y,descendant of concept mapped from leaf
+94190000,Secondary malignant neoplasm of blood vessel of buttock (disorder),y,descendant of concept mapped from leaf
+94592002,Secondary malignant neoplasm of soft tissues of perineum (disorder),y,descendant of concept mapped from leaf
+721626003,Primary malignant neuroendocrine neoplasm of esophagus (disorder),y,descendant of concept mapped from leaf
+188119005,Malignant neoplasm of skin of upper limb and shoulder (disorder),y,descendant of concept mapped from leaf
+277473004,B-cell chronic lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+93188005,Malignant histiocytosis of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+94548004,Secondary malignant neoplasm of skin of chin (disorder),y,descendant of concept mapped from leaf
+110007008,Adult T-cell leukemia/lymphoma (disorder),y,descendant of concept mapped from leaf
+105111000119109,Primary squamous cell carcinoma of thymus (disorder),y,descendant of concept mapped from leaf
+307609003,Adamantinoma of long bone (disorder),y,descendant of concept mapped from leaf
+702368000,Carcinosarcoma of ovary (disorder),y,descendant of concept mapped from leaf
+402503002,Basal cell carcinoma of nasal columella (disorder),y,descendant of concept mapped from leaf
+94020009,Primary malignant neoplasm of skin of eyebrow (disorder),y,descendant of concept mapped from leaf
+415287001,Relapsing chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+369513003,Primary malignant neoplasm of left fallopian tube (disorder),y,descendant of concept mapped from leaf
+402563000,Metastatic malignant melanoma with diffuse hypermelanosis (disorder),y,descendant of concept mapped from leaf
+123631000119103,Malignant poorly differentiated neuroendocrine carcinoma (disorder),y,descendant of concept mapped from leaf
+93821004,Primary malignant neoplasm of hand (disorder),y,descendant of concept mapped from leaf
+723182009,Primary squamous cell carcinoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+188090007,Malignant neoplasm of skin of auricle (ear) (disorder),y,descendant of concept mapped from leaf
+700423003,Adenocarcinoma of pancreas (disorder),y,descendant of concept mapped from leaf
+709517003,Malignant carcinoid tumor of small intestine (disorder),y,descendant of concept mapped from leaf
+307603002,Malignant blue nevus of skin (disorder),y,descendant of concept mapped from leaf
+708054009,Malignant neoplasm after immunosuppressive therapy (disorder),y,descendant of concept mapped from leaf
+718220008,Hereditary breast and ovarian cancer syndrome (disorder),y,descendant of concept mapped from leaf
+449268006,Sarcoma of clavicle (disorder),y,descendant of concept mapped from leaf
+93879004,Primary malignant neoplasm of lunate bone (disorder),y,descendant of concept mapped from leaf
+94104001,Primary malignant neoplasm of trachea (disorder),y,descendant of concept mapped from leaf
+277601005,Acute monoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+15956341000119105,Adenocarcinoma of left lung (disorder),y,descendant of concept mapped from leaf
+188667001,Mast cell malignancy of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+402521004,Basal cell carcinoma of upper extremity (disorder),y,descendant of concept mapped from leaf
+404092006,Carcinomatous metastasis in skin (disorder),y,descendant of concept mapped from leaf
+12622007,Clear cell sarcoma (except of Kidney M-89643) (morphologic abnormality),y,descendant of concept mapped from leaf
+703387000,Acute myeloid leukemia with normal karyotype (disorder),y,descendant of concept mapped from leaf
+93183001,Malignant histiocytosis of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+402523001,Basal cell carcinoma of truncal skin (disorder),y,descendant of concept mapped from leaf
+118614007,"Langerhans cell histiocytosis, disseminated (disorder)",y,descendant of concept mapped from leaf
+134312002,Odontogenic ghost cell carcinoma (disorder),y,descendant of concept mapped from leaf
+404148006,Diffuse large B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+369525000,Malignant tumor involving left ovary by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+128770002,Central osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94516003,Secondary malignant neoplasm of retina (disorder),y,descendant of concept mapped from leaf
+369604009,Malignant tumor involving an organ by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+448257000,Sarcoma of male breast (disorder),y,descendant of concept mapped from leaf
+389216001,Diaphyseal medullary stenosis with bone malignancy (disorder),y,descendant of concept mapped from leaf
+94316002,Secondary malignant neoplasm of glomus jugulare (disorder),y,descendant of concept mapped from leaf
+707388009,Primary squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+254633006,Oat cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+404015009,Superficial malignant fibrous histiocytoma of skin (disorder),y,descendant of concept mapped from leaf
+94595000,Secondary malignant neoplasm of soft tissues of trunk (disorder),y,descendant of concept mapped from leaf
+241861008,Metastatic malignant neoplasm to nasopharynx (disorder),y,descendant of concept mapped from leaf
+448274000,Malignant neoplasm of connective tissue (disorder),y,descendant of concept mapped from leaf
+208041000119100,Primary adenocarcinoma of endocervix (disorder),y,descendant of concept mapped from leaf
+448709005,Non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+733347006,Primary mucinous cystic neoplasm with associated invasive carcinoma of cystic duct (disorder),y,descendant of concept mapped from leaf
+188725004,Lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+448317000,Follicular non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+716179006,Extraventricular neurocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94294002,Secondary malignant neoplasm of facial nerve (disorder),y,descendant of concept mapped from leaf
+184881000119106,Primary adenocarcinoma of rectosigmoid junction (disorder),y,descendant of concept mapped from leaf
+723173003,Carcinosarcoma of uterine adnexa (disorder),y,descendant of concept mapped from leaf
+403912001,Cystic basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+1079171000119100,Primary basal cell carcinoma of right eyelid (disorder),y,descendant of concept mapped from leaf
+93903003,Primary malignant neoplasm of muscle of hip (disorder),y,descendant of concept mapped from leaf
+707350007,Malignant melanoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+371984007,Primary malignant neoplasm of esophagus (disorder),y,descendant of concept mapped from leaf
+93555009,Hodgkin's sarcoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+404140004,Primary cutaneous marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+93834003,Primary malignant neoplasm of inguinal region (disorder),y,descendant of concept mapped from leaf
+93672006,Primary malignant neoplasm of anterior portion of floor of mouth (disorder),y,descendant of concept mapped from leaf
+402525008,Basal cell carcinoma - adenoid (disorder),y,descendant of concept mapped from leaf
+371974006,Malignant neoplasm of border of tongue (disorder),y,descendant of concept mapped from leaf
+109366009,Overlapping malignant neoplasm of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+278189009,Hypergranular promyelocytic leukemia (disorder),y,descendant of concept mapped from leaf
+353671000119108,Overlapping primary malignant neoplasm of bone and articular cartilage of right upper limb (disorder),y,descendant of concept mapped from leaf
+404138009,Small lymphocytic B-cell lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+404153001,Leukemic infiltration of skin in chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+93228004,Malignant melanoma of skin of forearm (disorder),y,descendant of concept mapped from leaf
+404172001,Mast cell leukemia affecting skin (disorder),y,descendant of concept mapped from leaf
+188635004,Sézary's disease of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+188547001,Hodgkin's sarcoma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+1701000119104,Primary adenocarcinoma of colon (disorder),y,descendant of concept mapped from leaf
+369454008,Malignant tumor involving rectum by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+93657007,Primary malignant neoplasm of abducens nerve (disorder),y,descendant of concept mapped from leaf
+94185003,Secondary malignant neoplasm of biliary tract (disorder),y,descendant of concept mapped from leaf
+255071008,Squamous cell carcinoma of lip (disorder),y,descendant of concept mapped from leaf
+373090000,Primary malignant neoplasm of breast lower inner quadrant (disorder),y,descendant of concept mapped from leaf
+408644002,Adenocarcinoma of duodenum (disorder),y,descendant of concept mapped from leaf
+450902001,Papillary glioneuronal tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+371968006,Primary malignant neoplasm of anterior two-thirds of tongue (disorder),y,descendant of concept mapped from leaf
+128776008,Dedifferentiated chondrosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+443961001,Malignant adenomatous neoplasm (disorder),y,descendant of concept mapped from leaf
+402545000,Basal cell carcinoma - second recurrence (disorder),y,descendant of concept mapped from leaf
+402530007,Basal cell carcinoma with matrical differentiation (disorder),y,descendant of concept mapped from leaf
+402511007,Basal cell carcinoma of conchal bowl of ear (disorder),y,descendant of concept mapped from leaf
+94143002,Primary malignant neoplasm of vulva (disorder),y,descendant of concept mapped from leaf
+94035005,Primary malignant neoplasm of skin of nose (disorder),y,descendant of concept mapped from leaf
+423158009,Hurthle cell carcinoma of thyroid (disorder),y,descendant of concept mapped from leaf
+414780005,Mucosa-associated lymphoid tissue lymphoma of orbit (disorder),y,descendant of concept mapped from leaf
+422541001,Undifferentiated carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+723076008,Primary myxofibrosarcoma (disorder),y,descendant of concept mapped from leaf
+127066000,Familial polycythemia vera (disorder),y,descendant of concept mapped from leaf
+721546004,Primary adenocarcinoma of ciliary epithelium (disorder),y,descendant of concept mapped from leaf
+448273006,Malignant melanoma of skin of scrotum (disorder),y,descendant of concept mapped from leaf
+1651000119109,Primary adenocarcinoma of pancreas (disorder),y,descendant of concept mapped from leaf
+721718003,Primary adenocarcinoma of ampulla of Vater (disorder),y,descendant of concept mapped from leaf
+94024000,Primary malignant neoplasm of skin of foot (disorder),y,descendant of concept mapped from leaf
+82546001,Reactive immunoproliferative disease (disorder),y,descendant of concept mapped from leaf
+40312006,Pericarditis co-occurrent and due to tumor metastatic to pericardium (disorder),y,descendant of concept mapped from leaf
+371981004,Primary malignant neoplasm of commissure of lip (disorder),y,descendant of concept mapped from leaf
+94511008,Secondary malignant neoplasm of rectovaginal septum (disorder),y,descendant of concept mapped from leaf
+94124002,Primary malignant neoplasm of urinary bladder neck (disorder),y,descendant of concept mapped from leaf
+92581002,Carcinoma in situ of endocrine gland (disorder),y,descendant of concept mapped from leaf
+188674006,Diffuse malignant lymphoma - small non-cleaved cell (disorder),y,descendant of concept mapped from leaf
+93687001,Primary malignant neoplasm of base of tongue (disorder),y,descendant of concept mapped from leaf
+448220006,Non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+93835002,Primary malignant neoplasm of inner aspect of lip (disorder),y,descendant of concept mapped from leaf
+372015000,Primary malignant neoplasm of the mesentery (disorder),y,descendant of concept mapped from leaf
+188103003,Malignant neoplasm of skin of scalp (disorder),y,descendant of concept mapped from leaf
+94415002,Secondary malignant neoplasm of minor salivary gland (disorder),y,descendant of concept mapped from leaf
+449067008,Malignant neoplasm of parietal pleura (disorder),y,descendant of concept mapped from leaf
+372006007,Primary malignant neoplasm of prepuce (disorder),y,descendant of concept mapped from leaf
+404157000,Specific skin infiltration in Hodgkin's disease (disorder),y,descendant of concept mapped from leaf
+128910001,"Medulloepithelioma, benign (morphologic abnormality)",y,descendant of concept mapped from leaf
+94517007,Secondary malignant neoplasm of retrocecal tissue (disorder),y,descendant of concept mapped from leaf
+722714004,Primary mucoepidermoid carcinoma of lacrimal apparatus (disorder),y,descendant of concept mapped from leaf
+109828002,Primary malignant neoplasm of salivary gland duct (disorder),y,descendant of concept mapped from leaf
+94574005,Secondary malignant neoplasm of skin of toe (disorder),y,descendant of concept mapped from leaf
+91171000119107,Primary undifferentiated large cell malignant neoplasm of chest wall (disorder),y,descendant of concept mapped from leaf
+417417007,Malignant teratoma of undescended testis (disorder),y,descendant of concept mapped from leaf
+92508006,Burkitt's tumor of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+93518009,"Hodgkin's disease, nodular sclerosis of spleen (disorder)",y,descendant of concept mapped from leaf
+188633006,Sézary's disease of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+93645003,Malignant melanoma of skin of popliteal area (disorder),y,descendant of concept mapped from leaf
+188102008,Malignant neoplasm of scalp AND/OR skin of neck (disorder),y,descendant of concept mapped from leaf
+94444000,Secondary malignant neoplasm of nipple of male breast (disorder),y,descendant of concept mapped from leaf
+93649009,Malignant melanoma of skin of thigh (disorder),y,descendant of concept mapped from leaf
+277597005,Myelodysplastic syndrome with isolated del(5q) (disorder),y,descendant of concept mapped from leaf
+94059000,Primary malignant neoplasm of soft tissues of pelvis (disorder),y,descendant of concept mapped from leaf
+109947003,Primary malignant neoplasm of peripheral nerves of trunk (disorder),y,descendant of concept mapped from leaf
+109886000,Overlapping malignant neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+93152000,Leukemic reticuloendotheliosis of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+109972003,"Follicular non-Hodgkin's lymphoma, large cell (disorder)",y,descendant of concept mapped from leaf
+369460008,Malignant tumor involving rectum by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+93219000,Malignant melanoma of skin of chin (disorder),y,descendant of concept mapped from leaf
+94012007,Primary malignant neoplasm of skin of breast (disorder),y,descendant of concept mapped from leaf
+94376006,Secondary malignant neoplasm of left upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+190818004,Waldenström macroglobulinemia (disorder),y,descendant of concept mapped from leaf
+110000005,Refractory anemia with excess blasts in transformation (disorder),y,descendant of concept mapped from leaf
+1082191000119100,Primary squamous cell carcinoma of right ear (disorder),y,descendant of concept mapped from leaf
+724805000,Primary malignant neuroepitheliomatous neoplasm of peripheral nerve (disorder),y,descendant of concept mapped from leaf
+109941002,Primary malignant neoplasm of peripheral nerves of thorax (disorder),y,descendant of concept mapped from leaf
+254709009,Digital papillary eccrine carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+448386004,Non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+94305009,Secondary malignant neoplasm of foot (disorder),y,descendant of concept mapped from leaf
+188726003,Subacute lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+87121000119102,Malignant glioma of cerebellum (disorder),y,descendant of concept mapped from leaf
+707408006,Primary small cell non-keratinizing squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+445269007,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue (disorder),y,descendant of concept mapped from leaf
+707342003,Primary adenocarcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+314988008,Metastasis from malignant tumor of skin (disorder),y,descendant of concept mapped from leaf
+404122003,Leukemic infiltration of skin (chronic T-cell lymphocytic leukemia) (disorder),y,descendant of concept mapped from leaf
+404051002,Embryonal rhabdomyosarcoma (disorder),y,descendant of concept mapped from leaf
+766981007,Squamous cell carcinoma of colon (disorder),y,descendant of concept mapped from leaf
+425230006,"Squamous cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+285769009,Acute promyelocytic leukemia - hypogranular variant (disorder),y,descendant of concept mapped from leaf
+369488002,Secondary malignant neoplasm of seminal vesicle (disorder),y,descendant of concept mapped from leaf
+94121005,Primary malignant neoplasm of ureter (disorder),y,descendant of concept mapped from leaf
+109832008,Overlapping malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+421980000,"Papillary carcinoma, solid (morphologic abnormality)",y,descendant of concept mapped from leaf
+371996000,Primary malignant neoplasm of lip (disorder),y,descendant of concept mapped from leaf
+723844004,Primary chondrosarcoma of articular cartilage of limb (disorder),y,descendant of concept mapped from leaf
+423349005,Carcinoma of tip of nose (disorder),y,descendant of concept mapped from leaf
+707337006,Primary adenocarcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+684911000119105,Primary glioblastoma multiforme of frontal lobe (disorder),y,descendant of concept mapped from leaf
+717734005,Papillary thyroid carcinoma with renal papillary neoplasia (disorder),y,descendant of concept mapped from leaf
+703617004,Low grade fibromyxoid sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+702392008,Metastatic renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94328005,Secondary malignant neoplasm of hepatic flexure of colon (disorder),y,descendant of concept mapped from leaf
+369478003,Malignant tumor involving bladder by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+397015000,Systemic mastocytosis with associated clonal hematological non-mast cell lineage disease (disorder),y,descendant of concept mapped from leaf
+94637003,Secondary malignant neoplasm of tip and lateral border of tongue (disorder),y,descendant of concept mapped from leaf
+448298007,Malignant melanoma of skin of penis (disorder),y,descendant of concept mapped from leaf
+94630001,Secondary malignant neoplasm of third cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+423535002,Basal cell carcinoma of chest wall (disorder),y,descendant of concept mapped from leaf
+188511002,Burkitt's lymphoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+187866005,Malignant neoplasm of middle lobe of lung (disorder),y,descendant of concept mapped from leaf
+707353009,Primary squamous cell carcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+707361004,Malignant melanoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+92513005,Burkitt's tumor of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+721557009,Primary adenocarcinoma of parotid gland (disorder),y,descendant of concept mapped from leaf
+707580003,Primary basaloid carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94710006,Mycosis fungoides of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+733064004,"Osteosarcoma, limb anomalies, erythroid macrocytosis syndrome (disorder)",y,descendant of concept mapped from leaf
+369584003,Malignant tumor involving vagina by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+422350000,"Follicular carcinoma, grossly encapsulated with angioinvasion (morphologic abnormality)",y,descendant of concept mapped from leaf
+94584006,Secondary malignant neoplasm of soft tissues of buttock (disorder),y,descendant of concept mapped from leaf
+448376000,Non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+372152003,"Sarcoma, metastatic (morphologic abnormality)",y,descendant of concept mapped from leaf
+422282000,Malignant neoplasm associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+109921007,"Primary malignant neoplasm of peripheral nerve of head, face and/or neck (disorder)",y,descendant of concept mapped from leaf
+404125001,CD-30 positive anaplastic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+449053004,Lymphoma of lower esophagus (disorder),y,descendant of concept mapped from leaf
+313354001,Squamous cell carcinoma of bronchus in left upper lobe (disorder),y,descendant of concept mapped from leaf
+94607007,Secondary malignant neoplasm of subglottis (disorder),y,descendant of concept mapped from leaf
+369534005,Malignant tumor involving right ovary by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+403941005,Malignant cylindroma of skin (disorder),y,descendant of concept mapped from leaf
+448710000,Sarcoma of bone (disorder),y,descendant of concept mapped from leaf
+1081561000119108,Recurrent primary malignant neoplasm of right female breast (disorder),y,descendant of concept mapped from leaf
+254712007,Microcystic adnexal carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+94400003,Secondary malignant neoplasm of major salivary gland (disorder),y,descendant of concept mapped from leaf
+761958009,Malignant peripheral nerve sheath neoplasm with perineurial differentiation (disorder),y,descendant of concept mapped from leaf
+94385006,Secondary malignant neoplasm of lower inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+188537004,Hodgkin's granuloma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+714251006,Philadelphia chromosome-negative precursor B-cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+94680007,Secondary malignant neoplasm of vomer (disorder),y,descendant of concept mapped from leaf
+369572000,Malignant tumor involving right ovary by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+763796007,Megakaryoblastic acute myeloid leukemia with t(1;22)(p13;q13) (disorder),y,descendant of concept mapped from leaf
+94439007,Secondary malignant neoplasm of navicular bone of foot (disorder),y,descendant of concept mapped from leaf
+705061009,Childhood myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+369555007,Malignant tumor involving right fallopian tube by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+94590005,Secondary malignant neoplasm of soft tissues of neck (disorder),y,descendant of concept mapped from leaf
+184781000119102,Primary adenocarcinoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+67841000119103,"Primary small cell malignant neoplasm of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+188122007,Malignant neoplasm of skin of forearm (disorder),y,descendant of concept mapped from leaf
+449292003,Non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+707673006,Pleuropulmonary blastoma type III (disorder),y,descendant of concept mapped from leaf
+285839005,Acute myelomonocytic leukemia - eosinophilic variant (disorder),y,descendant of concept mapped from leaf
+93211002,Malignant melanoma of skin of ankle (disorder),y,descendant of concept mapped from leaf
+93913006,Primary malignant neoplasm of muscle (disorder),y,descendant of concept mapped from leaf
+93910009,Primary malignant neoplasm of muscle of thorax (disorder),y,descendant of concept mapped from leaf
+187822008,Fibrosarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+231831002,Squamous cell carcinoma of eyelid (disorder),y,descendant of concept mapped from leaf
+449034009,Malignant neoplasm of anterior and lateral floor of mouth (disorder),y,descendant of concept mapped from leaf
+423384009,Secondary malignant neoplasm of lacrimal gland duct (disorder),y,descendant of concept mapped from leaf
+707396004,Primary oxyphilic adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+95226002,Reticulosarcoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+424440001,Adenocarcinoma of small intestine (disorder),y,descendant of concept mapped from leaf
+94279001,Secondary malignant neoplasm of endocervix (disorder),y,descendant of concept mapped from leaf
+402912009,Vulval verrucous carcinoma of Buschke-Löwenstein (disorder),y,descendant of concept mapped from leaf
+94339008,Secondary malignant neoplasm of inguinal lymph nodes (disorder),y,descendant of concept mapped from leaf
+404154007,Leukemic infiltration of skin in monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+402515003,Basal cell carcinoma of anterior chest (disorder),y,descendant of concept mapped from leaf
+699356008,Endometrial stromal sarcoma (disorder),y,descendant of concept mapped from leaf
+711414003,Primary clear cell adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93143009,"Leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+94341009,Secondary malignant neoplasm of inner aspect of lip (disorder),y,descendant of concept mapped from leaf
+94285008,Secondary malignant neoplasm of epitrochlear lymph nodes (disorder),y,descendant of concept mapped from leaf
+703618009,Sclerosing epithelioid fibrosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+109979007,B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+448372003,Non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+723887001,Primary Ewing sarcoma of bone of rib (disorder),y,descendant of concept mapped from leaf
+93641007,Malignant melanoma of skin of lower limb (disorder),y,descendant of concept mapped from leaf
+94194009,Secondary malignant neoplasm of blood vessel of forearm (disorder),y,descendant of concept mapped from leaf
+94132005,Primary malignant neoplasm of vallecula (disorder),y,descendant of concept mapped from leaf
+448314007,Malignant epithelial neoplasm of spinal cord (disorder),y,descendant of concept mapped from leaf
+447951009,Ewing's sarcoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+109968002,"Diffuse non-Hodgkin's lymphoma, small cell (disorder)",y,descendant of concept mapped from leaf
+94040002,Primary malignant neoplasm of skin of temporal region (disorder),y,descendant of concept mapped from leaf
+188569008,"Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region and lower limb (disorder)",y,descendant of concept mapped from leaf
+188577007,"Hodgkin's disease, mixed cellularity of intra-abdominal lymph nodes (disorder)",y,descendant of concept mapped from leaf
+722685004,Primary high grade serous adenocarcinoma of ovary (disorder),y,descendant of concept mapped from leaf
+724467001,Primary squamous cell carcinoma of overlapping lesion of urinary organs (disorder),y,descendant of concept mapped from leaf
+681631000119108,Primary adenocarcinoma of body of stomach (disorder),y,descendant of concept mapped from leaf
+94042005,Primary malignant neoplasm of skin of toe (disorder),y,descendant of concept mapped from leaf
+397009000,Mast cell malignancy (disorder),y,descendant of concept mapped from leaf
+733470002,Collecting duct carcinoma of kidney (disorder),y,descendant of concept mapped from leaf
+721313009,Indeterminate dendritic cell neoplasm (disorder),y,descendant of concept mapped from leaf
+707455001,Primary papillary squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+4230004,Pacinian tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+403914000,Superficial basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+707672001,Pleuropulmonary blastoma type II (disorder),y,descendant of concept mapped from leaf
+109386008,Kaposi's sarcoma of skin (disorder),y,descendant of concept mapped from leaf
+94613003,Secondary malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707481002,Primary basaloid squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+423318000,Adenoid cystic carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+431396003,Human epidermal growth factor 2 negative carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+94551006,Secondary malignant neoplasm of skin of external auditory canal (disorder),y,descendant of concept mapped from leaf
+188127001,Malignant neoplasm of skin of lower limb and hip (disorder),y,descendant of concept mapped from leaf
+724553007,Primary undifferentiated carcinoma of thyroid gland (disorder),y,descendant of concept mapped from leaf
+94080006,Primary malignant neoplasm of supraglottis (disorder),y,descendant of concept mapped from leaf
+698286006,Malignant melanoma of palate (disorder),y,descendant of concept mapped from leaf
+371971003,Primary malignant neoplasm of body of uterus (disorder),y,descendant of concept mapped from leaf
+408642003,Transitional cell carcinoma of kidney (disorder),y,descendant of concept mapped from leaf
+94552004,Secondary malignant neoplasm of skin of eyebrow (disorder),y,descendant of concept mapped from leaf
+373089009,Primary malignant neoplasm of breast upper inner quadrant (disorder),y,descendant of concept mapped from leaf
+254650008,Malignant epithelial neoplasm of skin (disorder),y,descendant of concept mapped from leaf
+722678003,Primary squamous cell carcinoma of vagina (disorder),y,descendant of concept mapped from leaf
+94422005,Secondary malignant neoplasm of muscle of hip (disorder),y,descendant of concept mapped from leaf
+403951006,Ceruminous gland adenocarcinoma of skin (disorder),y,descendant of concept mapped from leaf
+764735002,Squamous cell carcinoma of small intestine (disorder),y,descendant of concept mapped from leaf
+93144003,Leukemic reticuloendotheliosis of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+92510008,Burkitt's tumor of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94519005,Secondary malignant neoplasm of retroperitoneal lymph nodes (disorder),y,descendant of concept mapped from leaf
+449295001,Sarcoma of skull (disorder),y,descendant of concept mapped from leaf
+404113004,Tumor stage mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+404067008,Adipocytic liposarcoma (disorder),y,descendant of concept mapped from leaf
+94092006,Primary malignant neoplasm of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+94023006,Primary malignant neoplasm of skin of finger (disorder),y,descendant of concept mapped from leaf
+717921000,Poorly-differentiated neuroendocrine carcinoma of thymus (disorder),y,descendant of concept mapped from leaf
+764991004,Renal mucinous tubular and spindle cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94676002,Secondary malignant neoplasm of vestibule of mouth (disorder),y,descendant of concept mapped from leaf
+707671008,Pleuropulmonary blastoma type I (disorder),y,descendant of concept mapped from leaf
+188668006,Mast cell malignancy of spleen (disorder),y,descendant of concept mapped from leaf
+449259009,Malignant neoplasm of broad ligament of uterus (disorder),y,descendant of concept mapped from leaf
+422833009,Adenoid cystic carcinoma of salivary gland (disorder),y,descendant of concept mapped from leaf
+722707001,Metastatic malignant neoplasm of peripheral nervous system (disorder),y,descendant of concept mapped from leaf
+93796005,Primary malignant neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+107601000119107,Primary transitional cell carcinoma of urethra (disorder),y,descendant of concept mapped from leaf
+863761000000109,Clinical stage B chronic lymphocytic leukaemia (disorder),y,descendant of concept mapped from leaf
+109989006,Multiple myeloma (disorder),y,descendant of concept mapped from leaf
+372024009,Primary malignant neoplasm of uterine cervix (disorder),y,descendant of concept mapped from leaf
+363745004,Primary malignant neoplasm of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+94714002,Mycosis fungoides of spleen (disorder),y,descendant of concept mapped from leaf
+402542002,Basal cell carcinoma recurrent following cryosurgery (disorder),y,descendant of concept mapped from leaf
+93981003,Primary malignant neoplasm of rectouterine pouch (disorder),y,descendant of concept mapped from leaf
+93198004,Malignant lymphoma of spleen (disorder),y,descendant of concept mapped from leaf
+94302007,Secondary malignant neoplasm of first cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+372008008,Primary malignant neoplasm of scaphoid bone (disorder),y,descendant of concept mapped from leaf
+94236003,Secondary malignant neoplasm of calcaneus (disorder),y,descendant of concept mapped from leaf
+93966009,Primary malignant neoplasm of pleura (disorder),y,descendant of concept mapped from leaf
+369499000,Malignant tumor involving uterine cervix by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+413843002,Chronic myeloid leukemia in myeloid blast crisis (disorder),y,descendant of concept mapped from leaf
+94038007,Primary malignant neoplasm of skin of scalp (disorder),y,descendant of concept mapped from leaf
+404149003,"Lymphoplasmacytic B-cell lymphoma, nodal/systemic with skin involvement (disorder)",y,descendant of concept mapped from leaf
+128792003,Atypical teratoid/rhabdoid tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+369588000,Malignant tumor involving vulva by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+762458004,Primary endometrioid carcinoma of endometrium of body of uterus (disorder),y,descendant of concept mapped from leaf
+422758009,Carcinoma of nasal meatus (disorder),y,descendant of concept mapped from leaf
+369516006,Malignant tumor involving left fallopian tube by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+93138002,Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+188529007,Hodgkin's paragranuloma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94675003,Secondary malignant neoplasm of vermilion border of upper lip (disorder),y,descendant of concept mapped from leaf
+94390009,Secondary malignant neoplasm of lunate bone (disorder),y,descendant of concept mapped from leaf
+369502001,Malignant tumor involving uterine corpus by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+681601000119101,Primary adenocarcinoma of ascending colon (disorder),y,descendant of concept mapped from leaf
+369510000,Malignant tumor involving vulva by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94016005,Primary malignant neoplasm of skin of chin (disorder),y,descendant of concept mapped from leaf
+404169008,Malignant histiocytosis involving skin (disorder),y,descendant of concept mapped from leaf
+443144000,Metastatic sarcoma (disorder),y,descendant of concept mapped from leaf
+93783009,Primary malignant neoplasm of epididymis (disorder),y,descendant of concept mapped from leaf
+188512009,Burkitt's lymphoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+726654006,Malignant carcinoid tumor of colon (disorder),y,descendant of concept mapped from leaf
+94296000,Secondary malignant neoplasm of false vocal cord (disorder),y,descendant of concept mapped from leaf
+404053004,Alveolar rhabdomyosarcoma (disorder),y,descendant of concept mapped from leaf
+93230002,Malignant melanoma of skin of groin (disorder),y,descendant of concept mapped from leaf
+447730004,Chordoma of sacrum (disorder),y,descendant of concept mapped from leaf
+94651003,Secondary malignant neoplasm of undescended testis (disorder),y,descendant of concept mapped from leaf
+92512000,"Burkitt's tumor of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+128466006,Primary malignant neoplasm of articular cartilage (disorder),y,descendant of concept mapped from leaf
+763064007,Adenoid cystic carcinoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+128816008,Follicular dendritic cell sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94191001,Secondary malignant neoplasm of blood vessel of face (disorder),y,descendant of concept mapped from leaf
+188630009,"Sézary's disease of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+737308008,Primary adenocarcinoma of sublingual gland (disorder),y,descendant of concept mapped from leaf
+733843002,Anaplastic oligodendroglioma with isocitrate dehydrogenase mutant and 1p/19q-codeleted (morphologic abnormality),y,descendant of concept mapped from leaf
+766757006,Undifferentiated carcinoma of stomach (disorder),y,descendant of concept mapped from leaf
+449207003,Sarcoma of humerus (disorder),y,descendant of concept mapped from leaf
+93516008,"Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+93210001,Malignant melanoma of skin of abdomen (disorder),y,descendant of concept mapped from leaf
+93992002,Primary malignant neoplasm of right middle lobe of lung (disorder),y,descendant of concept mapped from leaf
+188506004,Lymphosarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+707458004,Primary pleomorphic carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+722509001,Primary rhabdomyosarcoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+404045007,Epithelioid leiomyosarcoma of skin (disorder),y,descendant of concept mapped from leaf
+449472007,Malignant epithelial neoplasm of alveolus dentalis (disorder),y,descendant of concept mapped from leaf
+107751000119102,Primary malignant mixed Mullerian neoplasm of endometrium (disorder),y,descendant of concept mapped from leaf
+307635002,"Hodgkin's disease, nodular sclerosis - cellular phase (disorder)",y,descendant of concept mapped from leaf
+721638007,Primary neuroendocrine carcinoma of stomach (disorder),y,descendant of concept mapped from leaf
+733136006,Primary adenocarcinoma of urethra (disorder),y,descendant of concept mapped from leaf
+716586009,Carcinoma of stomach due to Epstein-Barr virus disease (disorder),y,descendant of concept mapped from leaf
+93951006,Primary malignant neoplasm of pelvic bone (disorder),y,descendant of concept mapped from leaf
+94001007,Primary malignant neoplasm of second cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+443493003,Metastatic malignant melanoma (disorder),y,descendant of concept mapped from leaf
+447109003,Primary malignant neoplasm of intrahepatic bile duct (disorder),y,descendant of concept mapped from leaf
+863741000000108,Clinical stage A chronic lymphocytic leukaemia (disorder),y,descendant of concept mapped from leaf
+371967001,Primary malignant neoplasm of ampulla of Vater (disorder),y,descendant of concept mapped from leaf
+302842009,Diffuse malignant lymphoma - centroblastic (disorder),y,descendant of concept mapped from leaf
+722514002,Primary leiomyosarcoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+423325007,Basal cell carcinoma of external auditory canal (disorder),y,descendant of concept mapped from leaf
+94322006,Secondary malignant neoplasm of hamate bone (disorder),y,descendant of concept mapped from leaf
+94022001,Primary malignant neoplasm of skin of face (disorder),y,descendant of concept mapped from leaf
+79281000119106,Primary adenocarcinoma of skin (disorder),y,descendant of concept mapped from leaf
+447100004,Marginal zone lymphoma (disorder),y,descendant of concept mapped from leaf
+93829002,Primary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+734095001,Primary solid type intraosseous squamous cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+254702000,Basosquamous carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+372113005,"Carcinoma of middle lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+403925009,Neurotropic malignant melanoma (disorder),y,descendant of concept mapped from leaf
+94326009,Secondary malignant neoplasm of head (disorder),y,descendant of concept mapped from leaf
+93942003,Primary malignant neoplasm of parametrium (disorder),y,descendant of concept mapped from leaf
+404108003,Poikilodermatous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+724536000,Primary adenocarcinoma of ileum (disorder),y,descendant of concept mapped from leaf
+396891002,Mixed acinar-endocrine carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+15956381000119100,Adenocarcinoma of right lung (disorder),y,descendant of concept mapped from leaf
+707705008,Nonkeratinizing carcinoma of the nasopharynx (disorder),y,descendant of concept mapped from leaf
+403940006,Clear cell eccrine hidradenocarcinoma of skin (disorder),y,descendant of concept mapped from leaf
+707587000,Primary carcinoma ex pleomorphic adenoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+449487002,Malignant epithelial neoplasm of mandible (disorder),y,descendant of concept mapped from leaf
+94311007,Secondary malignant neoplasm of fundus of stomach (disorder),y,descendant of concept mapped from leaf
+448216007,Malignant epithelial neoplasm of thyroid (disorder),y,descendant of concept mapped from leaf
+61471000119100,Basal cell carcinoma of naris (disorder),y,descendant of concept mapped from leaf
+307622006,Prolymphocytic lymphosarcoma (disorder),y,descendant of concept mapped from leaf
+369491002,Malignant tumor involving seminal vesicle by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+444604002,Carcinoma of breast with ductal and lobular features (disorder),y,descendant of concept mapped from leaf
+94320003,Secondary malignant neoplasm of greater curvature of stomach (disorder),y,descendant of concept mapped from leaf
+94257006,Secondary malignant neoplasm of clitoris (disorder),y,descendant of concept mapped from leaf
+449206007,Sarcoma of tibia (disorder),y,descendant of concept mapped from leaf
+449055006,Leiomyosarcoma of cardioesophageal junction (disorder),y,descendant of concept mapped from leaf
+188514005,Burkitt's lymphoma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+94291000119103,Mucinous adenocarcinoma of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+255102004,Angioendotheliomatosis (disorder),y,descendant of concept mapped from leaf
+733357007,Primary squamous cell carcinoma of intrathoracic organ (disorder),y,descendant of concept mapped from leaf
+722828003,Primary synovial sarcoma of intrathoracic organ (disorder),y,descendant of concept mapped from leaf
+397008008,Aggressive lymphadenopathic mastocytosis with eosinophilia (disorder),y,descendant of concept mapped from leaf
+721641003,Primary neuroendocrine carcinoma of pyloric antrum of stomach (disorder),y,descendant of concept mapped from leaf
+277625002,Follicular malignant lymphoma - small cleaved cell (disorder),y,descendant of concept mapped from leaf
+423595004,Adenocarcinoma carcinomatosis (disorder),y,descendant of concept mapped from leaf
+94082003,Primary malignant neoplasm of tail of pancreas (disorder),y,descendant of concept mapped from leaf
+94307001,Secondary malignant neoplasm of prepuce (disorder),y,descendant of concept mapped from leaf
+188538009,Hodgkin's granuloma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+448864006,Malignant epithelial neoplasm of ureter (disorder),y,descendant of concept mapped from leaf
+94345000,Secondary malignant neoplasm of intestinal lymph nodes (disorder),y,descendant of concept mapped from leaf
+733607005,Papillary renal cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94034009,Primary malignant neoplasm of skin of neck (disorder),y,descendant of concept mapped from leaf
+722680009,Primary serous adenocarcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+93530003,Hodgkin's granuloma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93858004,Primary malignant neoplasm of laryngeal surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+369594008,Malignant tumor involving an organ by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+93737003,Primary malignant neoplasm of calcaneus (disorder),y,descendant of concept mapped from leaf
+93771007,Primary malignant neoplasm of descending colon (disorder),y,descendant of concept mapped from leaf
+443487006,Mantle cell lymphoma (disorder),y,descendant of concept mapped from leaf
+128734000,Undifferentiated sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+717736007,Familial renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94501001,Secondary malignant neoplasm of preauricular lymph nodes (disorder),y,descendant of concept mapped from leaf
+716647001,Mixed oligoastrocytoma (disorder),y,descendant of concept mapped from leaf
+735919002,Primary malignant neuroepithelial neoplasm of iris (disorder),y,descendant of concept mapped from leaf
+93724001,Primary malignant neoplasm of bone of upper limb (disorder),y,descendant of concept mapped from leaf
+93133006,Letterer-Siwe disease of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+123842006,Endocervical adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+722515001,Primary liposarcoma of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+766046007,Acute myeloid leukemia and myelodysplastic syndrome related to topoisomerase type 2 inhibitor (disorder),y,descendant of concept mapped from leaf
+417181009,Hormone receptor positive malignant neoplasm of breast (disorder),y,descendant of concept mapped from leaf
+449267001,Sarcoma of mandible (disorder),y,descendant of concept mapped from leaf
+94010004,Primary malignant neoplasm of skin of axilla (disorder),y,descendant of concept mapped from leaf
+721630000,Primary adenocarcinoma of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+354671000119106,Primary malignant neoplasm of bone of right upper limb (disorder),y,descendant of concept mapped from leaf
+188631008,Sézary's disease of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+403916003,Basal cell carcinoma of forehead (disorder),y,descendant of concept mapped from leaf
+118605002,"Hodgkin lymphoma, nodular lymphocyte predominance (disorder)",y,descendant of concept mapped from leaf
+93195001,"Malignant lymphoma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+118615008,Malignant mast cell tumor (disorder),y,descendant of concept mapped from leaf
+240163000,Malignant neoplasm of nasopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+93507009,"Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+354651000119102,Primary malignant neoplasm of bone of left lower limb (disorder),y,descendant of concept mapped from leaf
+93994001,Primary malignant neoplasm of round ligament of uterus (disorder),y,descendant of concept mapped from leaf
+447784001,Sarcoma of axillary tail of female breast (disorder),y,descendant of concept mapped from leaf
+820601000000103,Refractory anaemia with multilineage dysplasia (disorder),y,descendant of concept mapped from leaf
+707592003,Primary infiltrating duct carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+109985000,Immunoproliferative small intestinal disease (disorder),y,descendant of concept mapped from leaf
+93848003,Primary malignant neoplasm of junctional zone of tongue (disorder),y,descendant of concept mapped from leaf
+94214001,Secondary malignant neoplasm of body of stomach (disorder),y,descendant of concept mapped from leaf
+413537009,Angioimmunoblastic T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+449217008,Diffuse non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+307647008,"Malignant lymphoma, centroblastic type, follicular (disorder)",y,descendant of concept mapped from leaf
+1681000119102,Metastasis to lymph node from adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+715215007,Chromosome 11p13 deletion syndrome (disorder),y,descendant of concept mapped from leaf
+448300007,Malignant melanoma of skin of vulva (disorder),y,descendant of concept mapped from leaf
+94389000,Secondary malignant neoplasm of lumbar vertebral column (disorder),y,descendant of concept mapped from leaf
+403468003,Squamous cell carcinoma of penis (disorder),y,descendant of concept mapped from leaf
+448561007,Follicular non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+414791003,"Myelodysplastic syndrome, unclassified by World Health Organization classification (disorder)",y,descendant of concept mapped from leaf
+423793008,Mucoepidermoid carcinoma of parotid gland (disorder),y,descendant of concept mapped from leaf
+307636001,"Malignant lymphoma, mixed lymphocytic-histiocytic, nodular (disorder)",y,descendant of concept mapped from leaf
+93969002,Primary malignant neoplasm of posterior mediastinum (disorder),y,descendant of concept mapped from leaf
+94048009,Primary malignant neoplasm of small intestine (disorder),y,descendant of concept mapped from leaf
+94427004,Secondary malignant neoplasm of muscle of perineum (disorder),y,descendant of concept mapped from leaf
+766048008,Acute myeloid leukemia and myelodysplastic syndrome related to radiation (disorder),y,descendant of concept mapped from leaf
+404069006,Myxoid liposarcoma (disorder),y,descendant of concept mapped from leaf
+447766003,Lymphoma of pyloric antrum of stomach (disorder),y,descendant of concept mapped from leaf
+372022008,Primary malignant neoplasm of upper gum (disorder),y,descendant of concept mapped from leaf
+307649006,Microglioma (disorder),y,descendant of concept mapped from leaf
+94379004,Secondary malignant neoplasm of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+93956001,Primary malignant neoplasm of perianal skin (disorder),y,descendant of concept mapped from leaf
+721580001,Primary myosarcoma of omentum (disorder),y,descendant of concept mapped from leaf
+396198006,Small cell carcinoma of prostate (disorder),y,descendant of concept mapped from leaf
+369578001,Malignant tumor involving uterine corpus by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+399954008,Basal cell carcinoma of earlobe (disorder),y,descendant of concept mapped from leaf
+110004001,"Acute promyelocytic leukemia, FAB M3 (disorder)",y,descendant of concept mapped from leaf
+447712006,Malignant melanoma of skin of anus (disorder),y,descendant of concept mapped from leaf
+707389001,Primary clear cell squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+707411007,Primary papillary adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+372107001,Primary malignant neoplasm of ribs and/or sternum and/or clavicle (disorder),y,descendant of concept mapped from leaf
+713483007,Reticulosarcoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+404115006,Bullous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+403905005,Multiple squamous cell carcinomata (disorder),y,descendant of concept mapped from leaf
+715901002,Ependymoblastoma (disorder),y,descendant of concept mapped from leaf
+725437002,Chronic lymphocytic leukemia genetic mutation variant (disorder),y,descendant of concept mapped from leaf
+403890009,Squamous cell carcinoma of vulva due to lichen sclerosus (disorder),y,descendant of concept mapped from leaf
+373888000,Extrauterine adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+415283002,Refractory anemia with excess blasts-1 (disorder),y,descendant of concept mapped from leaf
+94388008,Secondary malignant neoplasm of lower third of esophagus (disorder),y,descendant of concept mapped from leaf
+369563008,Malignant tumor involving left ovary by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94653000,Secondary malignant neoplasm of upper inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+93693009,Primary malignant neoplasm of blood vessel of buttock (disorder),y,descendant of concept mapped from leaf
+713574000,Malignant carcinoid tumor of kidney (disorder),y,descendant of concept mapped from leaf
+448269008,Lymphoma of lesser curvature of stomach (disorder),y,descendant of concept mapped from leaf
+721568009,Primary adenocarcinoma of parametrium (disorder),y,descendant of concept mapped from leaf
+188593003,"Hodgkin's disease, lymphocytic depletion of lymph nodes of multiple sites (disorder)",y,descendant of concept mapped from leaf
+715903004,Medulloepithelioma (disorder),y,descendant of concept mapped from leaf
+369512008,Malignant tumor involving vagina by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+404054005,Pleomorphic rhabdomyosarcoma (disorder),y,descendant of concept mapped from leaf
+767444009,Germline BRCA-mutated human epidermal growth factor receptor 2 negative metastatic carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+764845008,Adenocarcinoma of anal canal (disorder),y,descendant of concept mapped from leaf
+94373003,Secondary malignant neoplasm of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+254639005,Carcinoma in situ of lung parenchyma (disorder),y,descendant of concept mapped from leaf
+93756008,"Primary malignant neoplasm of ciliary body, primary (disorder)",y,descendant of concept mapped from leaf
+765328000,Classic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+92516002,Burkitt's tumor of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+91041000119104,Ewing sarcoma of bone structure of upper limb (disorder),y,descendant of concept mapped from leaf
+369551003,Malignant tumor involving right fallopian tube by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+109858008,Malignant mesothelioma of omentum (disorder),y,descendant of concept mapped from leaf
+313429000,Seminoma of descended testis (disorder),y,descendant of concept mapped from leaf
+698044008,Malignant melanoma of palatine arch (disorder),y,descendant of concept mapped from leaf
+722518004,Primary malignant nerve sheath neoplasm of autonomic nerve (disorder),y,descendant of concept mapped from leaf
+128756002,Gastrointestinal stromal sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+402505009,Basal cell carcinoma of upper lip (disorder),y,descendant of concept mapped from leaf
+707662004,Primary basaloid squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+188663002,Mast cell malignancy of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93940006,Primary malignant neoplasm of para-aortic body (disorder),y,descendant of concept mapped from leaf
+277626001,Diffuse high grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+13583002,Mast cell sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+314954002,Local recurrence of malignant tumor of lung (disorder),y,descendant of concept mapped from leaf
+369495006,Malignant tumor involving uterine corpus by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94122003,Primary malignant neoplasm of ureteric orifice of urinary bladder (disorder),y,descendant of concept mapped from leaf
+369505004,Malignant tumor involving vagina by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+12060004,Ganglioneuromatosis (morphologic abnormality),y,descendant of concept mapped from leaf
+109880006,Overlapping malignant neoplasm of uterine cervix (disorder),y,descendant of concept mapped from leaf
+128794002,"Retinoblastoma, spontaneously regressed (morphologic abnormality)",y,descendant of concept mapped from leaf
+94342002,Secondary malignant neoplasm of inner aspect of lower lip (disorder),y,descendant of concept mapped from leaf
+93519001,"Hodgkin's disease, nodular sclerosis of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+733360000,Primary undifferentiated carcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+371978009,Primary malignant neoplasm of cervical esophagus (disorder),y,descendant of concept mapped from leaf
+93182006,Malignant histiocytosis of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+369461007,Malignant tumor involving rectum by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+93899005,Primary malignant neoplasm of muscle of abdomen (disorder),y,descendant of concept mapped from leaf
+699355007,Leiomyosarcoma of orbit (disorder),y,descendant of concept mapped from leaf
+118618005,Mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+93739000,Primary malignant neoplasm of carina (disorder),y,descendant of concept mapped from leaf
+707470000,Primary mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+188741003,Aleukemic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+147131000119101,Glioblastoma multiforme of central nervous system (disorder),y,descendant of concept mapped from leaf
+109994006,Essential thrombocythemia (disorder),y,descendant of concept mapped from leaf
+424666005,Basal cell carcinoma of auricle of ear (disorder),y,descendant of concept mapped from leaf
+93532006,Hodgkin's granuloma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+413389003,Accelerated phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+425688002,Philadelphia chromosome-positive acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+94369001,Secondary malignant neoplasm of laryngeal surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+372023003,Primary malignant neoplasm of upper third of esophagus (disorder),y,descendant of concept mapped from leaf
+128911002,"Teratoid medulloepithelioma, benign (morphologic abnormality)",y,descendant of concept mapped from leaf
+10745291000119103,Malignant neoplastic disease in mother complicating childbirth (disorder),y,descendant of concept mapped from leaf
+93875005,Primary malignant neoplasm of lower limb (disorder),y,descendant of concept mapped from leaf
+423627007,Sarcoma of ovary (disorder),y,descendant of concept mapped from leaf
+93526001,Hodgkin's disease of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+734522002,Acute myeloid leukemia with FMS-like tyrosine kinase-3 mutation (disorder),y,descendant of concept mapped from leaf
+449308006,Malignant neoplasm of visceral pleura (disorder),y,descendant of concept mapped from leaf
+764847000,Adenosarcoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+718195003,Inherited predisposition to essential thrombocythemia (disorder),y,descendant of concept mapped from leaf
+707467004,Primary salivary gland type carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+369474001,Malignant tumor involving bladder by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+94561004,Secondary malignant neoplasm of skin of hip (disorder),y,descendant of concept mapped from leaf
+448995000,Follicular non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+93647006,Malignant melanoma of skin of shoulder (disorder),y,descendant of concept mapped from leaf
+403979000,Kaposi's sarcoma - endemic (disorder),y,descendant of concept mapped from leaf
+449208008,Sarcoma of coccyx (disorder),y,descendant of concept mapped from leaf
+426642002,"Erythroleukemia, FAB M6 in remission (disorder)",y,descendant of concept mapped from leaf
+188121000,Malignant neoplasm of skin of upper arm (disorder),y,descendant of concept mapped from leaf
+423195009,Primary malignant neoplasm of lacrimal drainage system (disorder),y,descendant of concept mapped from leaf
+94164003,Secondary malignant neoplasm of ampulla of Vater (disorder),y,descendant of concept mapped from leaf
+723855004,Primary Ewing sarcoma of articular cartilage of pelvis (disorder),y,descendant of concept mapped from leaf
+402520003,Basal cell carcinoma of hand (disorder),y,descendant of concept mapped from leaf
+402880009,Primary cutaneous large T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94221001,Secondary malignant neoplasm of bone of upper limb (disorder),y,descendant of concept mapped from leaf
+369493004,Malignant tumor involving uterine corpus by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+448989001,Malignant epithelial neoplasm of brain (disorder),y,descendant of concept mapped from leaf
+93222003,Malignant melanoma of skin of external auditory canal (disorder),y,descendant of concept mapped from leaf
+448774004,Non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+369514009,Secondary malignant neoplasm of left fallopian tube (disorder),y,descendant of concept mapped from leaf
+107691000119101,Non-seminomatous germ cell neoplasm of testis (disorder),y,descendant of concept mapped from leaf
+698011002,Keratinizing squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+254619006,Adenoid cystic carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+707343008,Primary adenocarcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+404117003,Spongiotic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+188744006,Monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+369587005,Malignant tumor involving vulva by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+133871000119103,Merkel cell carcinoma of upper limb (disorder),y,descendant of concept mapped from leaf
+735916009,Primary malignant neuroepithelial neoplasm of retina (disorder),y,descendant of concept mapped from leaf
+92573003,Carcinoma in situ of craniopharyngeal duct (disorder),y,descendant of concept mapped from leaf
+733881007,MiT family translocation renal cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93839008,Primary malignant neoplasm of intra-abdominal organs (disorder),y,descendant of concept mapped from leaf
+699229009,Intraosseous mucoepidermoid carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+372009000,Primary malignant neoplasm of scrotum (disorder),y,descendant of concept mapped from leaf
+254632001,Small cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94165002,Secondary malignant neoplasm of anal canal (disorder),y,descendant of concept mapped from leaf
+93917007,Primary malignant neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+96291000119105,Primary malignant inflammatory neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+372093008,Secondary malignant neoplasm of axillary tail of breast (disorder),y,descendant of concept mapped from leaf
+94558000,Secondary malignant neoplasm of skin of forehead (disorder),y,descendant of concept mapped from leaf
+94126000,Primary malignant neoplasm of uterine adnexa (disorder),y,descendant of concept mapped from leaf
+399712003,Seminoma with syncytiotrophoblastic cells (morphologic abnormality),y,descendant of concept mapped from leaf
+94372008,Secondary malignant neoplasm of lateral wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+413847001,Chronic phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+370511006,Vaccine-induced fibrosarcoma (disorder),y,descendant of concept mapped from leaf
+94533005,Secondary malignant neoplasm of second cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+188554007,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+404124002,Leukemic infiltration of skin (T-cell lymphoblastic leukemia) (disorder),y,descendant of concept mapped from leaf
+277627005,Nodular high grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+128796000,"Perineurioma, malignant (morphologic abnormality)",y,descendant of concept mapped from leaf
+94564007,Secondary malignant neoplasm of skin of lip (disorder),y,descendant of concept mapped from leaf
+94252000,Secondary malignant neoplasm of cheek (disorder),y,descendant of concept mapped from leaf
+369496007,Malignant tumor involving uterine corpus by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+93787005,Primary malignant neoplasm of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+363432004,Malignant tumor of trachea (disorder),y,descendant of concept mapped from leaf
+707422006,Primary spindle cell squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+94053004,Primary malignant neoplasm of soft tissues of face (disorder),y,descendant of concept mapped from leaf
+92811003,Chronic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+109851002,Overlapping malignant neoplasm of retroperitoneum and peritoneum (disorder),y,descendant of concept mapped from leaf
+448994001,Malignant epithelial neoplasm of upper rectum (disorder),y,descendant of concept mapped from leaf
+359648001,"Acute myeloid leukemia with maturation, FAB M2 (disorder)",y,descendant of concept mapped from leaf
+94055006,Primary malignant neoplasm of soft tissues of hip (disorder),y,descendant of concept mapped from leaf
+254629004,Large cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93725000,Primary malignant neoplasm of bone (disorder),y,descendant of concept mapped from leaf
+93894000,Primary malignant neoplasm of middle ear (disorder),y,descendant of concept mapped from leaf
+764856008,Acquired cystic disease associated renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+707475005,Primary adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94096009,Primary malignant neoplasm of thymus (disorder),y,descendant of concept mapped from leaf
+188768003,Myelomonocytic leukemia (disorder),y,descendant of concept mapped from leaf
+369517002,Malignant tumor involving left fallopian tube by direct extension from right fallopian tube (disorder),y,descendant of concept mapped from leaf
+448990005,Malignant epithelial neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+93224002,Malignant melanoma of skin of eyelid (disorder),y,descendant of concept mapped from leaf
+404056007,Alveolar soft part sarcoma (disorder),y,descendant of concept mapped from leaf
+369532009,Malignant tumor involving right ovary by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+94619004,Secondary malignant neoplasm of talus (disorder),y,descendant of concept mapped from leaf
+369472002,Malignant tumor involving bladder by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+706970001,Triple negative malignant neoplasm of breast (disorder),y,descendant of concept mapped from leaf
+92675002,Carcinoma in situ of parathyroid gland (disorder),y,descendant of concept mapped from leaf
+354641000119104,Primary malignant neoplasm of bone of left upper limb (disorder),y,descendant of concept mapped from leaf
+93836001,Primary malignant neoplasm of inner aspect of lower lip (disorder),y,descendant of concept mapped from leaf
+404055006,Spindle cell rhabdomyosarcoma (disorder),y,descendant of concept mapped from leaf
+93891008,Primary malignant neoplasm of mediastinum (disorder),y,descendant of concept mapped from leaf
+118608000,"Hodgkin's disease, nodular sclerosis (disorder)",y,descendant of concept mapped from leaf
+721549006,Primary adenocarcinoma of lacrimal apparatus (disorder),y,descendant of concept mapped from leaf
+681721000119103,Primary adenocarcinoma of head of pancreas (disorder),y,descendant of concept mapped from leaf
+94529003,Secondary malignant neoplasm of scapula (disorder),y,descendant of concept mapped from leaf
+733353006,Primary malignant neuroendocrine neoplasm of biliary tract (disorder),y,descendant of concept mapped from leaf
+369455009,Malignant tumor involving rectum by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+713646001,Malignant germ cell tumor of testis (disorder),y,descendant of concept mapped from leaf
+188565002,"Hodgkin's disease, nodular sclerosis of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+448215006,Malignant epithelial neoplasm of renal pelvis (disorder),y,descendant of concept mapped from leaf
+94056007,Primary malignant neoplasm of soft tissues of inguinal region (disorder),y,descendant of concept mapped from leaf
+473419009,Intraductal papillary mucinous carcinoma in situ of pancreas (disorder),y,descendant of concept mapped from leaf
+93993007,Primary malignant neoplasm of upper lobe of right lung (disorder),y,descendant of concept mapped from leaf
+1079151000119109,Primary basal cell carcinoma of right upper limb (disorder),y,descendant of concept mapped from leaf
+403711001,Psoralen and long-wave ultraviolet radiation therapy-associated skin malignancy (disorder),y,descendant of concept mapped from leaf
+10749871000119100,Malignant neoplastic disease in pregnancy (disorder),y,descendant of concept mapped from leaf
+722543005,Primary malignant melanoma of anal canal (disorder),y,descendant of concept mapped from leaf
+62497000,Stewart-Treves syndrome (disorder),y,descendant of concept mapped from leaf
+232075002,Lymphoma of retina (disorder),y,descendant of concept mapped from leaf
+405943005,Botryoid sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448387008,Non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+128749008,Spindle cell rhabdomyosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+189509003,"Refractory anemia without sideroblasts, so stated (disorder)",y,descendant of concept mapped from leaf
+94537006,Secondary malignant neoplasm of shoulder (disorder),y,descendant of concept mapped from leaf
+707464006,Primary myoepithelial carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+80914001,Anaplasia of cervix (disorder),y,descendant of concept mapped from leaf
+847631000000107,Follicular lymphoma grade 2 (disorder),y,descendant of concept mapped from leaf
+721669006,Primary adenocarcinoma of overlapping lesion of small intestine (disorder),y,descendant of concept mapped from leaf
+302855005,Subacute leukemia (disorder),y,descendant of concept mapped from leaf
+404130002,CD-30 negative pleomorphic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+733349009,Primary mucinous cystic neoplasm with associated invasive carcinoma of distal bile duct (disorder),y,descendant of concept mapped from leaf
+93964007,Primary malignant neoplasm of pituitary gland (disorder),y,descendant of concept mapped from leaf
+94210005,Secondary malignant neoplasm of blood vessel of upper limb (disorder),y,descendant of concept mapped from leaf
+94058008,Primary malignant neoplasm of soft tissues of neck (disorder),y,descendant of concept mapped from leaf
+371970002,Primary malignant neoplasm of biliary tract (disorder),y,descendant of concept mapped from leaf
+716274007,Nodular basal cell carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+94622002,Secondary malignant neoplasm of temporal lobe (disorder),y,descendant of concept mapped from leaf
+94039004,Primary malignant neoplasm of skin of shoulder (disorder),y,descendant of concept mapped from leaf
+313249007,Malignant neoplasm of upper eyelid (disorder),y,descendant of concept mapped from leaf
+93696001,Primary malignant neoplasm of blood vessel of foot (disorder),y,descendant of concept mapped from leaf
+1079091000119100,Primary basal cell carcinoma of left upper limb (disorder),y,descendant of concept mapped from leaf
+721700001,Primary malignant neuroendocrine neoplasm of rectum (disorder),y,descendant of concept mapped from leaf
+448449001,Sarcoma of female breast (disorder),y,descendant of concept mapped from leaf
+1691000119104,Metastasis to liver from adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+128771003,Intraosseous well differentiated osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+733343005,Primary squamous cell carcinoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+94712003,Mycosis fungoides of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+10708511000119108,Primary malignant neoplasm of uterus (disorder),y,descendant of concept mapped from leaf
+94498001,Secondary malignant neoplasm of posterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+403950007,Moll's gland adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+707425008,Primary adenoid squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+307634003,"Hodgkin's disease, lymphocytic depletion, reticular type (disorder)",y,descendant of concept mapped from leaf
+94310008,Secondary malignant neoplasm of frontal sinus (disorder),y,descendant of concept mapped from leaf
+414553000,Kappa light chain myeloma (disorder),y,descendant of concept mapped from leaf
+418529003,Secondary malignant neoplasm of lacrimal drainage structure (disorder),y,descendant of concept mapped from leaf
+733134009,Primary squamous cell carcinoma of paraurethral gland (disorder),y,descendant of concept mapped from leaf
+269616004,Secondary nodes - axilla/arm (disorder),y,descendant of concept mapped from leaf
+188754005,Megakaryocytic leukemia (disorder),y,descendant of concept mapped from leaf
+734038002,Intrapulmonary thymoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94071006,Primary malignant neoplasm of spleen (disorder),y,descendant of concept mapped from leaf
+449269003,Sarcoma of rib (disorder),y,descendant of concept mapped from leaf
+118601006,Non-Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+128884000,Malignant myoepithelioma (morphologic abnormality),y,descendant of concept mapped from leaf
+707539005,Primary adenoid cystic carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93778001,Primary malignant neoplasm of endocardium (disorder),y,descendant of concept mapped from leaf
+94470004,Secondary malignant neoplasm of parietal bone (disorder),y,descendant of concept mapped from leaf
+422886007,Olfactory neuroblastoma (disorder),y,descendant of concept mapped from leaf
+404133000,Subcutaneous panniculitic cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+93650009,Malignant melanoma of skin of toe (disorder),y,descendant of concept mapped from leaf
+91061000119100,Primary chondrosarcoma of bone of pelvis (disorder),y,descendant of concept mapped from leaf
+724537009,Primary adenocarcinoma of jejunum (disorder),y,descendant of concept mapped from leaf
+94456004,Secondary malignant neoplasm of palate (disorder),y,descendant of concept mapped from leaf
+403892001,Squamous cell carcinoma of skin of face (disorder),y,descendant of concept mapped from leaf
+93983000,Primary malignant neoplasm of rectovesical septum (disorder),y,descendant of concept mapped from leaf
+703595002,Medullary-like carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+721696009,Primary adenocarcinoma of transverse colon (disorder),y,descendant of concept mapped from leaf
+94184004,Secondary malignant neoplasm of base of tongue (disorder),y,descendant of concept mapped from leaf
+722112006,Primary squamous cell carcinoma of ear (disorder),y,descendant of concept mapped from leaf
+94125001,Primary malignant neoplasm of urinary system (disorder),y,descendant of concept mapped from leaf
+707483004,Primary undifferentiated carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+123845008,Adenocarcinoma of endometrium (disorder),y,descendant of concept mapped from leaf
+733608000,Papillary renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+721670007,Primary malignant neuroendocrine neoplasm of small intestine (disorder),y,descendant of concept mapped from leaf
+94660006,Secondary malignant neoplasm of ureteric orifice of urinary bladder (disorder),y,descendant of concept mapped from leaf
+93754006,Primary malignant neoplasm of chest wall (disorder),y,descendant of concept mapped from leaf
+93932000,Primary malignant neoplasm of orbit (disorder),y,descendant of concept mapped from leaf
+94443006,Secondary malignant neoplasm of nipple of female breast (disorder),y,descendant of concept mapped from leaf
+448711001,Sarcoma of back (disorder),y,descendant of concept mapped from leaf
+448468003,Diffuse non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+94229004,Secondary malignant neoplasm of bronchus of left upper lobe (disorder),y,descendant of concept mapped from leaf
+92509003,Burkitt's tumor of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94520004,Secondary malignant neoplasm of retropharyngeal lymph nodes (disorder),y,descendant of concept mapped from leaf
+109349007,Overlapping malignant neoplasm of soft tissues (disorder),y,descendant of concept mapped from leaf
+93760006,Primary malignant neoplasm of coccyx (disorder),y,descendant of concept mapped from leaf
+94072004,Primary malignant neoplasm of splenic flexure of colon (disorder),y,descendant of concept mapped from leaf
+351461000119100,Merkel cell carcinoma of right lower limb (disorder),y,descendant of concept mapped from leaf
+721579004,Primary synovial sarcoma of soft tissue of limb (disorder),y,descendant of concept mapped from leaf
+722674001,Primary squamous cell carcinoma of parotid gland (disorder),y,descendant of concept mapped from leaf
+764952009,Carcinosarcoma of corpus uteri (disorder),y,descendant of concept mapped from leaf
+372013007,Primary malignant neoplasm of spermatic cord (disorder),y,descendant of concept mapped from leaf
+93207008,Malignant mast cell tumor of spleen (disorder),y,descendant of concept mapped from leaf
+94267001,Secondary malignant neoplasm of craniopharyngeal duct (disorder),y,descendant of concept mapped from leaf
+93743001,Primary malignant neoplasm of cauda equina (disorder),y,descendant of concept mapped from leaf
+722510006,Primary rhabdomyosarcoma of pharynx (disorder),y,descendant of concept mapped from leaf
+94361003,Secondary malignant neoplasm of labia majora (disorder),y,descendant of concept mapped from leaf
+93542008,"Hodgkin's paragranuloma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+429114002,Malignant basal cell neoplasm of skin (disorder),y,descendant of concept mapped from leaf
+63211008,Synovial sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+277612005,"Hodgkin's disease, nodular sclerosis - lymphocytic depletion (disorder)",y,descendant of concept mapped from leaf
+94657004,Secondary malignant neoplasm of upper third of esophagus (disorder),y,descendant of concept mapped from leaf
+94111002,Primary malignant neoplasm of trunk (disorder),y,descendant of concept mapped from leaf
+188567005,"Hodgkin's disease, nodular sclerosis of intra-abdominal lymph nodes (disorder)",y,descendant of concept mapped from leaf
+444597005,Extranodal marginal zone lymphoma of mucosa-associated lymphoid tissue of stomach (disorder),y,descendant of concept mapped from leaf
+723849009,Primary osteosarcoma of articular cartilage of jaw (disorder),y,descendant of concept mapped from leaf
+369560006,Malignant tumor involving left ovary by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+369549002,Malignant tumor involving right fallopian tube by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+404127009,CD-30 positive T-immunoblastic cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+369603003,Malignant tumor involving an organ by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+109390005,Kaposi's sarcoma of lung (disorder),y,descendant of concept mapped from leaf
+425066001,"Carcinoma of urinary bladder, invasive (disorder)",y,descendant of concept mapped from leaf
+188609000,"Nodular lymphoma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+188613007,Nodular lymphoma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+277569004,Large granular lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+448558006,Malignant neoplasm of maxillofacial bone (disorder),y,descendant of concept mapped from leaf
+698288007,Malignant melanoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+109840002,Primary malignant neoplasm of cloacogenic zone (disorder),y,descendant of concept mapped from leaf
+722676004,Primary squamous cell carcinoma of middle ear (disorder),y,descendant of concept mapped from leaf
+372125008,Carcinoma of skin of lower limb (disorder),y,descendant of concept mapped from leaf
+399399005,Spermatocytic seminoma with sarcomatous component (morphologic abnormality),y,descendant of concept mapped from leaf
+70910003,Indolent systemic mastocytosis (disorder),y,descendant of concept mapped from leaf
+94167005,Secondary malignant neoplasm of anterior mediastinum (disorder),y,descendant of concept mapped from leaf
+94384005,Secondary malignant neoplasm of lower gum (disorder),y,descendant of concept mapped from leaf
+404014008,Malignant fibrous histiocytoma of skin (disorder),y,descendant of concept mapped from leaf
+188500005,"Lymphosarcoma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+93779009,Primary malignant neoplasm of endocervix (disorder),y,descendant of concept mapped from leaf
+94666000,Secondary malignant neoplasm of uveal tract (disorder),y,descendant of concept mapped from leaf
+372110008,"Primary malignant neoplasm of lower lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+61291000119103,Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+440422002,Asymptomatic multiple myeloma (disorder),y,descendant of concept mapped from leaf
+721606002,Primary adenocarcinoma of overlapping lesion of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+404106004,Lymphomatoid papulosis with Hodgkin's disease (disorder),y,descendant of concept mapped from leaf
+277611003,"Hodgkin's disease, nodular sclerosis - mixed cellularity (disorder)",y,descendant of concept mapped from leaf
+128874001,Cutaneous CD30+ lymphoproliferative disorder (disorder),y,descendant of concept mapped from leaf
+94570001,Secondary malignant neoplasm of skin of scalp (disorder),y,descendant of concept mapped from leaf
+93146001,Leukemic reticuloendotheliosis of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+369477008,Malignant tumor involving bladder by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+717916003,Neuroendocrine carcinoma of appendix (disorder),y,descendant of concept mapped from leaf
+94263002,Secondary malignant neoplasm of conjunctiva (disorder),y,descendant of concept mapped from leaf
+369535006,Secondary neoplasm of left broad ligament (disorder),y,descendant of concept mapped from leaf
+363499005,Malignant tumor of spleen (disorder),y,descendant of concept mapped from leaf
+447806008,Lymphoma of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+404132005,Pleomorphic small/medium-sized cell cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+724649000,Langerhans cell sarcoma (disorder),y,descendant of concept mapped from leaf
+399552004,"Monodermal teratoma, primitive neuroectodermal tumor (morphologic abnormality)",y,descendant of concept mapped from leaf
+36741007,"Seminoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+369562003,Malignant tumor involving left ovary by separate metastasis from right ovary (disorder),y,descendant of concept mapped from leaf
+424487008,Malignant melanoma of skin of upper lip (disorder),y,descendant of concept mapped from leaf
+721540005,Primary adnexal carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+93802007,Primary malignant neoplasm of floor of mouth (disorder),y,descendant of concept mapped from leaf
+94560003,Secondary malignant neoplasm of skin of hand (disorder),y,descendant of concept mapped from leaf
+449248000,Nasopharyngeal carcinoma (disorder),y,descendant of concept mapped from leaf
+399590005,Squamous cell carcinoma of prostate (disorder),y,descendant of concept mapped from leaf
+443439001,Malignant fibrous histiocytoma (disorder),y,descendant of concept mapped from leaf
+94286009,Secondary malignant neoplasm of esophagus (disorder),y,descendant of concept mapped from leaf
+424132000,"Non-small cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+441535001,Adenocarcinoma of head and neck (disorder),y,descendant of concept mapped from leaf
+278052009,Malignant lymphoma of breast (disorder),y,descendant of concept mapped from leaf
+94218003,Secondary malignant neoplasm of bone of face (disorder),y,descendant of concept mapped from leaf
+242862004,Secondary malignant neoplasm of nasopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+414785000,Multiple solitary plasmacytomas (disorder),y,descendant of concept mapped from leaf
+93831006,Primary malignant neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707451005,Primary adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93184007,Malignant histiocytosis of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+716859000,Hereditary diffuse carcinoma of stomach (disorder),y,descendant of concept mapped from leaf
+93930008,Primary malignant neoplasm of olfactory nerve (disorder),y,descendant of concept mapped from leaf
+95193005,Nodular lymphoma of spleen (disorder),y,descendant of concept mapped from leaf
+94677006,Secondary malignant neoplasm of vestibule of nose (disorder),y,descendant of concept mapped from leaf
+188492005,Reticulosarcoma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+94669007,Secondary malignant neoplasm of vagus nerve (disorder),y,descendant of concept mapped from leaf
+94608002,Secondary malignant neoplasm of sublingual gland (disorder),y,descendant of concept mapped from leaf
+93654000,Malignant melanoma of skin of wrist (disorder),y,descendant of concept mapped from leaf
+403896003,Squamous cell carcinoma of hand (disorder),y,descendant of concept mapped from leaf
+402538000,Recurrent basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+188718006,"Malignant plasma cell neoplasm, extramedullary plasmacytoma (disorder)",y,descendant of concept mapped from leaf
+94495003,Secondary malignant neoplasm of postcricoid region (disorder),y,descendant of concept mapped from leaf
+1081551000119106,Recurrent primary malignant neoplasm of left female breast (disorder),y,descendant of concept mapped from leaf
+424954002,Undifferentiated large cell carcinomatosis (disorder),y,descendant of concept mapped from leaf
+285422003,Immunoglobulin D myeloma (disorder),y,descendant of concept mapped from leaf
+698042007,Malignant melanoma of tongue (disorder),y,descendant of concept mapped from leaf
+188645002,"Leukemic reticuloendotheliosis of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+93773005,Primary malignant neoplasm of dorsal surface of tongue (disorder),y,descendant of concept mapped from leaf
+403939009,Eccrine ductal carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+92813000,Chronic lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+423746001,Adenocarcinoma of pelvis (disorder),y,descendant of concept mapped from leaf
+94203004,Secondary malignant neoplasm of blood vessel of perineum (disorder),y,descendant of concept mapped from leaf
+94173006,Secondary malignant neoplasm of aortic body (disorder),y,descendant of concept mapped from leaf
+94287000,Secondary malignant neoplasm of ethmoid bone (disorder),y,descendant of concept mapped from leaf
+715950008,Anaplastic lymphoma kinase positive large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+763771009,Leiomyosarcoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+447781009,Malignant epithelial neoplasm of peritoneum (disorder),y,descendant of concept mapped from leaf
+716588005,Primary non-gestational choriocarcinoma of ovary (disorder),y,descendant of concept mapped from leaf
+716648006,Embryonal sarcoma of liver (disorder),y,descendant of concept mapped from leaf
+734087000,Embryonal neoplasm with multilayered rosettes with C19MC-altered (morphologic abnormality),y,descendant of concept mapped from leaf
+93707007,Primary malignant neoplasm of blood vessel of popliteal space (disorder),y,descendant of concept mapped from leaf
+713189001,Malignant insulinoma (disorder),y,descendant of concept mapped from leaf
+94303002,Secondary malignant neoplasm of flank (disorder),y,descendant of concept mapped from leaf
+702476004,Therapy-related myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+403926005,Malignant melanoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+733471003,Chromophobe renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+443937008,Mixed glioma (disorder),y,descendant of concept mapped from leaf
+313356004,Squamous cell carcinoma of bronchus in right middle lobe (disorder),y,descendant of concept mapped from leaf
+93980002,Primary malignant neoplasm of rectosigmoid junction (disorder),y,descendant of concept mapped from leaf
+722445001,Primary giant cell sarcoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+188612002,Nodular lymphoma of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+721701002,Primary neuroendocrine carcinoma of rectum (disorder),y,descendant of concept mapped from leaf
+1091921000000103,B-cell non-Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+93978008,Primary malignant neoplasm of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+707460002,Primary pseudosarcomatous carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+709285002,Secondary malignant neoplasm of lumbosacral plexus (disorder),y,descendant of concept mapped from leaf
+254628007,Carcinoma of lung parenchyma (disorder),y,descendant of concept mapped from leaf
+94682004,Secondary malignant neoplasm of Waldeyer's ring (disorder),y,descendant of concept mapped from leaf
+403978008,Kaposi's sarcoma - sporadic (disorder),y,descendant of concept mapped from leaf
+715664005,Interdigitating dendritic cell sarcoma (disorder),y,descendant of concept mapped from leaf
+93934004,Primary malignant neoplasm of ovary (disorder),y,descendant of concept mapped from leaf
+93753000,Primary malignant neoplasm of cheek (disorder),y,descendant of concept mapped from leaf
+231835006,Kaposi's sarcoma of eyelid (disorder),y,descendant of concept mapped from leaf
+369543001,Malignant tumor involving left fallopian tube by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+109854005,Malignant mesothelioma of parietal peritoneum (disorder),y,descendant of concept mapped from leaf
+94312000,Secondary malignant neoplasm of gallbladder (disorder),y,descendant of concept mapped from leaf
+764694005,MiT family translocation renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+698040004,Malignant melanoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+94383004,Secondary malignant neoplasm of long bone of upper limb (disorder),y,descendant of concept mapped from leaf
+403902008,Adenosquamous carcinoma (disorder),y,descendant of concept mapped from leaf
+724468006,Primary urothelial carcinoma of overlapping lesion of urinary organ (disorder),y,descendant of concept mapped from leaf
+369498008,Malignant tumor involving uterine cervix by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+423610004,Rhabdomyosarcoma of connective or soft tissue (disorder),y,descendant of concept mapped from leaf
+402534003,Basal cell carcinoma with signet ring change (disorder),y,descendant of concept mapped from leaf
+94215000,Secondary malignant neoplasm of body of uterus (disorder),y,descendant of concept mapped from leaf
+94170009,Secondary malignant neoplasm of anterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+723879002,Primary adenocarcinoma of overlapping lesion of urinary organ (disorder),y,descendant of concept mapped from leaf
+707537007,Primary squamous cell carcinoma of anterior surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+766978002,Squamous cell carcinoma of gallbladder and extrahepatic biliary tract (disorder),y,descendant of concept mapped from leaf
+399644007,"Neurotropic melanoma, malignant (morphologic abnormality)",y,descendant of concept mapped from leaf
+402506005,Basal cell carcinoma of lower lip (disorder),y,descendant of concept mapped from leaf
+721642005,Primary neuroendocrine carcinoma of overlapping lesion of stomach (disorder),y,descendant of concept mapped from leaf
+93745008,Primary malignant neoplasm of central portion of female breast (disorder),y,descendant of concept mapped from leaf
+94572009,Secondary malignant neoplasm of skin of temporal region (disorder),y,descendant of concept mapped from leaf
+94368009,Secondary malignant neoplasm of laryngeal commissure (disorder),y,descendant of concept mapped from leaf
+703692009,Secondary osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94269003,Secondary malignant neoplasm of cuboid (disorder),y,descendant of concept mapped from leaf
+95194004,Nodular lymphoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+707529004,Overlapping squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+82501000119102,Anaplastic astrocytoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+94334003,Secondary malignant neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+399968001,Adenoid cystic eccrine carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93801000,Primary malignant neoplasm of flank (disorder),y,descendant of concept mapped from leaf
+423896007,Squamous cell carcinoma of tip of nose (disorder),y,descendant of concept mapped from leaf
+46585005,"Granulosa cell tumor, adult type (morphologic abnormality)",y,descendant of concept mapped from leaf
+372127000,Carcinoma of skin of trunk (disorder),y,descendant of concept mapped from leaf
+443261008,Oxyphilic adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+95261008,Sézary's disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+276811008,Gastric lymphoma (disorder),y,descendant of concept mapped from leaf
+95225003,Reticulosarcoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+707454002,Primary basaloid squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+766980008,Squamous cell carcinoma of stomach (disorder),y,descendant of concept mapped from leaf
+93497000,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+91855006,"Acute leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+425941003,Pre B-cell acute lymphoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+707380002,Primary salivary gland type carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94704006,Multiple myeloma in remission (disorder),y,descendant of concept mapped from leaf
+94639000,Secondary malignant neoplasm of tonsillar fossa (disorder),y,descendant of concept mapped from leaf
+1081811000119107,Primary seminoma of right testis (disorder),y,descendant of concept mapped from leaf
+423673009,Malignant melanoma of retina (disorder),y,descendant of concept mapped from leaf
+254637007,Non-small cell lung cancer (disorder),y,descendant of concept mapped from leaf
+404103007,Lymphomatoid papulosis type A (CD-30 positive type) (disorder),y,descendant of concept mapped from leaf
+24111000119105,Primary squamous cell carcinoma of upper limb (disorder),y,descendant of concept mapped from leaf
+721561003,Primary adenocarcinoma of middle ear (disorder),y,descendant of concept mapped from leaf
+94625000,Secondary malignant neoplasm of the mesocolon (disorder),y,descendant of concept mapped from leaf
+448776002,Sarcoma of vertebra (disorder),y,descendant of concept mapped from leaf
+110005000,"Acute myelomonocytic leukemia, FAB M4 (disorder)",y,descendant of concept mapped from leaf
+399475009,Minimal deviation melanoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448669004,Malignant neoplasm of soft tissue of orbit (disorder),y,descendant of concept mapped from leaf
+707429002,Overlapping squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+372129002,Carcinoma of skin of upper limb (disorder),y,descendant of concept mapped from leaf
+94489004,Secondary malignant neoplasm of pineal gland (disorder),y,descendant of concept mapped from leaf
+94465006,Secondary malignant neoplasm of parametrium (disorder),y,descendant of concept mapped from leaf
+188662007,"Mast cell malignancy of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+94425007,Secondary malignant neoplasm of muscle of neck (disorder),y,descendant of concept mapped from leaf
+399479003,"Malignant trophoblastic tumor, type cannot be determined (morphologic abnormality)",y,descendant of concept mapped from leaf
+87151000119105,Malignant glioma of central nervous system (disorder),y,descendant of concept mapped from leaf
+448672006,Follicular non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+422599000,Squamous cell carcinoma of back (disorder),y,descendant of concept mapped from leaf
+713327005,Malignant meningioma of meninges of brain (disorder),y,descendant of concept mapped from leaf
+764961009,Hereditary clear cell renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94599006,Secondary malignant neoplasm of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+722712000,Occupational cancer of skin (disorder),y,descendant of concept mapped from leaf
+707491008,Primary lymphoepithelial carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+402539008,Basal cell carcinoma recurrent following excision (disorder),y,descendant of concept mapped from leaf
+94183005,Secondary malignant neoplasm of back (disorder),y,descendant of concept mapped from leaf
+425178004,Adenocarcinoma of rectosigmoid junction (disorder),y,descendant of concept mapped from leaf
+94089007,Primary malignant neoplasm of the mesocolon (disorder),y,descendant of concept mapped from leaf
+87091000119101,Malignant glioma of cerebrum (disorder),y,descendant of concept mapped from leaf
+444134008,Ductal carcinoma in situ with microinvasion and involving nipple skin (morphologic abnormality),y,descendant of concept mapped from leaf
+723843005,Primary chondrosarcoma of bone of limb (disorder),y,descendant of concept mapped from leaf
+285307007,Squamous cell carcinoma of skin of upper lip (disorder),y,descendant of concept mapped from leaf
+94532000,Secondary malignant neoplasm of sebaceous gland (disorder),y,descendant of concept mapped from leaf
+369475000,Malignant tumor involving bladder by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+94346004,Secondary malignant neoplasm of intestinal tract (disorder),y,descendant of concept mapped from leaf
+369567009,Malignant tumor involving right ovary by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+734072005,Pulmonary myxoid sarcoma with EWSR1-CREB1 translocation (morphologic abnormality),y,descendant of concept mapped from leaf
+403899005,Squamous cell carcinoma of skin of trunk (disorder),y,descendant of concept mapped from leaf
+372136001,"Carcinoma of upper lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+403893006,Squamous cell carcinoma of forehead (disorder),y,descendant of concept mapped from leaf
+404664002,Malignant optic glioma (disorder),y,descendant of concept mapped from leaf
+400180002,Mucoepidermoid eccrine carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+403929003,Trichilemmal carcinoma (disorder),y,descendant of concept mapped from leaf
+72891000119103,Kaposi sarcoma of viscus (disorder),y,descendant of concept mapped from leaf
+707405009,Primary adenosquamous carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+721605003,Primary squamous cell carcinoma of overlapping lesion of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+369459003,Malignant tumor involving rectum by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+94662003,Secondary malignant neoplasm of urinary bladder neck (disorder),y,descendant of concept mapped from leaf
+707359008,Primary squamous cell carcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+93744007,Primary malignant neoplasm of central nervous system (disorder),y,descendant of concept mapped from leaf
+707390005,Primary basaloid squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94617002,Secondary malignant neoplasm of sweat gland (disorder),y,descendant of concept mapped from leaf
+698285005,Malignant melanoma of ethmoid sinus (disorder),y,descendant of concept mapped from leaf
+723847006,Primary chondrosarcoma of articular cartilage of rib (disorder),y,descendant of concept mapped from leaf
+94616006,Secondary malignant neoplasm of supraglottis (disorder),y,descendant of concept mapped from leaf
+93653006,Malignant melanoma of skin of upper limb (disorder),y,descendant of concept mapped from leaf
+94005003,Primary malignant neoplasm of shoulder (disorder),y,descendant of concept mapped from leaf
+443675005,Seminoma (disorder),y,descendant of concept mapped from leaf
+94399005,Secondary malignant neoplasm of main bronchus (disorder),y,descendant of concept mapped from leaf
+188544008,"Hodgkin's sarcoma of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+93987004,"Primary malignant neoplasm of retina, primary (disorder)",y,descendant of concept mapped from leaf
+448509007,Transglottic malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+399884001,Primary malignant neoplasm of blood vessel of upper arm (disorder),y,descendant of concept mapped from leaf
+415284008,Refractory anemia with excess blasts-2 (disorder),y,descendant of concept mapped from leaf
+94352003,Secondary malignant neoplasm of intrathoracic organs (disorder),y,descendant of concept mapped from leaf
+314975005,Local recurrence of malignant tumor of skin (disorder),y,descendant of concept mapped from leaf
+278491007,Mixed seminoma teratoma of testis (disorder),y,descendant of concept mapped from leaf
+369489005,Malignant tumor involving seminal vesicle by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+188135003,Malignant neoplasm of skin of heel (disorder),y,descendant of concept mapped from leaf
+188551004,Hodgkin's sarcoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+369571007,Malignant tumor involving right ovary by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+188133005,Malignant neoplasm of skin of lower leg (disorder),y,descendant of concept mapped from leaf
+448435005,Sarcoma lower inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+440501006,Siewert type II adenocarcinoma of esophagogastric junction (disorder),y,descendant of concept mapped from leaf
+400074007,Primary malignant neoplasm of blood vessel of lower leg (disorder),y,descendant of concept mapped from leaf
+93699008,Primary malignant neoplasm of blood vessel of head (disorder),y,descendant of concept mapped from leaf
+405822008,Squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+91860005,Acute myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+448378004,Sarcoma of bone of foot (disorder),y,descendant of concept mapped from leaf
+109967007,"Diffuse non-Hodgkin's lymphoma, small cleaved cell (disorder)",y,descendant of concept mapped from leaf
+188515006,Burkitt's lymphoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+285421005,Immunoglobulin G myeloma (disorder),y,descendant of concept mapped from leaf
+277617004,High grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+423121009,"Non-small cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+707704007,Primary squamous cell carcinoma of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+95209008,Plasma cell leukemia in remission (disorder),y,descendant of concept mapped from leaf
+698045009,Malignant melanoma of buccal mucosa (disorder),y,descendant of concept mapped from leaf
+93190006,Malignant histiocytosis of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+254631008,Giant cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+425657001,Osteosclerotic myeloma (disorder),y,descendant of concept mapped from leaf
+369576002,Malignant tumor involving uterine corpus by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+94620005,Secondary malignant neoplasm of tarsal bone (disorder),y,descendant of concept mapped from leaf
+698041000,Malignant melanoma of vestibule of mouth (disorder),y,descendant of concept mapped from leaf
+447389009,Leiomyosarcoma of uterus (disorder),y,descendant of concept mapped from leaf
+444911000,Acute myeloid leukemia with t(9:11)(p22;q23); MLLT3-MLL (disorder),y,descendant of concept mapped from leaf
+369507007,Malignant tumor involving vulva by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+94585007,Secondary malignant neoplasm of soft tissues of face (disorder),y,descendant of concept mapped from leaf
+188579005,"Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region and lower limb (disorder)",y,descendant of concept mapped from leaf
+722513008,Primary leiomyosarcoma of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+188665009,Mast cell malignancy of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+722229001,Primary sarcoma of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+370987005,Anaplastic astrocytoma of spinal cord (disorder),y,descendant of concept mapped from leaf
+449063007,Follicular non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+359785002,Metastatic malignant neoplasm to dome of urinary bladder (disorder),y,descendant of concept mapped from leaf
+354361000119107,Primary malignant neoplasm of right kidney (disorder),y,descendant of concept mapped from leaf
+369577006,Malignant tumor involving uterine corpus by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+303055001,"Malignant lymphoma, follicular center cell (disorder)",y,descendant of concept mapped from leaf
+369574004,Malignant tumor involving uterine cervix by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+763409006,Rhabdomyosarcoma of corpus uteri (disorder),y,descendant of concept mapped from leaf
+277664004,Malignant lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+449578008,Malignant neoplasm of alveolus of mandible (disorder),y,descendant of concept mapped from leaf
+94268006,Secondary malignant neoplasm of cubital lymph nodes (disorder),y,descendant of concept mapped from leaf
+1080261000119100,Infiltrating lobular carcinoma of left female breast (disorder),y,descendant of concept mapped from leaf
+372137005,Primary malignant neoplasm of breast (disorder),y,descendant of concept mapped from leaf
+369558009,Malignant tumor involving right fallopian tube by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+93545005,Hodgkin's paragranuloma of spleen (disorder),y,descendant of concept mapped from leaf
+369579009,Malignant tumor involving uterine corpus by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+721559007,Primary adenocarcinoma of common bile duct (disorder),y,descendant of concept mapped from leaf
+188100000,Malignant neoplasm of skin of temple (disorder),y,descendant of concept mapped from leaf
+721725005,Primary adenocarcinoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+94193003,Secondary malignant neoplasm of blood vessel of foot (disorder),y,descendant of concept mapped from leaf
+448666006,Follicular non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+371997009,Primary malignant neoplasm of lower gum (disorder),y,descendant of concept mapped from leaf
+94077005,Primary malignant neoplasm of submaxillary gland (disorder),y,descendant of concept mapped from leaf
+93991009,Primary malignant neoplasm of right lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+93670003,Primary malignant neoplasm of anterior aspect of epiglottis (disorder),y,descendant of concept mapped from leaf
+448259002,Sarcoma of posterior mediastinum (disorder),y,descendant of concept mapped from leaf
+93698000,Primary malignant neoplasm of blood vessel of hand (disorder),y,descendant of concept mapped from leaf
+404135007,Angiocentric natural killer/T-cell malignant lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+188568000,"Hodgkin's disease, nodular sclerosis of lymph nodes of axilla and upper limb (disorder)",y,descendant of concept mapped from leaf
+94349006,Secondary malignant neoplasm of intrahepatic bile ducts (disorder),y,descendant of concept mapped from leaf
+402527000,Basal cell carcinoma - infiltrative (disorder),y,descendant of concept mapped from leaf
+400058002,Secondary malignant neoplasm of blood vessel of lower leg (disorder),y,descendant of concept mapped from leaf
+705176003,Metastatic carcinoid tumor (disorder),y,descendant of concept mapped from leaf
+95224004,Reticulosarcoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+413446001,Adenocarcinoma of cecum (disorder),y,descendant of concept mapped from leaf
+399969009,Secondary malignant neoplasm of blood vessel of upper arm (disorder),y,descendant of concept mapped from leaf
+254792006,Proliferating angioendotheliomatosis (disorder),y,descendant of concept mapped from leaf
+93976007,Primary malignant neoplasm of pyloric antrum (disorder),y,descendant of concept mapped from leaf
+147101000119108,Primary malignant astrocytoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+421918000,"Papillary carcinoma, diffuse follicular (morphologic abnormality)",y,descendant of concept mapped from leaf
+448384001,Non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+93695002,Primary malignant neoplasm of blood vessel of finger (disorder),y,descendant of concept mapped from leaf
+307651005,Myelosclerosis with myeloid metaplasia (disorder),y,descendant of concept mapped from leaf
+94419008,Secondary malignant neoplasm of muscle of buttock (disorder),y,descendant of concept mapped from leaf
+254771006,Cutaneous leiomyosarcoma (disorder),y,descendant of concept mapped from leaf
+403903003,Signet ring squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+188572001,"Hodgkin's disease, nodular sclerosis of lymph nodes of multiple sites (disorder)",y,descendant of concept mapped from leaf
+253032007,Benign pheochromocytoma (disorder),y,descendant of concept mapped from leaf
+277568007,Hairy cell leukemia variant (disorder),y,descendant of concept mapped from leaf
+403911008,Nodulo-ulcerative basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+721303001,Refractory neutropenia (disorder),y,descendant of concept mapped from leaf
+724645006,T-cell hystiocyte rich large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+128791005,Dysplastic gangliocytoma of cerebellum (Lhermitte-Duclos) (morphologic abnormality),y,descendant of concept mapped from leaf
+707452003,Primary mucinous adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94549007,Secondary malignant neoplasm of skin of ear (disorder),y,descendant of concept mapped from leaf
+94098005,Primary malignant neoplasm of thyroid gland (disorder),y,descendant of concept mapped from leaf
+708504008,Periosteal osteosarcoma of jaw (disorder),y,descendant of concept mapped from leaf
+707400004,Primary mucinous adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+93729006,Primary malignant neoplasm of bronchus of left lower lobe (disorder),y,descendant of concept mapped from leaf
+402508006,Basal cell carcinoma of chin (disorder),y,descendant of concept mapped from leaf
+94474008,Secondary malignant neoplasm of parotid gland (disorder),y,descendant of concept mapped from leaf
+715412008,Familial malignant neoplasm of prostate (disorder),y,descendant of concept mapped from leaf
+721639004,Primary neuroendocrine carcinoma of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+277654008,Enteropathy-associated T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+448213004,Diffuse non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+93537000,Hodgkin's granuloma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+94123008,Primary malignant neoplasm of urethra (disorder),y,descendant of concept mapped from leaf
+403921000,Borderline malignant melanoma (disorder),y,descendant of concept mapped from leaf
+94596004,Secondary malignant neoplasm of soft tissues of upper limb (disorder),y,descendant of concept mapped from leaf
+369591000,Malignant tumor involving vulva by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+421283008,Primary lymphoma of brain associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+425048006,"Non-small cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+707410008,Primary solid carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+369483006,Malignant tumor involving vasa deferentia by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+716659002,Squamous cell carcinoma of head and neck (disorder),y,descendant of concept mapped from leaf
+447390000,Adenosarcoma of uterus (disorder),y,descendant of concept mapped from leaf
+128900005,"Mucinous cystadenocarcinoma, non-invasive (morphologic abnormality)",y,descendant of concept mapped from leaf
+369597001,Malignant tumor involving an organ by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+707344002,Primary adenocarcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+402518001,Basal cell carcinoma of lower back (disorder),y,descendant of concept mapped from leaf
+424938000,"Large cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+93515007,"Hodgkin's disease, nodular sclerosis of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+404104001,Lymphomatoid papulosis type B - mycosis fungoides-like (disorder),y,descendant of concept mapped from leaf
+372121004,Carcinoma of ribs and/or sternum and/or clavicle (disorder),y,descendant of concept mapped from leaf
+93746009,Primary malignant neoplasm of cerebellum (disorder),y,descendant of concept mapped from leaf
+93220006,Malignant melanoma of skin of ear (disorder),y,descendant of concept mapped from leaf
+369580007,Malignant tumor involving vagina by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+369530001,Secondary malignant neoplasm of right ovary (disorder),y,descendant of concept mapped from leaf
+93890009,Primary malignant neoplasm of Meckel's diverticulum (disorder),y,descendant of concept mapped from leaf
+20224008,Delta heavy chain disease (disorder),y,descendant of concept mapped from leaf
+404110001,Hypomelanotic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+369601001,Malignant tumor involving an organ by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+737058005,Microsatellite instability-high colorectal cancer (disorder),y,descendant of concept mapped from leaf
+398903003,Pleomorphic malignant fibrous histiocytoma of skin (disorder),y,descendant of concept mapped from leaf
+713325002,Primary cerebral lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+94496002,Secondary malignant neoplasm of posterior hypopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+448315008,Malignant epithelial neoplasm of anus (disorder),y,descendant of concept mapped from leaf
+94406009,Secondary malignant neoplasm of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+92514004,Burkitt's tumor of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+683991000119103,Extensive stage primary small cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93726004,Primary malignant neoplasm of brain stem (disorder),y,descendant of concept mapped from leaf
+733354000,Primary adenocarcinoma of biliary tract (disorder),y,descendant of concept mapped from leaf
+94440009,Secondary malignant neoplasm of scaphoid bone (disorder),y,descendant of concept mapped from leaf
+721697000,Primary neuroendocrine carcinoma of colon (disorder),y,descendant of concept mapped from leaf
+109951001,Overlapping malignant neoplasm of multiple endocrine glands (disorder),y,descendant of concept mapped from leaf
+423807009,Primary leiomyosarcoma (disorder),y,descendant of concept mapped from leaf
+109964000,"Diffuse non-Hodgkin's lymphoma, undifferentiated (disorder)",y,descendant of concept mapped from leaf
+369561005,Malignant tumor involving left ovary by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+372000001,Primary malignant neoplasm of minor salivary gland (disorder),y,descendant of concept mapped from leaf
+737310005,Primary squamous cell carcinoma of submandibular gland (disorder),y,descendant of concept mapped from leaf
+448664009,Malignant epithelial neoplasm of small intestine (disorder),y,descendant of concept mapped from leaf
+109977009,Peripheral T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+423615009,Adenoid cystic carcinoma of parotid gland (disorder),y,descendant of concept mapped from leaf
+445238008,Malignant carcinoid tumor (disorder),y,descendant of concept mapped from leaf
+307633009,"Hodgkin's disease, lymphocytic depletion, diffuse fibrosis (disorder)",y,descendant of concept mapped from leaf
+369487007,Primary malignant neoplasm of seminal vesicle (disorder),y,descendant of concept mapped from leaf
+369596005,Malignant tumor involving an organ by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+721635005,Primary malignant neuroendocrine neoplasm of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+815361000000107,Acute myeloid leukaemia with 11q23 abnormality (disorder),y,descendant of concept mapped from leaf
+717735006,Renal cell carcinoma of kidney except renal pelvis (disorder),y,descendant of concept mapped from leaf
+372019006,Primary malignant neoplasm of thoracic vertebral column (disorder),y,descendant of concept mapped from leaf
+1090231000000103,Malignant neoplasm of respiratory tract (disorder),y,descendant of concept mapped from leaf
+372119009,Primary malignant neoplasm of head of pancreas (disorder),y,descendant of concept mapped from leaf
+13351431000119102,Secondary malignant neoplasm of lymph nodes of neck from thyroid (disorder),y,descendant of concept mapped from leaf
+403918002,Basal cell carcinoma of glabella (disorder),y,descendant of concept mapped from leaf
+449156009,Malignant epithelial neoplasm of floor of mouth (disorder),y,descendant of concept mapped from leaf
+94332004,Secondary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+94565008,Secondary malignant neoplasm of skin of lower limb (disorder),y,descendant of concept mapped from leaf
+423600008,"Large cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+254710004,Basal cell carcinoma with eccrine differentiation (disorder),y,descendant of concept mapped from leaf
+93196000,Malignant lymphoma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+94171008,Secondary malignant neoplasm of anterior wall of urinary bladder (disorder),y,descendant of concept mapped from leaf
+277653002,Peripheral T-cell lymphoma - pleomorphic medium and large cell (disorder),y,descendant of concept mapped from leaf
+716855006,Theca steroid producing cell malignant neoplasm of ovary (disorder),y,descendant of concept mapped from leaf
+707535004,Primary squamous cell carcinoma of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+427685000,Human epidermal growth factor 2 positive carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+733362008,Primary adenocarcinoma of paraurethral gland (disorder),y,descendant of concept mapped from leaf
+723856003,Primary Ewing sarcoma of articular cartilage of rib (disorder),y,descendant of concept mapped from leaf
+1082071000119102,Primary squamous cell carcinoma of left ear (disorder),y,descendant of concept mapped from leaf
+93547002,Hodgkin's sarcoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+371962007,Primary malignant neoplasm of abdominal esophagus (disorder),y,descendant of concept mapped from leaf
+398623004,Refractory anemia with excess blasts (disorder),y,descendant of concept mapped from leaf
+403996004,Infantile fibrosarcoma (disorder),y,descendant of concept mapped from leaf
+94118008,Primary malignant neoplasm of upper respiratory tract (disorder),y,descendant of concept mapped from leaf
+764940002,Inherited acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+763477007,Primary lymphoma of conjunctiva (disorder),y,descendant of concept mapped from leaf
+94518002,Secondary malignant neoplasm of retromolar area (disorder),y,descendant of concept mapped from leaf
+402816008,Squamous cell carcinoma of anogenital area (disorder),y,descendant of concept mapped from leaf
+15635721000119108,Primary malignant neoplasm of both ovaries (disorder),y,descendant of concept mapped from leaf
+369518007,Malignant tumor involving left fallopian tube by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+402519009,Basal cell carcinoma of face (disorder),y,descendant of concept mapped from leaf
+721310007,Aggressive natural killer-cell leukemia (disorder),y,descendant of concept mapped from leaf
+94407000,Secondary malignant neoplasm of Meckel's diverticulum (disorder),y,descendant of concept mapped from leaf
+403897007,Squamous cell carcinoma of upper extremity (disorder),y,descendant of concept mapped from leaf
+733906003,Rosette-forming glioneuronal neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+94075002,Primary malignant neoplasm of subglottis (disorder),y,descendant of concept mapped from leaf
+369486003,Malignant tumor involving prostate by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+4135001,11p partial monosomy syndrome (disorder),y,descendant of concept mapped from leaf
+766759009,Rhabdomyosarcoma of vulva and vagina (disorder),y,descendant of concept mapped from leaf
+253046007,Malignant myomatous tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+313355000,Squamous cell carcinoma of bronchus in right lower lobe (disorder),y,descendant of concept mapped from leaf
+433067002,Adamantinoma of femur (disorder),y,descendant of concept mapped from leaf
+415177008,"Primary malignant neoplasm of ear, nose AND/OR throat (disorder)",y,descendant of concept mapped from leaf
+369509005,Malignant tumor involving vulva by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+710196003,Malignant odontogenic neoplasm of upper jaw (disorder),y,descendant of concept mapped from leaf
+93551000,"Hodgkin's sarcoma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+94094007,Primary malignant neoplasm of third cuneiform bone of foot (disorder),y,descendant of concept mapped from leaf
+94002000,Primary malignant neoplasm of septum of nose (disorder),y,descendant of concept mapped from leaf
+277589003,Atypical chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+94324007,Secondary malignant neoplasm of hard palate (disorder),y,descendant of concept mapped from leaf
+423699002,Enchondroma (morphologic abnormality),y,descendant of concept mapped from leaf
+93727008,Primary malignant neoplasm of brain (disorder),y,descendant of concept mapped from leaf
+94265009,Secondary malignant neoplasm of cornea (disorder),y,descendant of concept mapped from leaf
+93882009,Primary malignant neoplasm of main bronchus (disorder),y,descendant of concept mapped from leaf
+369450004,Malignant tumor involving rectum by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+446807009,Primary malignant neoplasm of perihilar bile duct (disorder),y,descendant of concept mapped from leaf
+109982002,Alpha heavy chain disease (disorder),y,descendant of concept mapped from leaf
+94672000,Secondary malignant neoplasm of ventral surface of tongue (disorder),y,descendant of concept mapped from leaf
+315006004,Metastasis from malignant tumor of lung (disorder),y,descendant of concept mapped from leaf
+369501008,Malignant tumor involving uterine cervix by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+449054005,Malignant epithelial neoplasm of fundus of uterus (disorder),y,descendant of concept mapped from leaf
+94709001,Mycosis fungoides of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+94370000,Secondary malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+403889000,Verrucous carcinoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+94719007,"Myeloid sarcoma, disease (disorder)",y,descendant of concept mapped from leaf
+448299004,Malignant neoplasm of mastoid (disorder),y,descendant of concept mapped from leaf
+94462009,Secondary malignant neoplasm of paraganglion (disorder),y,descendant of concept mapped from leaf
+109855006,Malignant mesothelioma of pelvic peritoneum (disorder),y,descendant of concept mapped from leaf
+93915004,Primary malignant neoplasm of myometrium (disorder),y,descendant of concept mapped from leaf
+93844001,Primary malignant neoplasm of isthmus of uterus (disorder),y,descendant of concept mapped from leaf
+93682007,Primary malignant neoplasm of upper arm (disorder),y,descendant of concept mapped from leaf
+109939003,Primary malignant neoplasm of peripheral nerves of hip (disorder),y,descendant of concept mapped from leaf
+404134006,Anaplastic large T-cell systemic malignant lymphoma (disorder),y,descendant of concept mapped from leaf
+369466002,Malignant tumor involving urethra by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+277549009,Chronic lymphocytic prolymphocytic leukemia syndrome (disorder),y,descendant of concept mapped from leaf
+447707005,Leiomyosarcoma of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+94017001,Primary malignant neoplasm of skin of ear (disorder),y,descendant of concept mapped from leaf
+403924008,Desmoplastic malignant melanoma (disorder),y,descendant of concept mapped from leaf
+723301009,Squamous non-small cell lung cancer (disorder),y,descendant of concept mapped from leaf
+109833003,"Overlapping malignant neoplasm of lip, oral cavity and/or pharynx (disorder)",y,descendant of concept mapped from leaf
+94509004,Secondary malignant neoplasm of rectosigmoid junction (disorder),y,descendant of concept mapped from leaf
+188531003,Hodgkin's paragranuloma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+118611004,Sézary's disease (disorder),y,descendant of concept mapped from leaf
+285420006,Immunoglobulin A myeloma (disorder),y,descendant of concept mapped from leaf
+302848008,"Nodular malignant lymphoma, lymphocytic - intermediate differentiation (disorder)",y,descendant of concept mapped from leaf
+397379005,Pineal parenchymal tumor of intermediate differentiation (morphologic abnormality),y,descendant of concept mapped from leaf
+440527006,Primary squamous cell carcinoma of naris (disorder),y,descendant of concept mapped from leaf
+94315003,Secondary malignant neoplasm of glans penis (disorder),y,descendant of concept mapped from leaf
+128735004,Desmoplastic small round cell tumor (morphologic abnormality),y,descendant of concept mapped from leaf
+764846009,Adenocarcinoma of penis (disorder),y,descendant of concept mapped from leaf
+722527003,Primary malignant neuroendocrine neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+93789008,Primary malignant neoplasm of exocervix (disorder),y,descendant of concept mapped from leaf
+254653005,Spindle cell squamous carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+402495002,Basal cell carcinoma of medial canthus (disorder),y,descendant of concept mapped from leaf
+94129007,Primary malignant neoplasm of uvula (disorder),y,descendant of concept mapped from leaf
+109389001,Kaposi's sarcoma of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+93694003,Primary malignant neoplasm of blood vessel of face (disorder),y,descendant of concept mapped from leaf
+397355008,"Dendritic cell sarcoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+254820002,Follicular atrophoderma and basal cell epitheliomata (disorder),y,descendant of concept mapped from leaf
+369548005,Malignant tumor involving right fallopian tube by direct extension from left fallopian tube (disorder),y,descendant of concept mapped from leaf
+448931007,Squamous cell carcinoma of shoulder (disorder),y,descendant of concept mapped from leaf
+448218008,Malignant neoplasm of cerebellopontine angle (disorder),y,descendant of concept mapped from leaf
+707379000,Primary mucoepidermoid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+408647009,Adenocarcinoma of stomach (disorder),y,descendant of concept mapped from leaf
+94182000,Secondary malignant neoplasm of axillary tail of female breast (disorder),y,descendant of concept mapped from leaf
+723845003,Primary chondrosarcoma of articular cartilage of pelvis (disorder),y,descendant of concept mapped from leaf
+61493004,Mu heavy chain disease (disorder),y,descendant of concept mapped from leaf
+93982005,Primary malignant neoplasm of rectovaginal septum (disorder),y,descendant of concept mapped from leaf
+762690000,Classical Hodgkin lymphoma (disorder),y,descendant of concept mapped from leaf
+699818003,T-cell large granular lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+188558005,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla and upper limb (disorder)",y,descendant of concept mapped from leaf
+449253005,Malignant epithelial neoplasm of hypothalamus (disorder),y,descendant of concept mapped from leaf
+372133009,Primary malignant neoplasm of upper limb bones and scapula (disorder),y,descendant of concept mapped from leaf
+420302007,Reticulosarcoma associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+766758001,Undifferentiated carcinoma of corpus uteri (disorder),y,descendant of concept mapped from leaf
+18121000119104,Primary squamous cell carcinoma of palatine tonsil (disorder),y,descendant of concept mapped from leaf
+721637002,Primary malignant neuroendocrine neoplasm of pyloric antrum of stomach (disorder),y,descendant of concept mapped from leaf
+421414006,"Papillary carcinoma, macrofollicular (morphologic abnormality)",y,descendant of concept mapped from leaf
+372120003,Carcinoma of main bronchus (disorder),y,descendant of concept mapped from leaf
+360331008,Rhabdomyosarcoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+93140007,Letterer-Siwe disease of spleen (disorder),y,descendant of concept mapped from leaf
+447011009,Mixed serous and mucinous cystadenocarcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+254654004,Acantholytic squamous cell carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+128753005,Stromal sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93208003,Malignant mast cell tumor of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+94667009,Secondary malignant neoplasm of uvula (disorder),y,descendant of concept mapped from leaf
+188746008,Subacute monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+118609008,"Hodgkin's disease, mixed cellularity (disorder)",y,descendant of concept mapped from leaf
+371977004,Primary malignant neoplasm of cecum (disorder),y,descendant of concept mapped from leaf
+414676007,Metastatic neuroblastoma of orbit proper (disorder),y,descendant of concept mapped from leaf
+369481008,Malignant tumor involving bladder by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+94648005,Secondary malignant neoplasm of trochlear nerve (disorder),y,descendant of concept mapped from leaf
+707492001,Primary squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+400175006,Myxofibrosarcoma of skin (disorder),y,descendant of concept mapped from leaf
+93710000,Primary malignant neoplasm of blood vessel of thorax (disorder),y,descendant of concept mapped from leaf
+93804008,Primary malignant neoplasm of forearm (disorder),y,descendant of concept mapped from leaf
+188099008,Malignant neoplasm of skin of nose (external) (disorder),y,descendant of concept mapped from leaf
+449153001,Adenocarcinoma of lower esophagus (disorder),y,descendant of concept mapped from leaf
+188536008,Hodgkin's granuloma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+67831000119107,"Primary small cell malignant neoplasm of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+94206007,Secondary malignant neoplasm of blood vessel of thigh (disorder),y,descendant of concept mapped from leaf
+93883004,Primary malignant neoplasm of major salivary gland (disorder),y,descendant of concept mapped from leaf
+1082221000119106,Primary squamous cell carcinoma of skin of right lower limb (disorder),y,descendant of concept mapped from leaf
+372002009,Primary malignant neoplasm of palate (disorder),y,descendant of concept mapped from leaf
+109923005,Primary malignant neoplasm of peripheral nerves of head (disorder),y,descendant of concept mapped from leaf
+254625005,Malignant tumor of lung parenchyma (disorder),y,descendant of concept mapped from leaf
+69408002,Gorlin syndrome (disorder),y,descendant of concept mapped from leaf
+93871001,Primary malignant neoplasm of long bone of lower limb (disorder),y,descendant of concept mapped from leaf
+352321000119107,Primary malignant neoplasm of soft tissue of left lower limb (disorder),y,descendant of concept mapped from leaf
+94293008,Secondary malignant neoplasm of face (disorder),y,descendant of concept mapped from leaf
+94241006,Secondary malignant neoplasm of cartilage of nose (disorder),y,descendant of concept mapped from leaf
+94340005,Secondary malignant neoplasm of inguinal region (disorder),y,descendant of concept mapped from leaf
+94231008,Secondary malignant neoplasm of bronchus of right middle lobe (disorder),y,descendant of concept mapped from leaf
+277632006,Diffuse malignant lymphoma - centroblastic polymorphic (disorder),y,descendant of concept mapped from leaf
+94386007,Secondary malignant neoplasm of lower limb (disorder),y,descendant of concept mapped from leaf
+404119000,Pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+93202002,Malignant mast cell tumor of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93885006,Primary malignant neoplasm of male genital organ (disorder),y,descendant of concept mapped from leaf
+721640002,Primary neuroendocrine carcinoma of body of stomach (disorder),y,descendant of concept mapped from leaf
+448738008,Non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+277474005,B-cell chronic lymphocytic leukemia variant (disorder),y,descendant of concept mapped from leaf
+447783007,Sarcoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+93962006,Primary malignant neoplasm of pineal gland (disorder),y,descendant of concept mapped from leaf
+733603009,Tubulocystic renal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+372065009,Malignant neoplasm of main bronchus (disorder),y,descendant of concept mapped from leaf
+372130007,Malignant neoplasm of skin (disorder),y,descendant of concept mapped from leaf
+1080241000119104,Infiltrating ductal carcinoma of upper outer quadrant of right female breast (disorder),y,descendant of concept mapped from leaf
+449318001,Non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+93909004,Primary malignant neoplasm of muscle of shoulder (disorder),y,descendant of concept mapped from leaf
+423425006,Malignant neoplasm of skin of eyelid (disorder),y,descendant of concept mapped from leaf
+95210003,"Plasma cell leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+94014008,Primary malignant neoplasm of skin of cheek (disorder),y,descendant of concept mapped from leaf
+423463003,Basal cell carcinoma of back (disorder),y,descendant of concept mapped from leaf
+187857006,Malignant neoplasm of carina of bronchus (disorder),y,descendant of concept mapped from leaf
+721636006,Primary malignant neuroendocrine neoplasm of body of stomach (disorder),y,descendant of concept mapped from leaf
+404118008,Syringotropic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+93733004,Primary malignant neoplasm of bronchus of right upper lobe (disorder),y,descendant of concept mapped from leaf
+302815008,Malignant tumor of frenum of lip (disorder),y,descendant of concept mapped from leaf
+93528000,Hodgkin's disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+93200005,Malignant mast cell tumor of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+427141003,Malignant lymphoma in remission (disorder),y,descendant of concept mapped from leaf
+94067008,Primary malignant neoplasm of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+424970000,"Large cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+449108003,Philadelphia chromosome positive chronic myelogenous leukemia (disorder),y,descendant of concept mapped from leaf
+99101000119101,Primary adenocarcinoma of fallopian tube (disorder),y,descendant of concept mapped from leaf
+402561003,Malignant melanoma of soft tissues (disorder),y,descendant of concept mapped from leaf
+449218003,Lymphoma of sigmoid colon (disorder),y,descendant of concept mapped from leaf
+369448007,Malignant tumor involving rectum by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+93898002,Primary malignant neoplasm of multiple endocrine glands (disorder),y,descendant of concept mapped from leaf
+302856006,Aleukemic leukemia (disorder),y,descendant of concept mapped from leaf
+92528005,Carcinoma in situ of adrenal medulla (disorder),y,descendant of concept mapped from leaf
+277609007,"Hodgkin's disease, lymphocytic predominance - diffuse (disorder)",y,descendant of concept mapped from leaf
+702405001,Malignant granulosa cell tumor of testis (disorder),y,descendant of concept mapped from leaf
+94636007,Secondary malignant neoplasm of tibial lymph nodes (disorder),y,descendant of concept mapped from leaf
+404156009,Leukemic infiltration of skin (disorder),y,descendant of concept mapped from leaf
+733355004,Primary adenocarcinoma of digestive organ (disorder),y,descendant of concept mapped from leaf
+447705002,Malignant germ cell neoplasm of posterior mediastinum (disorder),y,descendant of concept mapped from leaf
+373082000,Malignant neoplasm of breast upper inner quadrant (disorder),y,descendant of concept mapped from leaf
+733163007,Primary malignant neuroendocrine neoplasm of anal canal (disorder),y,descendant of concept mapped from leaf
+403927001,Malignant melanoma of nail apparatus (disorder),y,descendant of concept mapped from leaf
+369553000,Malignant tumor involving right fallopian tube by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+734033006,Mixed epithelial-mesenchymal hepatoblastoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94045007,Primary malignant neoplasm of skin of upper limb (disorder),y,descendant of concept mapped from leaf
+363493006,Malignant tumor of bronchus (disorder),y,descendant of concept mapped from leaf
+369533004,Malignant tumor involving right ovary by direct extension from left ovary (disorder),y,descendant of concept mapped from leaf
+707583001,Primary adenosquamous carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+128813000,Histiocytic sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+91131000119109,Primary adenocarcinoma of vulva (disorder),y,descendant of concept mapped from leaf
+403943008,Malignant chondroid syringoma of skin (disorder),y,descendant of concept mapped from leaf
+94497006,Secondary malignant neoplasm of posterior mediastinum (disorder),y,descendant of concept mapped from leaf
+721672004,Primary mucinous adenocarcinoma of appendix (disorder),y,descendant of concept mapped from leaf
+188517003,Burkitt's lymphoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+448712008,Sarcoma of femur (disorder),y,descendant of concept mapped from leaf
+705145009,Metastatic osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93141006,Letterer-Siwe disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+127225006,Chronic myelomonocytic leukemia (disorder),y,descendant of concept mapped from leaf
+94029005,Primary malignant neoplasm of skin of hip (disorder),y,descendant of concept mapped from leaf
+1091891000000106,B-cell Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+448229007,Leiomyosarcoma of lower esophagus (disorder),y,descendant of concept mapped from leaf
+369568004,Malignant tumor involving right ovary by separate metastasis from endometrium (disorder),y,descendant of concept mapped from leaf
+448354009,Non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+94536002,Secondary malignant neoplasm of short bone of upper limb (disorder),y,descendant of concept mapped from leaf
+93189002,Malignant histiocytosis of spleen (disorder),y,descendant of concept mapped from leaf
+93926005,Primary malignant neoplasm of nose (disorder),y,descendant of concept mapped from leaf
+285309005,Squamous cell carcinoma of skin of cheek (disorder),y,descendant of concept mapped from leaf
+403942003,Malignant eccrine spiradenoma of skin (disorder),y,descendant of concept mapped from leaf
+399887008,"Signet ring carcinoma, primary cutaneous (morphologic abnormality)",y,descendant of concept mapped from leaf
+93495008,"Hodgkin's disease, lymphocytic-histiocytic predominance of intrathoracic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+372128005,Malignant neoplasm of skin of upper limb (disorder),y,descendant of concept mapped from leaf
+94201002,Secondary malignant neoplasm of blood vessel of neck (disorder),y,descendant of concept mapped from leaf
+371999007,Primary malignant neoplasm of middle third of esophagus (disorder),y,descendant of concept mapped from leaf
+707402007,Primary adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+1078881000119102,Primary adenocarcinoma of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+402499008,Basal cell carcinoma of lateral side wall of nose (disorder),y,descendant of concept mapped from leaf
+307646004,"Malignant lymphoma, lymphocytic, poorly differentiated, nodular (disorder)",y,descendant of concept mapped from leaf
+369515005,Malignant tumor involving left fallopian tube by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+94525009,Secondary malignant neoplasm of round ligament of uterus (disorder),y,descendant of concept mapped from leaf
+95260009,"Sézary's disease of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+93226000,Malignant melanoma of skin of finger (disorder),y,descendant of concept mapped from leaf
+404089007,Extrarenal rhabdoid tumor (disorder),y,descendant of concept mapped from leaf
+402652009,Malignant vascular tumor of skin (disorder),y,descendant of concept mapped from leaf
+94153001,Secondary malignant neoplasm of abducens nerve (disorder),y,descendant of concept mapped from leaf
+707377003,Primary signet ring cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+116821000119104,Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of upper limb (disorder),y,descendant of concept mapped from leaf
+94356000,Secondary malignant neoplasm of jaw (disorder),y,descendant of concept mapped from leaf
+721563000,Primary malignant melanoma of vagina (disorder),y,descendant of concept mapped from leaf
+402559007,Congenital malignant melanoma (disorder),y,descendant of concept mapped from leaf
+352071000119105,Merkel cell carcinoma of left lower limb (disorder),y,descendant of concept mapped from leaf
+94237007,Secondary malignant neoplasm of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+707585008,Primary squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94116007,Primary malignant neoplasm of upper limb (disorder),y,descendant of concept mapped from leaf
+372010005,Primary malignant neoplasm of soft tissues (disorder),y,descendant of concept mapped from leaf
+707479004,Primary adenocarcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+432328008,Neuroblastoma (disorder),y,descendant of concept mapped from leaf
+402533009,Basal cell carcinoma with sebaceous differentiation (disorder),y,descendant of concept mapped from leaf
+724866001,Primary malignant neoplasm of skin due to and following radiotherapy caused by ionizing radiation (disorder),y,descendant of concept mapped from leaf
+713573006,Malignant carcinoid tumor of rectum (disorder),y,descendant of concept mapped from leaf
+109988003,Histiocytic sarcoma (disorder),y,descendant of concept mapped from leaf
+94468008,Secondary malignant neoplasm of paraurethral glands (disorder),y,descendant of concept mapped from leaf
+369522002,Primary malignant neoplasm of left ovary (disorder),y,descendant of concept mapped from leaf
+94207003,Secondary malignant neoplasm of blood vessel of thorax (disorder),y,descendant of concept mapped from leaf
+722688002,Malignant epithelial neoplasm (disorder),y,descendant of concept mapped from leaf
+93191005,Malignant lymphoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+94650002,Secondary malignant neoplasm of ulna (disorder),y,descendant of concept mapped from leaf
+766247009,Primitive neuroectodermal tumor of corpus uteri (disorder),y,descendant of concept mapped from leaf
+94569002,Secondary malignant neoplasm of skin of popliteal area (disorder),y,descendant of concept mapped from leaf
+369529006,Primary malignant neoplasm of right ovary (disorder),y,descendant of concept mapped from leaf
+369458006,Malignant tumor involving rectum by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+277641001,Follicular malignant lymphoma - large cell (disorder),y,descendant of concept mapped from leaf
+93192003,Malignant lymphoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+721622001,Primary adenocarcinoma of upper third of esophagus (disorder),y,descendant of concept mapped from leaf
+109962001,Diffuse non-Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+426370008,Subacute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+93918002,Primary malignant neoplasm of nasal concha (disorder),y,descendant of concept mapped from leaf
+722533007,Primary malignant neoplasm of esophagogastric junction (disorder),y,descendant of concept mapped from leaf
+400173004,Eccrine carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+721634009,Primary malignant neuroendocrine neoplasm of stomach (disorder),y,descendant of concept mapped from leaf
+762665002,Primary malignant neuroendocrine neoplasm of perihilar bile duct (disorder),y,descendant of concept mapped from leaf
+93505001,"Hodgkin's disease, mixed cellularity of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+234941000119100,Malignant glioma of eye (disorder),y,descendant of concept mapped from leaf
+94658009,Secondary malignant neoplasm of urachus (disorder),y,descendant of concept mapped from leaf
+94424006,Secondary malignant neoplasm of muscle of lower limb (disorder),y,descendant of concept mapped from leaf
+707670009,Pleuropulmonary blastoma (disorder),y,descendant of concept mapped from leaf
+94527001,Secondary malignant neoplasm of sacrum (disorder),y,descendant of concept mapped from leaf
+94450005,Secondary malignant neoplasm of oculomotor nerve (disorder),y,descendant of concept mapped from leaf
+449221001,Diffuse non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+764737005,Squamous cell carcinoma of corpus uteri (disorder),y,descendant of concept mapped from leaf
+372112000,"Primary malignant neoplasm of middle lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+109834009,Primary malignant neoplasm of branchial cleft (disorder),y,descendant of concept mapped from leaf
+93636004,Malignant melanoma of skin of hand (disorder),y,descendant of concept mapped from leaf
+424302003,Malignant melanoma of skin of lower lip (disorder),y,descendant of concept mapped from leaf
+93667002,Primary malignant neoplasm of alveolar ridge mucosa (disorder),y,descendant of concept mapped from leaf
+421686008,"Follicular carcinoma, clear cell (morphologic abnormality)",y,descendant of concept mapped from leaf
+369573005,Malignant tumor involving right ovary by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+94464005,Secondary malignant neoplasm of parametrial lymph nodes (disorder),y,descendant of concept mapped from leaf
+95192000,Nodular lymphoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+188570009,"Hodgkin's disease, nodular sclerosis of intrapelvic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+94463004,Secondary malignant neoplasm of paramammary lymph nodes (disorder),y,descendant of concept mapped from leaf
+707703001,Primary squamous cell carcinoma of postcricoid region (disorder),y,descendant of concept mapped from leaf
+399490008,Adenocarcinoma of prostate (disorder),y,descendant of concept mapped from leaf
+94486006,Secondary malignant neoplasm of phalanx of foot (disorder),y,descendant of concept mapped from leaf
+449065000,Diffuse non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+188642004,Malignant histiocytosis of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+448954003,Malignant epithelial neoplasm of urethra (disorder),y,descendant of concept mapped from leaf
+94090003,Primary malignant neoplasm of omentum (disorder),y,descendant of concept mapped from leaf
+402537005,Metastatic basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94466007,Secondary malignant neoplasm of pararectal lymph nodes (disorder),y,descendant of concept mapped from leaf
+369593002,Malignant tumor involving vulva by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+94556001,Secondary malignant neoplasm of skin of foot (disorder),y,descendant of concept mapped from leaf
+447738006,Paget's disease of skin of scrotum (disorder),y,descendant of concept mapped from leaf
+184871000119108,Primary adenocarcinoma of pelvis (disorder),y,descendant of concept mapped from leaf
+128912009,"Ganglioglioma, anaplastic (morphologic abnormality)",y,descendant of concept mapped from leaf
+94403001,Secondary malignant neoplasm of mandible (disorder),y,descendant of concept mapped from leaf
+403900000,Spindle cell squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+127070008,Malignant histiocytic disorder (disorder),y,descendant of concept mapped from leaf
+369559001,Malignant tumor involving left ovary by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+127220001,Malignant lymphoma of lymph nodes (disorder),y,descendant of concept mapped from leaf
+707409003,Primary acinar cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+702785000,Large cell anaplastic lymphoma T cell and Null cell type (disorder),y,descendant of concept mapped from leaf
+404070007,Round cell liposarcoma (disorder),y,descendant of concept mapped from leaf
+609515005,Epithelioid trophoblastic tumor (disorder),y,descendant of concept mapped from leaf
+94543008,Secondary malignant neoplasm of skin of back (disorder),y,descendant of concept mapped from leaf
+93142004,Leukemia in remission (disorder),y,descendant of concept mapped from leaf
+187868006,"Malignant neoplasm of lower lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+277643003,High grade T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+369511001,Malignant tumor involving vulva by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+448665005,Malignant epithelial neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+763884007,Splenic diffuse red pulp small B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+128913004,Retinocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+766935007,Primary bone lymphoma (disorder),y,descendant of concept mapped from leaf
+707430007,Overlapping squamous cell carcinoma of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+307341004,Atypical hairy cell leukemia (disorder),y,descendant of concept mapped from leaf
+707362006,Malignant melanoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+109879008,Overlapping malignant neoplasm of body of uterus (disorder),y,descendant of concept mapped from leaf
+371975007,Primary malignant neoplasm of border of tongue (disorder),y,descendant of concept mapped from leaf
+7391000119103,Primary adenoid cystic carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+402512000,Basal cell carcinoma of antitragus (disorder),y,descendant of concept mapped from leaf
+703228009,Non-small cell lung cancer with mutation in epidermal growth factor receptor (disorder),y,descendant of concept mapped from leaf
+277615007,Low grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+369608007,Malignant tumor involving an organ by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+404111002,Lymphomatoid papulosis-associated mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+93527005,Hodgkin's disease of spleen (disorder),y,descendant of concept mapped from leaf
+722519007,Primary sarcoma of peritoneum (disorder),y,descendant of concept mapped from leaf
+128774006,Intracortical osteosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94209000,Secondary malignant neoplasm of blood vessel of trunk (disorder),y,descendant of concept mapped from leaf
+721643000,Primary malignant mesenchymal neoplasm of stomach (disorder),y,descendant of concept mapped from leaf
+94079008,Primary malignant neoplasm of supraclavicular region (disorder),y,descendant of concept mapped from leaf
+93922007,Primary malignant neoplasm of neck (disorder),y,descendant of concept mapped from leaf
+447800002,Adenocarcinoma of scrotum (disorder),y,descendant of concept mapped from leaf
+9541000119105,Primary adenocarcinoma of gallbladder (disorder),y,descendant of concept mapped from leaf
+94524008,Secondary malignant neoplasm of right upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+420890002,Precursor T cell lymphoblastic leukemia/lymphoblastic lymphoma (disorder),y,descendant of concept mapped from leaf
+369575003,Malignant tumor involving uterine corpus by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+449058008,Follicular non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+721624000,Primary adenocarcinoma of overlapping lesion of esophagus (disorder),y,descendant of concept mapped from leaf
+93206004,Malignant mast cell tumor of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+402547008,Basal cell carcinoma - multiple recurrences (more than three times) (disorder),y,descendant of concept mapped from leaf
+448993007,Malignant epithelial neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+371966005,Primary malignant neoplasm of adrenal medulla (disorder),y,descendant of concept mapped from leaf
+94277004,Secondary malignant neoplasm of ectopic male breast tissue (disorder),y,descendant of concept mapped from leaf
+94128004,"Primary malignant neoplasm of uveal tract, primary (disorder)",y,descendant of concept mapped from leaf
+93669004,Primary malignant neoplasm of anal canal (disorder),y,descendant of concept mapped from leaf
+353661000119102,Overlapping primary malignant neoplasm of bone and articular cartilage of lower limb (disorder),y,descendant of concept mapped from leaf
+707584007,Primary lymphoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+423506005,Squamous cell carcinoma of external auditory canal (disorder),y,descendant of concept mapped from leaf
+93145002,Leukemic reticuloendotheliosis of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+404107008,Patch/plaque stage mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+447710003,Dermatofibrosarcoma protuberans of skin of shoulder (disorder),y,descendant of concept mapped from leaf
+94679009,Secondary malignant neoplasm of vocal cord (disorder),y,descendant of concept mapped from leaf
+423038006,Polymorphous low grade adenocarcinoma of salivary gland (disorder),y,descendant of concept mapped from leaf
+402501000,Basal cell carcinoma of supratip of nose (disorder),y,descendant of concept mapped from leaf
+187869003,Malignant neoplasm of lower lobe bronchus (disorder),y,descendant of concept mapped from leaf
+254620000,Squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+188585003,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+402879006,T-cell leukemic infiltration of skin (disorder),y,descendant of concept mapped from leaf
+369463005,Malignant tumor involving ureter by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+421246008,Precursor T-cell lymphoblastic lymphoma (disorder),y,descendant of concept mapped from leaf
+94076001,Primary malignant neoplasm of sublingual gland (disorder),y,descendant of concept mapped from leaf
+188504001,Lymphosarcoma of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+369541004,Malignant tumor involving left fallopian tube by direct extension from vagina (disorder),y,descendant of concept mapped from leaf
+94061009,Primary malignant neoplasm of soft tissues of shoulder (disorder),y,descendant of concept mapped from leaf
+449260004,Malignant neoplasm of alveolus dentalis (disorder),y,descendant of concept mapped from leaf
+402560002,Materno-fetal metastatic malignant melanoma (disorder),y,descendant of concept mapped from leaf
+418372008,Squamous cell carcinoma of mucous membrane of lower lip (disorder),y,descendant of concept mapped from leaf
+707423001,Primary basaloid carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+277637000,Large cell anaplastic lymphoma (disorder),y,descendant of concept mapped from leaf
+424887002,"Primary malignant neoplasm of thyroid gland, metastatic to bone (disorder)",y,descendant of concept mapped from leaf
+702786004,Follicular non-Hodgkin's lymphoma diffuse follicle center sub-type grade 1 (disorder),y,descendant of concept mapped from leaf
+254711000,Adenoid cystic eccrine carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+449634005,Primary malignant neoplasm of skin of lower leg (disorder),y,descendant of concept mapped from leaf
+404109006,Follicular mucinosis type mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+94047004,Primary malignant neoplasm of skin (disorder),y,descendant of concept mapped from leaf
+403898002,Squamous cell carcinoma of skin of lower extremity (disorder),y,descendant of concept mapped from leaf
+369456005,Malignant tumor involving rectum by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+448296006,Dermatofibrosarcoma protuberans of skin of chest (disorder),y,descendant of concept mapped from leaf
+707146006,Metastatic embryonal rhabdomyosarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93169003,Lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+369536007,Secondary neoplasm of right broad ligament (disorder),y,descendant of concept mapped from leaf
+734066005,Diffuse large B-cell lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+269475001,"Malignant tumor of lymphoid, hemopoietic AND/OR related tissue (disorder)",y,descendant of concept mapped from leaf
+94152006,Secondary malignant neoplasm of abdominal esophagus (disorder),y,descendant of concept mapped from leaf
+93905005,Primary malignant neoplasm of muscle of lower limb (disorder),y,descendant of concept mapped from leaf
+762457009,Astroblastoma of brain (disorder),y,descendant of concept mapped from leaf
+94107008,Primary malignant neoplasm of trapezoid bone (disorder),y,descendant of concept mapped from leaf
+94131003,Primary malignant neoplasm of vagus nerve (disorder),y,descendant of concept mapped from leaf
+277610002,"Hodgkin's disease, nodular sclerosis - lymphocytic predominance (disorder)",y,descendant of concept mapped from leaf
+94163009,Secondary malignant neoplasm of alveolar ridge mucosa (disorder),y,descendant of concept mapped from leaf
+443136000,Malignant neoplasm of skin of face (disorder),y,descendant of concept mapped from leaf
+352311000119100,Primary malignant neoplasm of soft tissue of right lower extremity (disorder),y,descendant of concept mapped from leaf
+369547000,Malignant tumor involving right fallopian tube by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+94036006,Primary malignant neoplasm of skin of perineum (disorder),y,descendant of concept mapped from leaf
+723265000,Primary squamous cell carcinoma of anus (disorder),y,descendant of concept mapped from leaf
+369531002,Malignant tumor involving right ovary by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+404128004,CD-30 negative cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94246001,Secondary malignant neoplasm of cerebral meninges (disorder),y,descendant of concept mapped from leaf
+94417005,Secondary malignant neoplasm of multiple endocrine glands (disorder),y,descendant of concept mapped from leaf
+93751003,Primary malignant neoplasm of cervical vertebral column (disorder),y,descendant of concept mapped from leaf
+403712008,Psoralen and long-wave ultraviolet radiation therapy-associated basal cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94043000,Primary malignant neoplasm of skin of trunk (disorder),y,descendant of concept mapped from leaf
+94461002,Secondary malignant neoplasm of para-aortic body (disorder),y,descendant of concept mapped from leaf
+313357008,Squamous cell carcinoma of bronchus in right upper lobe (disorder),y,descendant of concept mapped from leaf
+717922007,Well-differentiated neuroendocrine carcinoma of thymus (disorder),y,descendant of concept mapped from leaf
+109870007,Overlapping malignant neoplasm of urinary system (disorder),y,descendant of concept mapped from leaf
+21851000119103,Malignant pheochromocytoma (disorder),y,descendant of concept mapped from leaf
+118599009,Hodgkin's disease (disorder),y,descendant of concept mapped from leaf
+707472008,Primary papillary adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+25050002,"Alpha heavy chain disease, respiratory form (disorder)",y,descendant of concept mapped from leaf
+93843007,Primary malignant neoplasm of islets of Langerhans (disorder),y,descendant of concept mapped from leaf
+93150008,Leukemic reticuloendotheliosis of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+722683006,Primary neuroendocrine carcinoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+354621000119105,Overlapping primary malignant neoplasm of bone and articular cartilage of left upper limb (disorder),y,descendant of concept mapped from leaf
+733348001,Primary malignant neuroendocrine neoplasm of cystic duct (disorder),y,descendant of concept mapped from leaf
+93784003,Primary malignant neoplasm of epiglottis (disorder),y,descendant of concept mapped from leaf
+721548003,Primary malignant neoplasm of lacrimal apparatus (disorder),y,descendant of concept mapped from leaf
+94160007,Secondary malignant neoplasm of adrenal cortex (disorder),y,descendant of concept mapped from leaf
+699704002,Classic medulloblastoma (disorder),y,descendant of concept mapped from leaf
+369605005,Malignant tumor involving an organ by separate metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+352201000119105,Malignant melanoma of skin of left upper limb (disorder),y,descendant of concept mapped from leaf
+94652005,Secondary malignant neoplasm of upper gum (disorder),y,descendant of concept mapped from leaf
+369546009,Malignant tumor involving left fallopian tube by separate metastasis from vagina (disorder),y,descendant of concept mapped from leaf
+188524002,Hodgkin's paragranuloma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+722444002,Primary giant cell sarcoma of retroperitoneum (disorder),y,descendant of concept mapped from leaf
+722542000,Primary squamous cell carcinoma of anal canal (disorder),y,descendant of concept mapped from leaf
+1081751000119103,Primary sarcoma of right lower limb (disorder),y,descendant of concept mapped from leaf
+94435001,Secondary malignant neoplasm of nasal bone (disorder),y,descendant of concept mapped from leaf
+307617006,Neutrophilic leukemia (disorder),y,descendant of concept mapped from leaf
+188576003,"Hodgkin's disease, mixed cellularity of intrathoracic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+94108003,Primary malignant neoplasm of trigeminal nerve (disorder),y,descendant of concept mapped from leaf
+709191009,Metastatic papillary thyroid carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94635006,Secondary malignant neoplasm of tibia (disorder),y,descendant of concept mapped from leaf
+707339009,Primary adenocarcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+700488005,Malignant sex cord tumor of testis (disorder),y,descendant of concept mapped from leaf
+254948003,Astrocytoma of spinal cord (disorder),y,descendant of concept mapped from leaf
+449635006,Primary malignant neoplasm of lower leg (disorder),y,descendant of concept mapped from leaf
+402876004,Malignant tumor of nerve sheath origin (disorder),y,descendant of concept mapped from leaf
+12311000132101,Refractory acute lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+95264000,Sézary's disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+423050000,"Large cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+369565001,Malignant tumor involving left ovary by separate metastasis uterus (disorder),y,descendant of concept mapped from leaf
+93642000,Malignant melanoma of skin of neck (disorder),y,descendant of concept mapped from leaf
+91856007,Acute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+93705004,Primary malignant neoplasm of blood vessel of pelvis (disorder),y,descendant of concept mapped from leaf
+94507002,Secondary malignant neoplasm of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+369600000,Malignant tumor involving an organ by direct extension from uterus (disorder),y,descendant of concept mapped from leaf
+278051002,Malignant lymphoma of thyroid gland (disorder),y,descendant of concept mapped from leaf
+94354002,Secondary malignant neoplasm of islets of Langerhans (disorder),y,descendant of concept mapped from leaf
+735918005,Primary malignant neoplasm of lacrimal caruncle (disorder),y,descendant of concept mapped from leaf
+94472007,Secondary malignant neoplasm of parietal peritoneum (disorder),y,descendant of concept mapped from leaf
+369592007,Malignant tumor involving vulva by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+94401004,Secondary malignant neoplasm of male breast (disorder),y,descendant of concept mapped from leaf
+93944002,Primary malignant neoplasm of paraurethral glands (disorder),y,descendant of concept mapped from leaf
+94247005,Secondary malignant neoplasm of cerebral ventricle (disorder),y,descendant of concept mapped from leaf
+369485004,Malignant tumor involving prostate by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+254726003,Malignant skin tumor with apocrine differentiation (disorder),y,descendant of concept mapped from leaf
+1080231000119108,Infiltrating ductal carcinoma of upper inner quadrant of right female breast (disorder),y,descendant of concept mapped from leaf
+448371005,Non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+188748009,Aleukemic monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+94535003,Secondary malignant neoplasm of short bone of lower limb (disorder),y,descendant of concept mapped from leaf
+307637005,"Malignant lymphoma, centroblastic-centrocytic, follicular (disorder)",y,descendant of concept mapped from leaf
+440397000,Primary osteosarcoma of pelvis (disorder),y,descendant of concept mapped from leaf
+722953004,B-cell lymphoma unclassifiable with features intermediate between Burkitt lymphoma and diffuse large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+15635801000119106,Primary malignant neoplasm of bilateral female breasts (disorder),y,descendant of concept mapped from leaf
+91861009,"Acute myeloid leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+93931007,Primary malignant neoplasm of optic nerve (disorder),y,descendant of concept mapped from leaf
+422676009,Squamous cell carcinoma of ala nasi (disorder),y,descendant of concept mapped from leaf
+269617008,Secondary nodes - inguinal/leg (disorder),y,descendant of concept mapped from leaf
+285776004,Intermediate grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+188676008,Malignant lymphoma - mixed small and large cell (disorder),y,descendant of concept mapped from leaf
+94485005,Secondary malignant neoplasm of perirenal tissue (disorder),y,descendant of concept mapped from leaf
+277550009,Richter's syndrome (disorder),y,descendant of concept mapped from leaf
+1079111000119108,Primary basal cell carcinoma of left eyelid (disorder),y,descendant of concept mapped from leaf
+403458008,Localized skin involvement by breast carcinoma (disorder),y,descendant of concept mapped from leaf
+441313008,Indolent multiple myeloma (disorder),y,descendant of concept mapped from leaf
+372005006,Primary malignant neoplasm of penis (disorder),y,descendant of concept mapped from leaf
+404126000,CD-30 positive pleomorphic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+94429001,Secondary malignant neoplasm of muscle of thorax (disorder),y,descendant of concept mapped from leaf
+94430006,Secondary malignant neoplasm of muscle of trunk (disorder),y,descendant of concept mapped from leaf
+426885008,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head (disorder)",y,descendant of concept mapped from leaf
+847481000000109,Follicular lymphoma grade 1 (disorder),y,descendant of concept mapped from leaf
+94382009,Secondary malignant neoplasm of long bone of lower limb (disorder),y,descendant of concept mapped from leaf
+448553002,Lymphoma of pelvis (disorder),y,descendant of concept mapped from leaf
+236811000119101,Paget disease of anal canal (disorder),y,descendant of concept mapped from leaf
+94226006,Secondary malignant neoplasm of broad ligament (disorder),y,descendant of concept mapped from leaf
+94483003,Secondary malignant neoplasm of perianal skin (disorder),y,descendant of concept mapped from leaf
+400174005,Basal cell carcinoma of antihelix of ear (disorder),y,descendant of concept mapped from leaf
+699354006,Sarcoma of orbit (disorder),y,descendant of concept mapped from leaf
+93534007,Hodgkin's granuloma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+93749002,Primary malignant neoplasm of cerebrum (disorder),y,descendant of concept mapped from leaf
+713293002,Malignant germ cell neoplasm of mediastinum (disorder),y,descendant of concept mapped from leaf
+93712008,Primary malignant neoplasm of blood vessel of trunk (disorder),y,descendant of concept mapped from leaf
+188734009,Chronic neutrophilic leukemia (disorder),y,descendant of concept mapped from leaf
+707590006,Primary acinar cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94480000,Secondary malignant neoplasm of pelvis (disorder),y,descendant of concept mapped from leaf
+427492003,Hormone refractory prostate cancer (disorder),y,descendant of concept mapped from leaf
+388650006,Desmoplastic mesothelioma (morphologic abnormality),y,descendant of concept mapped from leaf
+94546000,Secondary malignant neoplasm of skin of cheek (disorder),y,descendant of concept mapped from leaf
+723846002,Primary chondrosarcoma of bone of rib (disorder),y,descendant of concept mapped from leaf
+359780007,Metastatic malignant neoplasm to lateral axillary lymph nodes (disorder),y,descendant of concept mapped from leaf
+93213004,Malignant melanoma of skin of axilla (disorder),y,descendant of concept mapped from leaf
+702346005,Chromosome 11p11.2 deletion syndrome (disorder),y,descendant of concept mapped from leaf
+1080151000119109,Infiltrating ductal carcinoma of upper inner quadrant of left female breast (disorder),y,descendant of concept mapped from leaf
+1079101000119105,Primary basal cell carcinoma of left ear (disorder),y,descendant of concept mapped from leaf
+402541009,Basal cell carcinoma recurrent following curettage (disorder),y,descendant of concept mapped from leaf
+446189008,Primary malignant neoplasm of extrahepatic bile duct (disorder),y,descendant of concept mapped from leaf
+402532004,Basal cell carcinoma with monster cells (disorder),y,descendant of concept mapped from leaf
+92527000,Carcinoma in situ of adrenal gland (disorder),y,descendant of concept mapped from leaf
+369589008,Malignant tumor involving vulva by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+94656008,Secondary malignant neoplasm of upper respiratory tract (disorder),y,descendant of concept mapped from leaf
+402871009,Malignant neoplasm of subcutaneous fibrous tissue (disorder),y,descendant of concept mapped from leaf
+699659007,Glandular malignant peripheral nerve sheath tumor (disorder),y,descendant of concept mapped from leaf
+99121000119105,Primary adenocarcinoma of vagina (disorder),y,descendant of concept mapped from leaf
+93521006,Hodgkin's disease of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+369607002,Malignant tumor involving an organ by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+371991005,Primary malignant neoplasm of hard palate (disorder),y,descendant of concept mapped from leaf
+733351008,Primary malignant neuroendocrine neoplasm of ampulla of Vater (disorder),y,descendant of concept mapped from leaf
+404120006,Localized pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+109992005,Polycythemia vera (disorder),y,descendant of concept mapped from leaf
+369569007,Malignant tumor involving right ovary by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+353741000119106,Secondary malignant neoplasm of left lung (disorder),y,descendant of concept mapped from leaf
+721632008,Primary adenocarcinoma of pyloric antrum of stomach (disorder),y,descendant of concept mapped from leaf
+93134000,Letterer-Siwe disease of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+188640007,"Malignant histiocytosis of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+449633004,Secondary malignant neoplasm of upper arm (disorder),y,descendant of concept mapped from leaf
+93543003,Hodgkin's paragranuloma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+188132000,Malignant neoplasm of skin of popliteal fossa area (disorder),y,descendant of concept mapped from leaf
+372104008,Carcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+447882007,Malignant epithelial neoplasm of vulva (disorder),y,descendant of concept mapped from leaf
+94255003,Secondary malignant neoplasm of ciliary body (disorder),y,descendant of concept mapped from leaf
+94154007,Secondary malignant neoplasm of accessory nerve (disorder),y,descendant of concept mapped from leaf
+94011000,Primary malignant neoplasm of skin of back (disorder),y,descendant of concept mapped from leaf
+403947009,Perianal Paget's disease (disorder),y,descendant of concept mapped from leaf
+94553009,Secondary malignant neoplasm of skin of eyelid (disorder),y,descendant of concept mapped from leaf
+373081007,Malignant neoplasm of breast lower outer quadrant (disorder),y,descendant of concept mapped from leaf
+373088001,Primary malignant neoplasm of breast upper outer quadrant (disorder),y,descendant of concept mapped from leaf
+277574007,Null cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+277624003,Follicular malignant lymphoma - mixed cell type (disorder),y,descendant of concept mapped from leaf
+449101009,Sarcoma of sternum (disorder),y,descendant of concept mapped from leaf
+93552007,Hodgkin's sarcoma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+722795004,Meningeal leukemia (disorder),y,descendant of concept mapped from leaf
+93494007,"Hodgkin's disease, lymphocytic-histiocytic predominance of intrapelvic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+372030009,Primary malignant neoplasm of vocal cord (disorder),y,descendant of concept mapped from leaf
+722517009,Primary malignant nerve sheath neoplasm of peripheral nervous system structure (disorder),y,descendant of concept mapped from leaf
+93700009,Primary malignant neoplasm of blood vessel of hip (disorder),y,descendant of concept mapped from leaf
+277613000,Cutaneous/peripheral T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+397079001,"Mucoepidermoid carcinoma, low grade (morphologic abnormality)",y,descendant of concept mapped from leaf
+733356003,Primary mucinous carcinoma of digestive organ (disorder),y,descendant of concept mapped from leaf
+448450001,Sarcoma of omentum (disorder),y,descendant of concept mapped from leaf
+188575004,"Hodgkin's disease, mixed cellularity of lymph nodes of head, face and neck (disorder)",y,descendant of concept mapped from leaf
+94037002,Primary malignant neoplasm of skin of popliteal area (disorder),y,descendant of concept mapped from leaf
+13048006,Orbital lymphoma (disorder),y,descendant of concept mapped from leaf
+722528008,Primary malignant neuroendocrine neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+863781000000100,Clinical stage C chronic lymphocytic leukaemia (disorder),y,descendant of concept mapped from leaf
+93506000,"Hodgkin's disease, mixed cellularity of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+94521000,Secondary malignant neoplasm of rib (disorder),y,descendant of concept mapped from leaf
+68979007,Heavy chain disease (disorder),y,descendant of concept mapped from leaf
+93549004,Hodgkin's sarcoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+93229007,Malignant melanoma of skin of forehead (disorder),y,descendant of concept mapped from leaf
+94300004,Secondary malignant neoplasm of femur (disorder),y,descendant of concept mapped from leaf
+277619001,B-cell prolymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+448212009,Anaplastic lymphoma kinase negative anaplastic large cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94502008,Secondary malignant neoplasm of presacral region (disorder),y,descendant of concept mapped from leaf
+94664002,Secondary malignant neoplasm of uterine adnexa (disorder),y,descendant of concept mapped from leaf
+109925003,Primary malignant neoplasm of peripheral nerves of face (disorder),y,descendant of concept mapped from leaf
+93768004,Primary malignant neoplasm of craniopharyngeal duct (disorder),y,descendant of concept mapped from leaf
+94522007,Secondary malignant neoplasm of right lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+94003005,Primary malignant neoplasm of short bone of lower limb (disorder),y,descendant of concept mapped from leaf
+278453007,Acute biphenotypic leukemia (disorder),y,descendant of concept mapped from leaf
+93900000,Primary malignant neoplasm of muscle of buttock (disorder),y,descendant of concept mapped from leaf
+92817004,Chronic myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+109933002,Primary malignant neoplasm of peripheral nerves of shoulder (disorder),y,descendant of concept mapped from leaf
+254898001,Paget's disease of vulva (disorder),y,descendant of concept mapped from leaf
+767448007,Pineoblastoma (disorder),y,descendant of concept mapped from leaf
+408643008,Infiltrating duct carcinoma of breast (disorder),y,descendant of concept mapped from leaf
+93960003,Primary malignant neoplasm of phalanx of hand (disorder),y,descendant of concept mapped from leaf
+94606003,Secondary malignant neoplasm of stomach (disorder),y,descendant of concept mapped from leaf
+707575007,Primary squamous cell carcinoma of supraglottis (disorder),y,descendant of concept mapped from leaf
+92515003,Burkitt's tumor of spleen (disorder),y,descendant of concept mapped from leaf
+94633004,Secondary malignant neoplasm of thyroglossal duct (disorder),y,descendant of concept mapped from leaf
+94135007,Primary malignant neoplasm of vermilion border of lip (disorder),y,descendant of concept mapped from leaf
+254707006,Malignant skin tumor with eccrine differentiation (disorder),y,descendant of concept mapped from leaf
+707591005,Primary mucoepidermoid carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+371983001,Primary malignant neoplasm of endocrine gland (disorder),y,descendant of concept mapped from leaf
+94259009,Secondary malignant neoplasm of coccyx (disorder),y,descendant of concept mapped from leaf
+369506003,Malignant tumor involving vagina by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+94240007,Secondary malignant neoplasm of carpal bone (disorder),y,descendant of concept mapped from leaf
+93984006,Primary malignant neoplasm of rectum (disorder),y,descendant of concept mapped from leaf
+766979005,Squamous cell carcinoma of rectum (disorder),y,descendant of concept mapped from leaf
+93989001,Primary malignant neoplasm of retromolar area (disorder),y,descendant of concept mapped from leaf
+425148008,Squamous cell carcinoma of temple (disorder),y,descendant of concept mapped from leaf
+94156009,Secondary malignant neoplasm of acoustic nerve (disorder),y,descendant of concept mapped from leaf
+448988009,Malignant epithelial neoplasm of nose (disorder),y,descendant of concept mapped from leaf
+733123006,Diffuse leptomeningeal glioneuronal neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+419240004,Squamous cell carcinoma of mucous membrane of upper lip (disorder),y,descendant of concept mapped from leaf
+722666002,Primary squamous cell carcinoma of lacrimal apparatus (disorder),y,descendant of concept mapped from leaf
+94367004,Secondary malignant neoplasm of laryngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+109995007,Myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+444910004,Primary mediastinal (thymic) large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+188738007,Granulocytic sarcoma (disorder),y,descendant of concept mapped from leaf
+93509007,"Hodgkin's disease, mixed cellularity of spleen (disorder)",y,descendant of concept mapped from leaf
+94054005,Primary malignant neoplasm of soft tissues of head (disorder),y,descendant of concept mapped from leaf
+384951004,Carcinoma of salivary gland type (morphologic abnormality),y,descendant of concept mapped from leaf
+93187000,Malignant histiocytosis of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+733350009,Primary malignant neuroendocrine of distal bile duct (disorder),y,descendant of concept mapped from leaf
+91858008,Acute monocytic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+93541001,Hodgkin's paragranuloma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+449219006,Follicular non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+738527001,Myeloid and/or lymphoid neoplasm associated with platelet derived growth factor receptor alpha rearrangement (disorder),y,descendant of concept mapped from leaf
+94582005,Secondary malignant neoplasm of soft tissues of abdomen (disorder),y,descendant of concept mapped from leaf
+303017006,"Malignant lymphoma, convoluted cell type (disorder)",y,descendant of concept mapped from leaf
+707395000,Primary adenocarcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+313428008,Seminoma of undescended testis (disorder),y,descendant of concept mapped from leaf
+733358002,Primary squamous cell carcinoma of respiratory system (disorder),y,descendant of concept mapped from leaf
+94445004,Secondary malignant neoplasm of nose (disorder),y,descendant of concept mapped from leaf
+369494005,Malignant tumor involving uterine corpus by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+94304008,Secondary malignant neoplasm of floor of mouth (disorder),y,descendant of concept mapped from leaf
+93828005,Primary malignant neoplasm of hypoglossal nerve (disorder),y,descendant of concept mapped from leaf
+109838007,Overlapping malignant neoplasm of colon (disorder),y,descendant of concept mapped from leaf
+93717002,Primary malignant neoplasm of body of stomach (disorder),y,descendant of concept mapped from leaf
+420519005,Malignant lymphoma of the eye region (disorder),y,descendant of concept mapped from leaf
+93857009,Primary malignant neoplasm of laryngeal commissure (disorder),y,descendant of concept mapped from leaf
+61301000119102,Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+721603005,Primary choriocarcinoma of testis (disorder),y,descendant of concept mapped from leaf
+765143008,Sporadic pheochromocytoma and secreting paraganglioma (disorder),y,descendant of concept mapped from leaf
+188501009,Lymphosarcoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+733848006,Anaplastic pleomorphic xanthoastrocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93911008,Primary malignant neoplasm of muscle of trunk (disorder),y,descendant of concept mapped from leaf
+707349007,Primary carcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+94568005,Secondary malignant neoplasm of skin of perineum (disorder),y,descendant of concept mapped from leaf
+93958000,Primary malignant neoplasm of perirenal tissue (disorder),y,descendant of concept mapped from leaf
+1661000119106,Metastasis to lung from adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+94318001,Secondary malignant neoplasm of glottis (disorder),y,descendant of concept mapped from leaf
+93690007,Primary malignant neoplasm of blood vessel of abdomen (disorder),y,descendant of concept mapped from leaf
+109822001,Overlapping malignant neoplasm of lip (disorder),y,descendant of concept mapped from leaf
+445406001,Hepatosplenic T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+721560002,Primary adenocarcinoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+188507008,Lymphosarcoma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+94258001,Secondary malignant neoplasm of coccygeal body (disorder),y,descendant of concept mapped from leaf
+253074002,Desmoplastic juvenile ganglioglioma (morphologic abnormality),y,descendant of concept mapped from leaf
+707384006,Primary solid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+402498000,Basal cell carcinoma of dorsum of nose (disorder),y,descendant of concept mapped from leaf
+404046008,Myxoid leiomyosarcoma of skin (disorder),y,descendant of concept mapped from leaf
+721699002,Primary adenocarcinoma of descending colon and splenic flexure (disorder),y,descendant of concept mapped from leaf
+732968009,Pheochromocytoma crisis (disorder),y,descendant of concept mapped from leaf
+403891008,Squamous cell carcinoma of scalp (disorder),y,descendant of concept mapped from leaf
+276751004,Amelanotic malignant melanoma of skin (disorder),y,descendant of concept mapped from leaf
+709031009,Malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+721555001,Follicular lymphoma of small intestine (disorder),y,descendant of concept mapped from leaf
+93660000,Primary malignant neoplasm of acoustic nerve (disorder),y,descendant of concept mapped from leaf
+399477001,Sarcomatoid mesothelioma (morphologic abnormality),y,descendant of concept mapped from leaf
+707532001,Primary squamous cell carcinoma of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+373168002,Reticulosarcoma (disorder),y,descendant of concept mapped from leaf
+737312002,Primary malignant neuroendocrine neoplasm of jejunum (disorder),y,descendant of concept mapped from leaf
+448221005,Sarcoma of fibula (disorder),y,descendant of concept mapped from leaf
+94500000,Secondary malignant neoplasm of posterior wall of urinary bladder (disorder),y,descendant of concept mapped from leaf
+438946002,Siewert type I adenocarcinoma of esophagogastric junction (disorder),y,descendant of concept mapped from leaf
+188541000,Hodgkin's granuloma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+109882003,Primary malignant neoplasm of fundus uteri (disorder),y,descendant of concept mapped from leaf
+94159002,Secondary malignant neoplasm of adnexa of skin (disorder),y,descendant of concept mapped from leaf
+94557005,Secondary malignant neoplasm of skin of forearm (disorder),y,descendant of concept mapped from leaf
+94176003,Secondary malignant neoplasm of areola of female breast (disorder),y,descendant of concept mapped from leaf
+93985007,Primary malignant neoplasm of renal pelvis (disorder),y,descendant of concept mapped from leaf
+277551008,Splenic lymphoma with villous lymphocytes (disorder),y,descendant of concept mapped from leaf
+92814006,"Chronic lymphoid leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+402531006,Basal cell carcinoma with granular cell change (disorder),y,descendant of concept mapped from leaf
+94686001,Mixed cell type lymphosarcoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+277618009,Follicular low grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+424849005,Primary sarcoma of tongue (disorder),y,descendant of concept mapped from leaf
+369581006,Malignant tumor involving vagina by separate metastasis from bladder (disorder),y,descendant of concept mapped from leaf
+735921007,Primary malignant neuroepithelial neoplasm of orbit (disorder),y,descendant of concept mapped from leaf
+188634000,Sézary's disease of lymph nodes of inguinal region and lower limb (disorder),y,descendant of concept mapped from leaf
+369465003,Malignant tumor involving urethra by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+421630008,"Papillary carcinoma, clear cell (morphologic abnormality)",y,descendant of concept mapped from leaf
+93876006,Primary malignant neoplasm of lower outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+735680008,Primary osteosarcoma (disorder),y,descendant of concept mapped from leaf
+717731002,Basal cell carcinoma of vulva (disorder),y,descendant of concept mapped from leaf
+93706003,Primary malignant neoplasm of blood vessel of perineum (disorder),y,descendant of concept mapped from leaf
+707399006,Primary papillary adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94180008,Secondary malignant neoplasm of axilla (disorder),y,descendant of concept mapped from leaf
+424549003,"Malignant tumor of spinal cord, extramedullary (disorder)",y,descendant of concept mapped from leaf
+94239005,Secondary malignant neoplasm of carotid body (disorder),y,descendant of concept mapped from leaf
+449073009,Malignant epithelial neoplasm of body of uterus (disorder),y,descendant of concept mapped from leaf
+402636006,Malignant neoplasm of nail apparatus (disorder),y,descendant of concept mapped from leaf
+274905008,"Malignant lymphoma - lymphocytic, intermediate differentiation (disorder)",y,descendant of concept mapped from leaf
+109971005,"Follicular non-Hodgkin's lymphoma, mixed small cleaved cell and large cell (disorder)",y,descendant of concept mapped from leaf
+94281004,Secondary malignant neoplasm of endometrium (disorder),y,descendant of concept mapped from leaf
+422572002,Squamous cell carcinoma of chin (disorder),y,descendant of concept mapped from leaf
+93793002,Primary malignant neoplasm of facial nerve (disorder),y,descendant of concept mapped from leaf
+402882001,Hodgkin's disease affecting skin (disorder),y,descendant of concept mapped from leaf
+402817004,Squamous cell carcinoma of nail apparatus (disorder),y,descendant of concept mapped from leaf
+726653000,Malignant carcinoid tumor of bronchus (disorder),y,descendant of concept mapped from leaf
+109370001,Primary malignant neoplasm of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+371134001,"Malignant lymphoma, large cell, polymorphous, immunoblastic (disorder)",y,descendant of concept mapped from leaf
+188733003,Chronic eosinophilic leukemia (disorder),y,descendant of concept mapped from leaf
+447885009,Sarcoma of pelvis (disorder),y,descendant of concept mapped from leaf
+372122006,Malignant neoplasm of skin head and neck (disorder),y,descendant of concept mapped from leaf
+93846004,Primary malignant neoplasm of jejunum (disorder),y,descendant of concept mapped from leaf
+422853008,Lymphoma of retroperitoneal space (disorder),y,descendant of concept mapped from leaf
+94068003,Primary malignant neoplasm of spinal cord (disorder),y,descendant of concept mapped from leaf
+369524001,Malignant tumor involving left ovary by direct extension from endometrium (disorder),y,descendant of concept mapped from leaf
+313250007,Malignant neoplasm of lower eyelid (disorder),y,descendant of concept mapped from leaf
+448436006,Sarcoma of central portion of female breast (disorder),y,descendant of concept mapped from leaf
+765741003,Adenocarcinoma of gallbladder and extrahepatic biliary tract (disorder),y,descendant of concept mapped from leaf
+404136008,Aggressive natural killer-cell leukemia involving skin (disorder),y,descendant of concept mapped from leaf
+721314003,Fibroblastic reticular cell neoplasm (disorder),y,descendant of concept mapped from leaf
+724554001,Primary malignant epithelial neoplasm of endocrine gland (disorder),y,descendant of concept mapped from leaf
+721604004,Primary squamous cell carcinoma of overlapping lesion of male genital organ (disorder),y,descendant of concept mapped from leaf
+447266004,Sarcoma of endometrium (disorder),y,descendant of concept mapped from leaf
+9395006,Sarcomatosis (morphologic abnormality),y,descendant of concept mapped from leaf
+231832009,Basal cell carcinoma of eyelid (disorder),y,descendant of concept mapped from leaf
+724647003,Diffuse large B-cell lymphoma co-occurrent with chronic inflammation caused by Epstein-Barr virus (disorder),y,descendant of concept mapped from leaf
+369504000,Malignant tumor involving vagina by direct extension from bladder (disorder),y,descendant of concept mapped from leaf
+352231000119103,Primary malignant neoplasm of soft tissue of left upper extremity (disorder),y,descendant of concept mapped from leaf
+737311009,Primary squamous cell carcinoma of sublingual gland (disorder),y,descendant of concept mapped from leaf
+277587001,Juvenile chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+93740003,Primary malignant neoplasm of carotid body (disorder),y,descendant of concept mapped from leaf
+93777006,Primary malignant neoplasm of ectopic male breast tissue (disorder),y,descendant of concept mapped from leaf
+94588009,Secondary malignant neoplasm of soft tissues of inguinal region (disorder),y,descendant of concept mapped from leaf
+91857003,"Acute lymphoid leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+352001000119100,Malignant melanoma of skin of right lower limb (disorder),y,descendant of concept mapped from leaf
+1082101000119106,Primary squamous cell carcinoma of skin of left lower limb (disorder),y,descendant of concept mapped from leaf
+448165009,Squamous cell carcinoma arising in chronic ulcer (disorder),y,descendant of concept mapped from leaf
+403977003,Angiosarcoma (disorder),y,descendant of concept mapped from leaf
+93845000,Primary malignant neoplasm of jaw (disorder),y,descendant of concept mapped from leaf
+94308006,Secondary malignant neoplasm of frontal bone (disorder),y,descendant of concept mapped from leaf
+94288005,Secondary malignant neoplasm of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+404071006,Pleomorphic liposarcoma (disorder),y,descendant of concept mapped from leaf
+703650004,"Phosphaturic mesenchymal tumor, malignant (morphologic abnormality)",y,descendant of concept mapped from leaf
+402819001,Basal cell carcinoma of skin of lip (disorder),y,descendant of concept mapped from leaf
+94562006,Secondary malignant neoplasm of skin of knee (disorder),y,descendant of concept mapped from leaf
+94027007,Primary malignant neoplasm of skin of groin (disorder),y,descendant of concept mapped from leaf
+440173001,Nonsquamous nonsmall cell neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+93809003,Primary malignant neoplasm of fundus of stomach (disorder),y,descendant of concept mapped from leaf
+369599003,Malignant tumor involving an organ by direct extension from uterine cervix (disorder),y,descendant of concept mapped from leaf
+254713002,Mucoepidermoid carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+369598006,Malignant tumor involving an organ by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+446578007,Endometrial stromal sarcoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+109984001,Gamma heavy chain disease (disorder),y,descendant of concept mapped from leaf
+93524003,"Hodgkin's disease of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+94212002,Secondary malignant neoplasm of body of pancreas (disorder),y,descendant of concept mapped from leaf
+369585002,Malignant tumor involving vagina by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+93803002,Primary malignant neoplasm of foot (disorder),y,descendant of concept mapped from leaf
+369471009,Malignant tumor involving bladder by direct extension from ovary (disorder),y,descendant of concept mapped from leaf
+448607004,Diffuse non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+716653001,Neuroendocrine carcinoma of thymus (disorder),y,descendant of concept mapped from leaf
+109975001,T-zone lymphoma (disorder),y,descendant of concept mapped from leaf
+372092003,Primary malignant neoplasm of axillary tail of breast (disorder),y,descendant of concept mapped from leaf
+764990003,Renal mucinous tubular and spindle cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94555002,Secondary malignant neoplasm of skin of finger (disorder),y,descendant of concept mapped from leaf
+404114005,Erythrodermic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+372001002,Primary malignant neoplasm of oral cavity (disorder),y,descendant of concept mapped from leaf
+93715005,Primary malignant neoplasm of body of pancreas (disorder),y,descendant of concept mapped from leaf
+404040002,Malignant Triton tumor (disorder),y,descendant of concept mapped from leaf
+128726006,"Endometrial stromal sarcoma, low grade (morphologic abnormality)",y,descendant of concept mapped from leaf
+369570008,Malignant tumor involving right ovary by separate metastasis from left ovary (disorder),y,descendant of concept mapped from leaf
+402524007,Basal cell carcinoma - adamantinoid (disorder),y,descendant of concept mapped from leaf
+94109006,Primary malignant neoplasm of trigone of urinary bladder (disorder),y,descendant of concept mapped from leaf
+93721009,Primary malignant neoplasm of bone of face (disorder),y,descendant of concept mapped from leaf
+93730001,Primary malignant neoplasm of bronchus of left upper lobe (disorder),y,descendant of concept mapped from leaf
+109357005,Primary malignant neoplasm of ill-defined site (disorder),y,descendant of concept mapped from leaf
+93936002,Primary malignant neoplasm of palatine bone (disorder),y,descendant of concept mapped from leaf
+94644007,Secondary malignant neoplasm of trapezium (disorder),y,descendant of concept mapped from leaf
+118602004,Hodgkin's granuloma (disorder),y,descendant of concept mapped from leaf
+93939009,Primary malignant neoplasm of pancreatic duct (disorder),y,descendant of concept mapped from leaf
+277622004,Mucosa-associated lymphoma (disorder),y,descendant of concept mapped from leaf
+93874009,Primary malignant neoplasm of lower inner quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+734014001,Clear cell papillary renal cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+188732008,Myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+404087009,Carcinosarcoma of skin (disorder),y,descendant of concept mapped from leaf
+707484005,Primary adenoid squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+1080341000119105,Infiltrating lobular carcinoma of right female breast (disorder),y,descendant of concept mapped from leaf
+254748009,Cutaneous fibrosarcoma (disorder),y,descendant of concept mapped from leaf
+721673009,Primary malignant neuroendocrine neoplasm of appendix (disorder),y,descendant of concept mapped from leaf
+93531004,Hodgkin's granuloma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+372105009,Carcinoma of supraglottis (disorder),y,descendant of concept mapped from leaf
+404047004,Cutaneous leiomyosarcoma with granular cell change (disorder),y,descendant of concept mapped from leaf
+1080191000119104,Infiltrating ductal carcinoma of central portion of right female breast (disorder),y,descendant of concept mapped from leaf
+373083005,Malignant neoplasm of breast upper outer quadrant (disorder),y,descendant of concept mapped from leaf
+707393007,Primary adenosquamous carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+93496009,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+402500004,Basal cell carcinoma of ala nasi (disorder),y,descendant of concept mapped from leaf
+352301000119103,Primary malignant neoplasm of soft tissue of right upper extremity (disorder),y,descendant of concept mapped from leaf
+94673005,Secondary malignant neoplasm of vermilion border of lip (disorder),y,descendant of concept mapped from leaf
+353561000119103,Secondary malignant neoplasm of right lung (disorder),y,descendant of concept mapped from leaf
+404016005,Giant cell malignant fibrous histiocytoma of skin (disorder),y,descendant of concept mapped from leaf
+703625002,Kaposi sarcoma not associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+94538001,Secondary malignant neoplasm of sigmoid colon (disorder),y,descendant of concept mapped from leaf
+93214005,Malignant melanoma of skin of back (disorder),y,descendant of concept mapped from leaf
+93775003,Primary malignant neoplasm of duodenum (disorder),y,descendant of concept mapped from leaf
+722718001,Primary malignant meningioma (disorder),y,descendant of concept mapped from leaf
+372103002,Carcinoma of glottis (disorder),y,descendant of concept mapped from leaf
+78411000119107,Ewing sarcoma of bone of pelvis (disorder),y,descendant of concept mapped from leaf
+93974005,Primary malignant neoplasm of prostate (disorder),y,descendant of concept mapped from leaf
+715414009,Familial malignant neoplasm of pancreas (disorder),y,descendant of concept mapped from leaf
+735920008,Primary malignant neuroepithelial neoplasm of ciliary body (disorder),y,descendant of concept mapped from leaf
+94213007,Secondary malignant neoplasm of body of penis (disorder),y,descendant of concept mapped from leaf
+109970006,"Follicular non-Hodgkin's lymphoma, small cleaved cell (disorder)",y,descendant of concept mapped from leaf
+443719001,Leiomyosarcoma (disorder),y,descendant of concept mapped from leaf
+449386007,Philadelphia chromosome negative chronic myelogenous leukemia (disorder),y,descendant of concept mapped from leaf
+92661009,Carcinoma in situ of multiple endocrine glands (disorder),y,descendant of concept mapped from leaf
+402558004,Malignant melanoma (vertical growth phase) (disorder),y,descendant of concept mapped from leaf
+96281000119107,Overlapping malignant neoplasm of colon and rectum (disorder),y,descendant of concept mapped from leaf
+448663003,Diffuse non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+369606006,Malignant tumor involving an organ by separate metastasis from prostate (disorder),y,descendant of concept mapped from leaf
+448139005,Fibrosarcoma of connective tissue (disorder),y,descendant of concept mapped from leaf
+721547008,Primary adenocarcinoma of epithelium of iris (disorder),y,descendant of concept mapped from leaf
+277571004,B-cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+94414003,Secondary malignant neoplasm of middle third of esophagus (disorder),y,descendant of concept mapped from leaf
+93646002,Malignant melanoma of skin of scalp (disorder),y,descendant of concept mapped from leaf
+93851005,Primary malignant neoplasm of labia minora (disorder),y,descendant of concept mapped from leaf
+441962003,Large cell lymphoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+733912008,Primary intraosseous squamous cell carcinoma derived from odontogenic cyst (morphologic abnormality),y,descendant of concept mapped from leaf
+421658000,"Papillary carcinoma, Warthin-like (morphologic abnormality)",y,descendant of concept mapped from leaf
+699317002,Paratesticular malignant neoplasm (disorder),y,descendant of concept mapped from leaf
+94711005,"Mycosis fungoides of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+94172001,Secondary malignant neoplasm of anus (disorder),y,descendant of concept mapped from leaf
+109965004,"Diffuse non-Hodgkin's lymphoma, lymphoblastic (disorder)",y,descendant of concept mapped from leaf
+93510002,"Hodgkin's disease, mixed cellularity of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+707427000,Primary verrucous carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+94670008,Secondary malignant neoplasm of vallecula (disorder),y,descendant of concept mapped from leaf
+276815004,Lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+716652006,Primary hepatic neuroendocrine carcinoma (disorder),y,descendant of concept mapped from leaf
+93902008,Primary malignant neoplasm of muscle of head (disorder),y,descendant of concept mapped from leaf
+722677008,Primary mesothelioma overlapping lesion of retroperitoneum peritoneum and omentum (disorder),y,descendant of concept mapped from leaf
+94230009,Secondary malignant neoplasm of bronchus of right lower lobe (disorder),y,descendant of concept mapped from leaf
+45221000119105,Primary invasive malignant neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+439478008,Siewert type III adenocarcinoma of esophagogastric junction (disorder),y,descendant of concept mapped from leaf
+93722002,Primary malignant neoplasm of bone of lower limb (disorder),y,descendant of concept mapped from leaf
+12246561000119101,Secondary malignant neoplasm of bilateral adrenal glands (disorder),y,descendant of concept mapped from leaf
+93216007,Malignant melanoma of skin of buttock (disorder),y,descendant of concept mapped from leaf
+93689003,Primary malignant neoplasm of bladder (disorder),y,descendant of concept mapped from leaf
+12240951000119107,Squamous cell carcinoma of left lung (disorder),y,descendant of concept mapped from leaf
+449211009,Malignant epithelial neoplasm of face (disorder),y,descendant of concept mapped from leaf
+372100004,Carcinoma of exocervix (disorder),y,descendant of concept mapped from leaf
+240531002,African Burkitt's lymphoma (disorder),y,descendant of concept mapped from leaf
+16260631000119101,Secondary malignant neoplasm of lymph node from neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+94387003,Secondary malignant neoplasm of lower outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+710195004,Malignant odontogenic neoplasm of lower jaw (disorder),y,descendant of concept mapped from leaf
+369538008,Malignant tumor involving left broad ligament by metastasis from ovary (disorder),y,descendant of concept mapped from leaf
+93986008,Primary malignant neoplasm of respiratory tract (disorder),y,descendant of concept mapped from leaf
+721304007,Refractory thrombocytopenia (disorder),y,descendant of concept mapped from leaf
+423189008,Adenoid cystic carcinoma of submandibular gland (disorder),y,descendant of concept mapped from leaf
+110002002,Mast cell leukemia (disorder),y,descendant of concept mapped from leaf
+93498005,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+94593007,Secondary malignant neoplasm of soft tissues of shoulder (disorder),y,descendant of concept mapped from leaf
+369583009,Malignant tumor involving vagina by separate metastasis from fallopian tube (disorder),y,descendant of concept mapped from leaf
+254727007,Extramammary Paget's disease of skin (disorder),y,descendant of concept mapped from leaf
+277604002,Acute eosinophilic leukemia (disorder),y,descendant of concept mapped from leaf
+402910001,Anogenital verrucous carcinoma of Buschke-Löwenstein (disorder),y,descendant of concept mapped from leaf
+277616008,Diffuse low grade B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94044006,Primary malignant neoplasm of skin of umbilicus (disorder),y,descendant of concept mapped from leaf
+109856007,Malignant mesothelioma of mesentery (disorder),y,descendant of concept mapped from leaf
+93221005,Malignant melanoma of skin of elbow (disorder),y,descendant of concept mapped from leaf
+94250008,Secondary malignant neoplasm of cervical vertebral column (disorder),y,descendant of concept mapped from leaf
+403954003,Mixed eccrine/pilar adnexal carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+402815007,Squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+94646009,Secondary malignant neoplasm of trigeminal nerve (disorder),y,descendant of concept mapped from leaf
+372116002,"Carcinoma of pelvic bones, sacrum and coccyx (disorder)",y,descendant of concept mapped from leaf
+397080003,"Mucoepidermoid carcinoma, intermediate grade (morphologic abnormality)",y,descendant of concept mapped from leaf
+94169008,Secondary malignant neoplasm of anterior two-thirds of tongue (disorder),y,descendant of concept mapped from leaf
+93679002,Primary malignant neoplasm of appendix (disorder),y,descendant of concept mapped from leaf
+369497003,Malignant tumor involving uterine cervix by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+94234000,Secondary malignant neoplasm of buccal mucosa (disorder),y,descendant of concept mapped from leaf
+707358000,Primary squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+403944002,Small cell eccrine carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+254794007,Angiosarcoma of skin (disorder),y,descendant of concept mapped from leaf
+187861000,Malignant neoplasm of upper lobe bronchus (disorder),y,descendant of concept mapped from leaf
+188672005,Follicular non-Hodgkin's mixed small cleaved and large cell lymphoma (disorder),y,descendant of concept mapped from leaf
+94162004,Secondary malignant neoplasm of adrenal medulla (disorder),y,descendant of concept mapped from leaf
+118617000,Burkitt's lymphoma (disorder),y,descendant of concept mapped from leaf
+94004004,Primary malignant neoplasm of short bone of upper limb (disorder),y,descendant of concept mapped from leaf
+93948004,Primary malignant neoplasm of parietal pleura (disorder),y,descendant of concept mapped from leaf
+699028006,Primitive neuroectodermal tumor (disorder),y,descendant of concept mapped from leaf
+94506006,Secondary malignant neoplasm of pylorus (disorder),y,descendant of concept mapped from leaf
+427038005,"Non-small cell lung cancer, negative for epidermal growth factor receptor expression (disorder)",y,descendant of concept mapped from leaf
+369610009,Malignant tumor involving left fallopian tube by separate metastasis from uterine cervix (disorder),y,descendant of concept mapped from leaf
+188502002,Lymphosarcoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+254651007,Squamous cell carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+94539009,Secondary malignant neoplasm of skin of abdomen (disorder),y,descendant of concept mapped from leaf
+95231000,Reticulosarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+94105000,Primary malignant neoplasm of transverse colon (disorder),y,descendant of concept mapped from leaf
+94447007,Secondary malignant neoplasm of occipital bone (disorder),y,descendant of concept mapped from leaf
+94148006,Megakaryocytic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+254622008,Squamous cell carcinoma of bronchus (disorder),y,descendant of concept mapped from leaf
+187853005,Malignant neoplasm of cartilage of trachea (disorder),y,descendant of concept mapped from leaf
+722686003,Primary serous carcinoma of uterine adnexa (disorder),y,descendant of concept mapped from leaf
+422378004,Squamous cell carcinoma of bridge of nose (disorder),y,descendant of concept mapped from leaf
+402562005,Malignant melanoma animal-type (disorder),y,descendant of concept mapped from leaf
+722511005,Primary rhabdomyosarcoma of respiratory organ (disorder),y,descendant of concept mapped from leaf
+94309003,Secondary malignant neoplasm of frontal lobe (disorder),y,descendant of concept mapped from leaf
+735678002,Primary chondrosarcoma of articular cartilage (disorder),y,descendant of concept mapped from leaf
+94423000,Secondary malignant neoplasm of muscle of inguinal region (disorder),y,descendant of concept mapped from leaf
+93709005,Primary malignant neoplasm of blood vessel of thigh (disorder),y,descendant of concept mapped from leaf
+445448008,Acute myeloid leukemia with myelodysplasia-related changes (disorder),y,descendant of concept mapped from leaf
+735735001,Primary malignant neuroendocrine neoplasm of pancreas (disorder),y,descendant of concept mapped from leaf
+277580004,Non-secretory myeloma (disorder),y,descendant of concept mapped from leaf
+427056005,Subacute leukemia in remission (disorder),y,descendant of concept mapped from leaf
+400122007,Primary cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+123313007,"Alpha heavy chain disease, enteric form (disorder)",y,descendant of concept mapped from leaf
+707347009,Primary carcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+93186009,"Malignant histiocytosis of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+372004005,Primary malignant neoplasm of parotid gland (disorder),y,descendant of concept mapped from leaf
+94589001,Secondary malignant neoplasm of soft tissues of lower limb (disorder),y,descendant of concept mapped from leaf
+277579002,Light chain myeloma (disorder),y,descendant of concept mapped from leaf
+404145009,Primary cutaneous anaplastic large cell B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+277573001,Common acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+1671000119100,Metastasis to lymph node from squamous cell carcinoma (disorder),y,descendant of concept mapped from leaf
+448952004,Infiltrating duct carcinoma of female breast (disorder),y,descendant of concept mapped from leaf
+402873007,Malignant fibrohistiocytic tumor of skin (disorder),y,descendant of concept mapped from leaf
+449216004,Diffuse non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+449416001,Malignant epithelial neoplasm of skin of anus (disorder),y,descendant of concept mapped from leaf
+423424005,Mucoepidermoid carcinoma of submandibular gland (disorder),y,descendant of concept mapped from leaf
+92818009,"Chronic myeloid leukemia, disease (disorder)",y,descendant of concept mapped from leaf
+408646000,Adenocarcinoma of liver (disorder),y,descendant of concept mapped from leaf
+93199007,Malignant lymphoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+402517006,Basal cell carcinoma of upper back (disorder),y,descendant of concept mapped from leaf
+93514006,"Hodgkin's disease, nodular sclerosis of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+93500006,"Hodgkin's disease, lymphocytic-histiocytic predominance of spleen (disorder)",y,descendant of concept mapped from leaf
+734035004,Epithelial variant hepatoblastoma (morphologic abnormality),y,descendant of concept mapped from leaf
+400057007,Basal cell carcinoma of pinnal sulcus (disorder),y,descendant of concept mapped from leaf
+404081005,Yolk sac tumor (disorder),y,descendant of concept mapped from leaf
+1082301000119109,Transitional cell carcinoma of right renal pelvis (disorder),y,descendant of concept mapped from leaf
+94655007,Secondary malignant neoplasm of upper outer quadrant of female breast (disorder),y,descendant of concept mapped from leaf
+371990006,Primary malignant neoplasm of gum (disorder),y,descendant of concept mapped from leaf
+449419008,Follicular non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+93864006,Primary malignant neoplasm of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+93761005,Primary malignant neoplasm of colon (disorder),y,descendant of concept mapped from leaf
+94157000,Secondary malignant neoplasm of acromion (disorder),y,descendant of concept mapped from leaf
+1081711000119104,Primary sarcoma of left lower limb (disorder),y,descendant of concept mapped from leaf
+369490001,Malignant tumor involving seminal vesicle by direct extension from prostate (disorder),y,descendant of concept mapped from leaf
+94631002,Secondary malignant neoplasm of thoracic esophagus (disorder),y,descendant of concept mapped from leaf
+109998009,Refractory anemia with ringed sideroblasts (disorder),y,descendant of concept mapped from leaf
+254638002,Pancoast tumor (disorder),y,descendant of concept mapped from leaf
+403917007,Basal cell carcinoma of temple (disorder),y,descendant of concept mapped from leaf
+94614009,Secondary malignant neoplasm of supraclavicular lymph nodes (disorder),y,descendant of concept mapped from leaf
+188641006,Malignant histiocytosis of lymph nodes of axilla and upper limb (disorder),y,descendant of concept mapped from leaf
+93652001,Malignant melanoma of skin of umbilicus (disorder),y,descendant of concept mapped from leaf
+94189009,Secondary malignant neoplasm of blood vessel of axilla (disorder),y,descendant of concept mapped from leaf
+414166008,"Extranodal natural killer/T-cell lymphoma, nasal type (disorder)",y,descendant of concept mapped from leaf
+449177007,Diffuse non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+93776002,Primary malignant neoplasm of ectopic female breast tissue (disorder),y,descendant of concept mapped from leaf
+427642009,T-cell acute lymphoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+423691004,Malignant neoplasm of gum and contiguous sites (disorder),y,descendant of concept mapped from leaf
+449293008,Sarcoma of connective tissue (disorder),y,descendant of concept mapped from leaf
+188559002,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region and lower limb (disorder)",y,descendant of concept mapped from leaf
+188691005,Malignant immunoproliferative small intestinal disease (disorder),y,descendant of concept mapped from leaf
+93998003,"Primary malignant neoplasm of sclera, primary (disorder)",y,descendant of concept mapped from leaf
+271944004,Clear cell sarcoma (morphologic abnormality),y,descendant of concept mapped from leaf
+699357004,Low grade endometrial stromal sarcoma (disorder),y,descendant of concept mapped from leaf
+447792005,Chondrosarcoma of bone (disorder),y,descendant of concept mapped from leaf
+94550007,Secondary malignant neoplasm of skin of elbow (disorder),y,descendant of concept mapped from leaf
+404141000,Primary cutaneous immunocytoma (disorder),y,descendant of concept mapped from leaf
+402514004,Basal cell carcinoma of obverse of pinna (disorder),y,descendant of concept mapped from leaf
+94272005,Secondary malignant neoplasm of diaphragm (disorder),y,descendant of concept mapped from leaf
+707469001,Primary non-mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+402497005,Basal cell carcinoma of root of nose (disorder),y,descendant of concept mapped from leaf
+445227008,Juvenile myelomonocytic leukemia (disorder),y,descendant of concept mapped from leaf
+94505005,Secondary malignant neoplasm of pyloric antrum (disorder),y,descendant of concept mapped from leaf
+93714009,Primary malignant neoplasm of blood vessel (disorder),y,descendant of concept mapped from leaf
+93912001,Primary malignant neoplasm of muscle of upper limb (disorder),y,descendant of concept mapped from leaf
+311779007,Malignant neoplasm of skin of scapular region (disorder),y,descendant of concept mapped from leaf
+402528005,Basal cell carcinoma - keratotic (disorder),y,descendant of concept mapped from leaf
+369449004,Malignant tumor involving rectum by direct extension from fallopian tube (disorder),y,descendant of concept mapped from leaf
+371976008,Primary malignant neoplasm of buccal mucosa (disorder),y,descendant of concept mapped from leaf
+369545008,Malignant tumor involving left fallopian tube by separate metastasis from uterus (disorder),y,descendant of concept mapped from leaf
+716651004,Leiomyosarcoma of small intestine (disorder),y,descendant of concept mapped from leaf
+93860002,Primary malignant neoplasm of lateral portion of floor of mouth (disorder),y,descendant of concept mapped from leaf
+402818009,Basal cell carcinoma of nose (disorder),y,descendant of concept mapped from leaf
+369544007,Malignant tumor involving left fallopian tube by separate metastasis from right fallopian tube (disorder),y,descendant of concept mapped from leaf
+763063001,Adenoid basal carcinoma of cervix uteri (disorder),y,descendant of concept mapped from leaf
+449074003,Lymphoma of small intestine (disorder),y,descendant of concept mapped from leaf
+188566001,"Hodgkin's disease, nodular sclerosis of intrathoracic lymph nodes (disorder)",y,descendant of concept mapped from leaf
+371993008,Primary malignant neoplasm of lacrimal gland (disorder),y,descendant of concept mapped from leaf
+93767009,Primary malignant neoplasm of cranial nerve (disorder),y,descendant of concept mapped from leaf
+269476000,Nodular lymphoma (disorder),y,descendant of concept mapped from leaf
+188592008,"Hodgkin's disease, lymphocytic depletion of spleen (disorder)",y,descendant of concept mapped from leaf
+307592006,Basophilic leukemia (disorder),y,descendant of concept mapped from leaf
+93203007,Malignant mast cell tumor of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+716649003,Extraovarian primary peritoneal carcinoma (disorder),y,descendant of concept mapped from leaf
+721617001,Primary adenocarcinoma of lower third of esophagus due to Barrett esophagus (disorder),y,descendant of concept mapped from leaf
+733345003,Primary squamous cell carcinoma of pharynx (disorder),y,descendant of concept mapped from leaf
+426248008,Aleukemic lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+1080161000119106,Infiltrating ductal carcinoma of upper outer quadrant of left female breast (disorder),y,descendant of concept mapped from leaf
+254731001,Nodular malignant melanoma of skin (disorder),y,descendant of concept mapped from leaf
+94426008,Secondary malignant neoplasm of muscle of pelvis (disorder),y,descendant of concept mapped from leaf
+94249008,Secondary malignant neoplasm of cervical esophagus (disorder),y,descendant of concept mapped from leaf
+94534004,Secondary malignant neoplasm of septum of nose (disorder),y,descendant of concept mapped from leaf
+702369008,Carcinosarcoma of uterus (disorder),y,descendant of concept mapped from leaf
+447782002,Malignant epithelial neoplasm of female breast (disorder),y,descendant of concept mapped from leaf
+94542003,Secondary malignant neoplasm of skin of axilla (disorder),y,descendant of concept mapped from leaf
+402564006,Multiple primary malignant melanomata (disorder),y,descendant of concept mapped from leaf
+94200001,Secondary malignant neoplasm of blood vessel of lower limb (disorder),y,descendant of concept mapped from leaf
+276738009,Primary signet ring carcinoma of skin (disorder),y,descendant of concept mapped from leaf
+94243009,Secondary malignant neoplasm of central nervous system (disorder),y,descendant of concept mapped from leaf
+93970001,Primary malignant neoplasm of posterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+128858006,Central neurocytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93533001,"Hodgkin's granuloma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+763131005,Clear cell adenocarcinoma of ovary (disorder),y,descendant of concept mapped from leaf
+703655009,Adenocarcinoma of rete ovarii (morphologic abnormality),y,descendant of concept mapped from leaf
+404112009,Granulomatous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+707391009,Primary papillary squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+764855007,Acute myeloid leukemia with CCAAT/enhancer binding protein alpha somatic mutation (disorder),y,descendant of concept mapped from leaf
+94323001,Secondary malignant neoplasm of hand (disorder),y,descendant of concept mapped from leaf
+94097000,Primary malignant neoplasm of thyroglossal duct (disorder),y,descendant of concept mapped from leaf
+424260006,Squamous cell carcinoma of nasolabial fold (disorder),y,descendant of concept mapped from leaf
+447785000,Leiomyosarcoma of stomach (disorder),y,descendant of concept mapped from leaf
+93523009,Hodgkin's disease of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+442771000000109,[X]Kaposi's sarcoma of multiple organs (disorder),n,via Query Table
+190056002,[M]Eosinophilic leukemia NOS (morphologic abnormality),n,via Query Table
+190043009,[M]Erythroleukemia NOS (morphologic abnormality),n,via Query Table
+451131000000102,[M]Liposarcoma NOS (morphologic abnormality),n,via Query Table
+428411000000106,[X]Secondary malignant neoplasm of other and unspecified parts of nervous system (disorder),n,via Query Table
+190033006,[M]Lymphoid leukemias (morphologic abnormality),n,via Query Table
+662451000000101,Sézary's disease NOS (disorder),n,via Query Table
+478881000000100,[X]Malignant neoplasm of overlapping lesion of other and ill-defined sites (disorder),n,via Query Table
+565591000000106,Secondary and unspecified malignant neoplasm of posterior mediastinal lymph nodes (disorder),n,via Query Table
+414711000000102,[X]Malignant neoplasm overlapping lesion of skin,n,via Query Table
+189687009,"[M]Papillary cystadenocarcinoma, NOS (morphologic abnormality)",n,via Query Table
+566531000000103,"Malignant neoplasm of oropharynx, other specified sites (disorder)",n,via Query Table
+15118008,AIDS with reticulosarcoma (disorder),n,via Query Table
+549571000000103,"Malignant neoplasm of bone, connective tissue, skin and breast NOS (disorder)",n,via Query Table
+543371000000108,Malignant neoplasm of nose NOS (disorder),n,via Query Table
+462711000000105,"[X]Malignant neoplasm of connective and soft tissue, unspecified (disorder)",n,via Query Table
+397621000000100,[M]Large cell carcinoma NOS (morphologic abnormality),n,via Query Table
+189606002,[M]Solid carcinoma NOS (morphologic abnormality),n,via Query Table
+573361000000100,"Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of head, face and neck (disorder)",n,via Query Table
+657351000000103,Ca rectum + Ca anus NOS (disorder),n,via Query Table
+634961000000107,Malignant neoplasm of small intestine NOS (disorder),n,via Query Table
+390391000000109,"[X]Mesothelioma, unspecified (disorder)",n,via Query Table
+833111000000100,Refractory anaemia with multilineage dysplasia,n,via Query Table
+427141000000104,[M]Chondromatous neoplasms (morphologic abnormality),n,via Query Table
+462341000000107,"[X]Malignant neoplasm of ill-defined, secondary and unspecified sites (disorder)",n,via Query Table
+411991000000107,[M]Hairy naevus NOS (morphologic abnormality),n,via Query Table
+578331000000104,Malignant neoplasm of connective and soft tissue of abdomen NOS (disorder),n,via Query Table
+189624000,[M]Villous adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+189672004,[M]Ceruminous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+449891000000106,[M]Mixed cell adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+190122006,[X]Malignant neoplasm of female genital organs (disorder),n,via Query Table
+420441000000109,[M]Acute myelofibrosis (morphologic abnormality),n,via Query Table
+538081000000104,Secondary and unspecified malignant neoplasm of inguinal and lower limb lymph nodes (disorder),n,via Query Table
+552141000000106,Malignant neoplasm of specified parts of peritoneum NOS (disorder),n,via Query Table
+426721000000108,[M]Pancreatic adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+93148000,"Leukemic reticuloendotheliosis of lymph nodes of head, face AND/OR neck (disorder)",n,via Query Table
+91859000,"Acute monocytic leukemia, FAB M5 (disorder)",n,via Query Table
+556071000000103,Other specified reticulosarcoma or lymphosarcoma (disorder),n,via Query Table
+437751000000102,[M]Mucinous cystadenocarcinoma NOS (morphologic abnormality),n,via Query Table
+575511000000109,Malignant neoplasm of long bones of leg NOS (disorder),n,via Query Table
+188196004,Malignant neoplasm of lower uterine segment (disorder),n,via Query Table
+190004005,[M]Mycosis fungoides NOS (morphologic abnormality),n,via Query Table
+463391000000108,[M]Precancerous melanosis NOS (morphologic abnormality),n,via Query Table
+189882001,[M] Small cell osteosarcoma (morphologic abnormality),n,via Query Table
+536201000000102,Secondary and unspecified malignant neoplasm of axillary lymph nodes (disorder),n,via Query Table
+187775000,Malignant neoplasm of intrahepatic biliary passages (disorder),n,via Query Table
+541711000000100,Secondary malignant neoplasm of large intestine or rectum NOS (disorder),n,via Query Table
+189850004,[M]Strumal neoplasms (morphologic abnormality),n,via Query Table
+408791000000100,[M]Leiomyosarcoma NOS (morphologic abnormality),n,via Query Table
+409651000000108,"[M]Carcinoma, anaplastic type, NOS (morphologic abnormality)",n,via Query Table
+188523008,"Hodgkin's paragranuloma of lymph nodes of head, face, and neck (disorder)",n,via Query Table
+461431000000101,[M]Signet ring carcinoma NOS (morphologic abnormality),n,via Query Table
+470351000000104,[M]Polycythemia vera (morphologic abnormality),n,via Query Table
+46347006,Squamous cell carcinoma of horn (morphologic abnormality),n,via Query Table
+408881000000106,[M]Cystadenocarcinoma NOS (morphologic abnormality),n,via Query Table
+189702009,[M]Signet ring carcinoma NOS (morphologic abnormality),n,via Query Table
+190111007,[X]Kaposi's sarcoma of multiple organs (disorder),n,via Query Table
+567711000000101,"Malignant neoplasm of upper lip, vermilion border NOS (disorder)",n,via Query Table
+248455008,Pheochromocytoma storm (finding),n,via Query Table
+425531000000108,"[X]Malignant neoplasm of connective and soft tissue of trunk, unspecified (disorder)",n,via Query Table
+189806000,[M]Mesenchymal nephroblastoma (morphologic abnormality),n,via Query Table
+292551000000103,[M] Refractory anaemia with excess of blasts,n,via Query Table
+276499003,[M]Hairy nevus NOS (morphologic abnormality),n,via Query Table
+556041000000109,Malignant neoplasm of pancreas NOS (disorder),n,via Query Table
+389871000000106,[M]Burkitt's tumours (morphologic abnormality),n,via Query Table
+190013007,[M]Angioendotheliomatosis (morphologic abnormality),n,via Query Table
+408381000000103,[M]Carcinoid tumours NOS (morphologic abnormality),n,via Query Table
+396181000000106,[X]Melanoma and other malignant neoplasms of skin (disorder),n,via Query Table
+534671000000104,Malignant neoplasm of fixed part of tongue NOS (disorder),n,via Query Table
+578171000000100,Malignant neoplasm of extrahepatic bile ducts NOS (disorder),n,via Query Table
+189933000,[M]Neuroepithelioma NOS (morphologic abnormality),n,via Query Table
+401123009,Cancer care review (regime/therapy),n,via Query Table
+538031000000103,Secondary and unspecified malignant neoplasm of axilla and upper limb lymph nodes (disorder),n,via Query Table
+408851000000100,[M]Adenocarcinoma in villous adenoma (morphologic abnormality),n,via Query Table
+575491000000101,Malignant neoplasm of hand bones NOS (disorder),n,via Query Table
+833341000000102,Follicular lymphoma grade 1,n,via Query Table
+189576006,[M]Transitional cell carcinoma NOS (morphologic abnormality),n,via Query Table
+557141000000108,Malignant neoplasm of heart NOS (disorder),n,via Query Table
+187852000,"Malignant neoplasm of trachea, bronchus and lung (disorder)",n,via Query Table
+634911000000105,Malignant neoplasm of other specified site of stomach (disorder),n,via Query Table
+189670007,[M]Sebaceous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+477501000000108,[M]Solid carcinoma NOS (morphologic abnormality),n,via Query Table
+190075007,[M]Monocytoid B-cell lymphoma (morphologic abnormality),n,via Query Table
+549551000000107,Malignant neoplasm of male breast NOS (disorder),n,via Query Table
+95258007,Sézary's disease of intrathoracic lymph nodes (disorder),n,via Query Table
+833401000000105,[M]Letterer - Siwe disease,n,via Query Table
+462401000000104,"[X]Malignant neoplasms of lymphoid, haematopoietic and related tissue (disorder)",n,via Query Table
+409571000000100,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+832561000000100,Malignant tumour of unknown origin,n,via Query Table
+579281000000102,Malignant neoplasm of genitourinary organ NOS (disorder),n,via Query Table
+832691000000107,Heavy chain disease,n,via Query Table
+464771000000108,"[X]Other specified malignant neoplasms of lymphoid, haematopoietic and related tissue (disorder)",n,via Query Table
+832671000000108,B-cell prolymphocytic leukaemia,n,via Query Table
+26328002,Disseminated eosinophilic collagen disease (disorder),n,via Query Table
+462371000000101,"[X]Refractory anemia, unspecified (disorder)",n,via Query Table
+450851000000105,[M]Sweat gland adenoma and adenocarcinomas (morphologic abnormality),n,via Query Table
+134174002,Malignant meningioma (morphologic abnormality),n,via Query Table
+409701000000100,[X]Secondary malignant neoplasm of bladder and other and unspecified urinary organs (disorder),n,via Query Table
+419641000000108,"[X]Kaposi's sarcoma, unspecified (disorder)",n,via Query Table
+396651000000108,[M]Angiomyoliposarcoma (morphologic abnormality),n,via Query Table
+189510008,Refractory anemia with sideroblasts (disorder),n,via Query Table
+478131000000106,[X]Malignant neoplasm of breast (disorder),n,via Query Table
+190050008,[M]Neutrophilic leukemia (morphologic abnormality),n,via Query Table
+421835000,Immunoblastic lymphoma associated with acquired immunodeficiency syndrome (disorder),n,via Query Table
+450201000000108,[M]Cerebellar sarcoma NOS (morphologic abnormality),n,via Query Table
+402761000000108,"[X]Refractory anaemia, unspecified",n,via Query Table
+549541000000109,Malignant neoplasm of other site of male breast (disorder),n,via Query Table
+190146004,[X]Secondary malignant neoplasm of other and unspecified digestive organs (disorder),n,via Query Table
+666541000000104,Malignant neoplasm of nasal cavities NOS (disorder),n,via Query Table
+778101000000109,Pigmented basal cell carcinoma,n,via Query Table
+833481000000100,[M]Adult T-cell leukaemia/lymphoma,n,via Query Table
+833581000000104,Non-Hodgkin's lymphoma - disorder,n,via Query Table
+634951000000109,Malignant neoplasm of stomach NOS (disorder),n,via Query Table
+189912009,"[M]Choroid plexus papilloma, malignant (morphologic abnormality)",n,via Query Table
+409171000000109,[X]Malignant neoplasm of urinary tract (disorder),n,via Query Table
+534781000000105,Malignant neoplasm of hypopharynx NOS (disorder),n,via Query Table
+438351000000100,[M]Cystadenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+404146005,Primary cutaneous diffuse large cell B-cell lymphoma of the leg (disorder),n,via Query Table
+451121000000104,[M]Mucinous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+564911000000107,Malignant neoplasm of inguinal region NOS (disorder),n,via Query Table
+634611000000102,Myeloid leukemia NOS (disorder),n,via Query Table
+537961000000106,Malignant neoplasm of floor of mouth NOS (disorder),n,via Query Table
+833451000000106,"Chronic myelogenous leukaemia, BCR/ABL positive",n,via Query Table
+432082001,Non-seminomatous malignant neoplasm of testis (disorder),n,via Query Table
+534691000000100,Malignant neoplasm of retroperitoneum and peritoneum NOS (disorder),n,via Query Table
+467201000000100,[X]Other sarcomas of the liver (disorder),n,via Query Table
+555741000000104,Malignant histiocytosis of unspecified site (disorder),n,via Query Table
+424621000000108,"[X]Malignant neoplasm of meninges, unspecified (disorder)",n,via Query Table
+396611000000109,[X]Malignant neoplasm of overlapping lesion of bone and articular cartilage (disorder),n,via Query Table
+422052002,Burkitt's lymphoma associated with acquired immunodeficiency syndrome (disorder),n,via Query Table
+400094003,Acquired melanocytic nevus (morphologic abnormality),n,via Query Table
+91113000,Avian sarcoma (disorder),n,via Query Table
+175621000000105,Cancer pain and symptom management,n,via Query Table
+566551000000105,Malignant neoplasm of oropharynx NOS (disorder),n,via Query Table
+190145000,[X]Secondary malignant neoplasm of other and unspecified respiratory organs (disorder),n,via Query Table
+546321000000103,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of multiple sites (disorder),n,via Query Table
+189777004,[M]Liposarcoma NOS (morphologic abnormality),n,via Query Table
+572591000000105,Malignant neoplasm of other site of female breast (disorder),n,via Query Table
+419471000000104,[M]Lymphosarcoma cell leukaemia,n,via Query Table
+134181009,[M] Immunoproliferative small intestinal disease (morphologic abnormality),n,via Query Table
+186723002,Human immunodeficiency virus disease resulting in Burkitt's lymphoma (disorder),n,via Query Table
+189713007,[M]Lobular carcinoma NOS (morphologic abnormality),n,via Query Table
+359777006,Metastatic malignant neoplasm to brachial lymph nodes (disorder),n,via Query Table
+189667008,[M]Sweat gland adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+425951000000108,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas (disorder),n,via Query Table
+634641000000101,Monocytic leukemia NOS (disorder),n,via Query Table
+189928004,[M]Ganglioneuromatous neoplasms (morphologic abnormality),n,via Query Table
+188528004,Hodgkin's paragranuloma of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+815141000000109,"Follicular lymphoma, cutaneous follicle centre (morphologic abnormality)",n,via Query Table
+555761000000103,Letterer-Siwe disease of unspecified sites (disorder),n,via Query Table
+269466003,Malignant tumor of bone and articular cartilage (disorder),n,via Query Table
+448673001,Malignant mixed Mullerian tumor of uterus (disorder),n,via Query Table
+543381000000105,Malignant neoplasm of jaw NOS (disorder),n,via Query Table
+478871000000102,[M]Medulloepithelioma NOS (morphologic abnormality),n,via Query Table
+534831000000100,Malignant neoplasm of pylorus of stomach NOS (disorder),n,via Query Table
+573671000000104,Malignant neoplasm of uterine adnexa NOS (disorder),n,via Query Table
+112684005,Mesodermal mixed tumor (morphologic abnormality),n,via Query Table
+396771000000108,"[X]Malignant neoplasm of uterine adnexa, unspecified (disorder)",n,via Query Table
+371985008,Primary malignant neoplasm of extrahepatic bile ducts (disorder),n,via Query Table
+190229005,"[X]Myelodysplastic syndrome, unspecified (disorder)",n,via Query Table
+134182002,[M]Polycythemia vera (morphologic abnormality),n,via Query Table
+833531000000103,"Extranodal natural killer/T-cell lymphoma, nasal type",n,via Query Table
+190167004,[X]Unspecified B-cell non-Hodgkin's lymphoma (disorder),n,via Query Table
+559181000000106,Malignant neoplasm of posterior wall of nasopharynx NOS (disorder),n,via Query Table
+478041000000103,"[X]Malignant neoplasm of mediastinum, part unspecified (disorder)",n,via Query Table
+543361000000101,Malignant neoplasm of cheek NOS (disorder),n,via Query Table
+396131000000107,[X]Malignant neoplasm of other and unspecified cranial nerves (disorder),n,via Query Table
+337241000000104,Clark melanoma level 3,n,via Query Table
+190127000,[X]Malignant neoplasm of male genital organs (disorder),n,via Query Table
+189626003,[M]Adenocarcinoma in villous adenoma (morphologic abnormality),n,via Query Table
+277648007,Angiocentric T-cell lymphoma (disorder),n,via Query Table
+471231000000108,"[M]Malignant lymphoma, mixed lymphocytic - histiocytic NOS (& [diffuse reticulolymphosarcoma])",n,via Query Table
+428031000000108,"[M]Mixed tumor, malignant, NOS (morphologic abnormality)",n,via Query Table
+439291000000106,[M]Neuroepitheliomatous neoplasm NOS (morphologic abnormality),n,via Query Table
+450051000000104,[X]Other types of follicular non-Hodgkin's lymphoma (disorder),n,via Query Table
+857651000000102,Local recurrence of malignant tumour of breast,n,via Query Table
+189926000,[M]Glioma NOS (morphologic abnormality),n,via Query Table
+558011000000107,Secondary and unspecified malignant neoplasm of intrathoracic lymph nodes (disorder),n,via Query Table
+569301000000105,Secondary and unspecified malignant neoplasm of submandibular lymph nodes (disorder),n,via Query Table
+409831000000100,[M]Ceruminous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+189663007,[M]Sweat gland adenoma and adenocarcinomas (morphologic abnormality),n,via Query Table
+190025005,[M]leukemia NOS (morphologic abnormality),n,via Query Table
+189669006,[M]Apocrine adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+312939009,Ocular lymphoma (disorder),n,via Query Table
+541661000000108,Secondary and unspecified malignant neoplasm of intrapelvic lymph nodes NOS (disorder),n,via Query Table
+396801000000106,[M]Sarcoma NOS (morphologic abnormality),n,via Query Table
+1054001000000101,Invasive carcinoma of uterine cervix co-occurrent with human immunodeficiency virus infection (disorder),n,via Query Table
+461841000000107,"[M]No microscopic confirmation of tumor, clinically malignant (morphologic abnormality)",n,via Query Table
+549601000000105,Malignant neoplasm of endocervix NOS (disorder),n,via Query Table
+561591000000109,Malignant neoplasm of eye NOS (disorder),n,via Query Table
+449741000000108,"[M]Mesothelioma, unspecified (morphologic abnormality)",n,via Query Table
+833571000000101,Angioimmunoblastic lymphadenopathy with dysproteinaemia,n,via Query Table
+556021000000102,Malignant neoplasm of other gallbladder and extrahepatic bile ducts (disorder),n,via Query Table
+477861000000105,"[X]Malignant neoplasm of bones and articular cartilage of limb, unspecified (disorder)",n,via Query Table
+190038002,[M]Plasma cell leukemias (morphologic abnormality),n,via Query Table
+188434008,Secondary malignant neoplasm of other respiratory organs (disorder),n,via Query Table
+408811000000104,[M]Adenomatous or adenocarcinomatous polyp NOS (morphologic abnormality),n,via Query Table
+189747005,[M]Nevi and melanomas (morphologic abnormality),n,via Query Table
+191333009,Essential thrombocytosis (disorder),n,via Query Table
+269567005,Ca trachea/bronchus/lung NOS (disorder),n,via Query Table
+439271000000107,[M]Mucinous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+396761000000101,[M]Tubular adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+338011000000108,Mucosa-associated lymphoma,n,via Query Table
+461891000000102,[M]Plasma cell leukaemia NOS (morphologic abnormality),n,via Query Table
+467071000000100,"[X]Malignant neoplasm, overlapping lesion of brain and other part of central nervous system (disorder)",n,via Query Table
+190040007,[M]Erythroleukemias (morphologic abnormality),n,via Query Table
+397451000000107,"[X]Malignant neoplasm of lymphoid, haematopoietic and related tissue, unspecified (disorder)",n,via Query Table
+615441000000105,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+534821000000102,Malignant neoplasm of cardia of stomach NOS (disorder),n,via Query Table
+561471000000109,Malignant neoplasm tonsil NOS (disorder),n,via Query Table
+734069003,Malignant peripheral nerve sheath neoplasm with perineurial differentiation (morphologic abnormality),n,via Query Table
+479011000000106,[M]Retinoblastomas (morphologic abnormality),n,via Query Table
+634921000000104,Malignant neoplasm of anterior wall of stomach NEC (disorder),n,via Query Table
+189587003,[M]Pancreatic adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+477541000000106,[X]Other myeloid leukaemia (morphologic abnormality),n,via Query Table
+833001000000103,Diffuse follicle centre lymphoma,n,via Query Table
+95259004,Sézary's disease of lymph nodes of axilla AND/OR upper limb (disorder),n,via Query Table
+437821000000100,[M]Small cell carcinoma NOS (morphologic abnormality),n,via Query Table
+413961000000100,[X]Other specified carcinomas of liver (disorder),n,via Query Table
+557101000000105,"Malignant neoplasm of lower lobe, bronchus or lung NOS (disorder)",n,via Query Table
+408871000000109,[M]Cystadenoma and carcinoma (morphologic abnormality),n,via Query Table
+424771000000103,[M]Comedocarcinoma NOS (morphologic abnormality),n,via Query Table
+463371000000109,"[M]Carcinoid tumor, nonargentaffin, malignant (morphologic abnormality)",n,via Query Table
+833441000000108,"Atypical chronic myeloid leukaemia, BCR/ABL negative",n,via Query Table
+533371000000109,Malignant neoplasm of cervix uteri NOS (disorder),n,via Query Table
+390271000000100,[X]Malignant neoplasm overlapping lesion of skin (disorder),n,via Query Table
+189802003,"[M]Mixed tumor, malignant, NOS (morphologic abnormality)",n,via Query Table
+84290008,Epithelioid hemangioendothelioma (morphologic abnormality),n,via Query Table
+93965008,Primary malignant neoplasm of placenta (disorder),n,via Query Table
+669301000000101,Malignant neoplasm of esophagus NOS (disorder),n,via Query Table
+189797009,[M]Myoma or myosarcoma NOS (morphologic abnormality),n,via Query Table
+389361000000109,[M]Erythroleukemias (morphologic abnormality),n,via Query Table
+634971000000100,Malignant neoplasm of other specified sites of colon (disorder),n,via Query Table
+190023003,[M]Burkitt's tumor NOS (morphologic abnormality),n,via Query Table
+419427007,Primary cutaneous large B-cell lymphoma of the leg (morphologic abnormality),n,via Query Table
+438401000000106,[M]Blue naevus NOS (morphologic abnormality),n,via Query Table
+461901000000101,"[X]Malignant melanoma of skin, unspecified (disorder)",n,via Query Table
+190222001,[X]Neoplasm of uncertain and unknown behavior of other myelodysplastic syndromes (disorder),n,via Query Table
+557691000000106,Burkitt's lymphoma of unspecified site (disorder),n,via Query Table
+537911000000109,Malignant neoplasm of other major salivary glands (disorder),n,via Query Table
+462951000000106,[M]Hepatobiliary adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+190110008,"[X]Mesothelioma, unspecified (disorder)",n,via Query Table
+189765009,[M]Sarcomatosis NOS (morphologic abnormality),n,via Query Table
+477471000000101,[M]Mesothelial neoplasms (morphologic abnormality),n,via Query Table
+462381000000104,[M]Carcinoid tumour NOS (morphologic abnormality),n,via Query Table
+285766002,Acute myeloblastic leukemia without maturation (disorder),n,via Query Table
+833391000000107,Cutaneous follicle centre lymphoma,n,via Query Table
+455551000000102,[M]Dermatofibrosarcoma NOS (qualifier value),n,via Query Table
+867941000000102,[M]Juvenile myelomonocytic leukaemia ,n,via Query Table
+188561006,"Hodgkin's, lymphocytic-histiocytic predominance of spleen (disorder)",n,via Query Table
+579221000000103,Malignant neoplasm of connective and soft tissue of hip and lower limb NOS (disorder),n,via Query Table
+542881000000106,Secondary and unspecified malignant neoplasm of superficial parotid lymph nodes (disorder),n,via Query Table
+480061000000108,[M]Chondroma NOS (morphologic abnormality),n,via Query Table
+543411000000107,Malignant neoplasm of supraclavicular fossa NOS (disorder),n,via Query Table
+698161000000105,Ca skin - other NOS (disorder),n,via Query Table
+553641000000108,Secondary and unspecified malignant neoplasm of intercostal lymph nodes (disorder),n,via Query Table
+190008008,[M] Peripheral T-cell lymphoma NOS (morphologic abnormality),n,via Query Table
+539581000000102,"Hodgkin's disease, lymphocytic depletion NOS (disorder)",n,via Query Table
+702741000000102,Secondary carcinoma of other specified sites (disorder),n,via Query Table
+190080003,"[M]No microscopic confirmation of tumor, clinically metastatic (morphologic abnormality)",n,via Query Table
+437761000000104,[X]Other lymphoid leukaemia (disorder),n,via Query Table
+189590009,[M]Hepatobiliary tract adenomas and carcinomas (morphologic abnormality),n,via Query Table
+634601000000104,Other myeloid leukemia NOS (disorder),n,via Query Table
+190149006,[X]Secondary malignant neoplasm of other specified sites (disorder),n,via Query Table
+442591000000102,[M]Malignant melanoma NOS (morphologic abnormality),n,via Query Table
+635021000000104,Primary malignant neoplasm of liver NOS (disorder),n,via Query Table
+389881000000108,[M]Mesothelial neoplasm NOS (morphologic abnormality),n,via Query Table
+277600006,Acute myeloblastic leukemia (disorder),n,via Query Table
+189840000,[M]Seminomas (morphologic abnormality),n,via Query Table
+875381000000107,[M]Peripheral neuroectodermal tumour,n,via Query Table
+189562005,[M]Papillary carcinoma NOS (morphologic abnormality),n,via Query Table
+472871000000100,[M] Gamma heavy chain disease (morphologic abnormality),n,via Query Table
+189790006,[M]Leiomyosarcoma NOS (morphologic abnormality),n,via Query Table
+757831000000107,Grade 1 (Stage pTa) papillary urothelial/transitional cell carcinoma,n,via Query Table
+666501000000102,Malignant neoplasm of tongue NOS (disorder),n,via Query Table
+425251000000104,"[M]Choroid plexus papilloma, malignant (morphologic abnormality)",n,via Query Table
+659491000000109,"Meckel's diverticulum, unspecified (disorder)",n,via Query Table
+271385002,"[X]Non-Hodgkin's lymphoma, unspecified type (disorder)",n,via Query Table
+534791000000107,"Malignant neoplasm of lip, oral cavity and pharynx NOS (disorder)",n,via Query Table
+533951000000104,Secondary malignant neoplasm of skin NOS (disorder),n,via Query Table
+403948004,Vulval Paget's disease (disorder),n,via Query Table
+670121000000109,Secondary nodes NOS (disorder),n,via Query Table
+94031001,Primary malignant neoplasm of skin of leg (disorder),n,via Query Table
+477571000000100,[M]Clear cell adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+557171000000102,Malignant neoplasm of other and ill-defined sites within the respiratory and intrathoracic organs (disorder),n,via Query Table
+438231000000101,"[X]Malignant neoplasm of female genital organ, unspecified (disorder)",n,via Query Table
+425541000000104,[M] Large cell lymphoma (morphologic abnormality),n,via Query Table
+833511000000106,True histiocytic lymphoma,n,via Query Table
+189608001,[M]Carcinoid tumor NOS (morphologic abnormality),n,via Query Table
+833691000000101,Hypereosinophilic syndrome,n,via Query Table
+190100004,"[X]Malignant neoplasm of bones and articular cartilage of limb, unspecified (disorder)",n,via Query Table
+541121000000107,Secondary and unspecified malignant neoplasm of superficial mesenteric lymph nodes (disorder),n,via Query Table
+189709000,[M]Comedocarcinoma NOS (morphologic abnormality),n,via Query Table
+190045002,[M]Lymphosarcoma cell leukemia (morphologic abnormality),n,via Query Table
+411561000000109,"[X]Kaposi's sarcoma, unspecified (disorder)",n,via Query Table
+408281000000107,[X]Other malignant immunoproliferative diseases (disorder),n,via Query Table
+450981000000106,[M]leukemia NOS (morphologic abnormality),n,via Query Table
+565911000000106,Malignant lymphoma NOS of intra-abdominal lymph nodes (disorder),n,via Query Table
+449731000000104,[M]Nevi or melanoma NOS (morphologic abnormality),n,via Query Table
+93212009,Malignant melanoma of skin of arm (disorder),n,via Query Table
+408491000000105,[M]Endometrioid adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+89277004,Noninfiltrating intracystic carcinoma (morphologic abnormality),n,via Query Table
+556171000000104,Secondary malignant neoplasm of other part of nervous system (disorder),n,via Query Table
+190141009,"[X]Malignant neoplasm of ill-defined, secondary and unspecified sites (disorder)",n,via Query Table
+541701000000102,Secondary malignant neoplasm of small intestine or duodenum NOS (disorder),n,via Query Table
+255116009,Secondary carcinoma of respiratory and/or digestive systems (disorder),n,via Query Table
+188521005,Hodgkin's paragranuloma (disorder),n,via Query Table
+397421000000102,[M]Ganglioneuromatous neoplasm NOS (morphologic abnormality),n,via Query Table
+573471000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of spleen (disorder),n,via Query Table
+550101000000109,Malignant neoplasm of trachea NOS (disorder),n,via Query Table
+663631000000101,"Malignant neoplasm of lower lip, vermilion border NOS (disorder)",n,via Query Table
+1025781000000106,Recurrent squamous cell carcinoma (disorder),n,via Query Table
+956461000000105,Malignant Melanoma Stage IIIB ,n,via Query Table
+478091000000108,[M]Brenner tumour NOS (morphologic abnormality),n,via Query Table
+188527009,Hodgkin's paragranuloma of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+663641000000105,"Malignant neoplasm of upper lip, inner aspect NOS (disorder)",n,via Query Table
+440781000000105,[M]Glioblastoma NOS (morphologic abnormality),n,via Query Table
+189843003,[M]Embryonal carcinoma NOS (morphologic abnormality),n,via Query Table
+438191000000105,[X]Malignant neoplasm of other specified sites (disorder),n,via Query Table
+269468002,Malignant neoplasm of short bones of leg (disorder),n,via Query Table
+666481000000106,Malignant neoplasm of anterior 2/3 of tongue unspecified (disorder),n,via Query Table
+337691000000107,Clark melanoma level 4,n,via Query Table
+42215000,Solitary osseous myeloma (disorder),n,via Query Table
+455391000000100,[M]Hodgkin's disease NOS (& [lymphogranuloma malignant]),n,via Query Table
+478231000000103,"[M]No microscopic confirmation of tumor, clinically metastatic (morphologic abnormality)",n,via Query Table
+396821000000102,"[X]Malignant neoplasm - pluriglandular involvement, unspecified (disorder)",n,via Query Table
+414451000000109,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas,n,via Query Table
+190108006,[X]Malignant neoplasm of mesothelial and soft tissue (disorder),n,via Query Table
+77865003,AIDS with Kaposi's sarcoma (disorder),n,via Query Table
+540311000000106,Malignant neoplasm of skin NOS (disorder),n,via Query Table
+540261000000104,Malignant neoplasm of scalp or skin of neck NOS (disorder),n,via Query Table
+687931000000101,Lymphoid and histiocytic malignancy NOS (disorder),n,via Query Table
+698181000000101,Ca cervix uteri NOS (disorder),n,via Query Table
+559881000000101,Malignant neoplasm of anterior wall of nasopharynx NOS (disorder),n,via Query Table
+570621000000109,Malignant neoplasm of labia majora NOS (disorder),n,via Query Table
+533391000000108,Malignant neoplasm of isthmus of uterine body NOS (disorder),n,via Query Table
+573661000000106,Malignant neoplasm of scapula and long bones of upper arm NOS (disorder),n,via Query Table
+468691000000106,[M]Other myeloid leukaemia NOS (morphologic abnormality),n,via Query Table
+189699002,[M]Mucinous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+541741000000104,Secondary malignant neoplasm of other urinary organs (disorder),n,via Query Table
+536941000000107,Secondary and unspecified malignant neoplasm of obturator lymph nodes (disorder),n,via Query Table
+832531000000105,Juvenile myelomonocytic leukaemia,n,via Query Table
+190120003,[X]Kaposi's sarcoma of other sites (disorder),n,via Query Table
+189976003,[M]Malignant lymphomatous polyposis (morphologic abnormality),n,via Query Table
+189993003,"Lymphoma, nodular or follicular (morphologic abnormality)",n,via Query Table
+770531000000106,Pigmented basal cell carcinoma (morphologic abnormality),n,via Query Table
+634981000000103,"Malignant neoplasm of other sites of rectum, rectosigmoid junction and anus (disorder)",n,via Query Table
+427151000000101,[M]Chondrosarcoma NOS (morphologic abnormality),n,via Query Table
+397141000000100,"[X]Malignant neoplasm of eye, brain and other parts of central nervous system (disorder)",n,via Query Table
+189603005,[M]Tubular adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+543401000000105,Malignant neoplasm of neck NOS (disorder),n,via Query Table
+478211000000106,[M]Spongioblastoma NOS (morphologic abnormality),n,via Query Table
+572201000000101,Hodgkin's sarcoma of unspecified site (disorder),n,via Query Table
+443501000000104,[M]Subacute myeloid leukaemia (disorder),n,via Query Table
+189596003,[M]Adenomatous and adenocarcinomatous polyps (morphologic abnormality),n,via Query Table
+704441000000101,"Malignant neoplasm of lip, unspecified (disorder)",n,via Query Table
+396161000000102,[M] Epithelioid haemangioendothelioma NOS (morphologic abnormality),n,via Query Table
+546871000000108,Malignant melanoma of other specified skin site (disorder),n,via Query Table
+734933008,Malignant pigmented skin lesion (finding),n,via Query Table
+559871000000103,Malignant neoplasm of lateral wall of nasopharynx NOS (disorder),n,via Query Table
+395671000000107,[M] Alpha heavy chain disease (morphologic abnormality),n,via Query Table
+535821000000103,Secondary and unspecified malignant neoplasm of bronchopulmonary lymph nodes (disorder),n,via Query Table
+815271000000105,"Chronic myeloid leukaemia, BCR/ABL-positive (morphologic abnormality)",n,via Query Table
+833081000000108,"Refractory anaemia without sideroblasts, so stated",n,via Query Table
+189627007,[M]Villous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+189756002,[M]Spindle cell melanoma NOS (morphologic abnormality),n,via Query Table
+537921000000103,Malignant neoplasm of major salivary gland NOS (disorder),n,via Query Table
+956481000000101,Malignant Melanoma Stage IIIC ,n,via Query Table
+188623003,Mycosis fungoides of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+95257002,Sézary's disease of intrapelvic lymph nodes (disorder),n,via Query Table
+449751000000106,[M]Angioendotheliomatosis (morphologic abnormality),n,via Query Table
+189615009,[M]Carcinoid tumors NOS (morphologic abnormality),n,via Query Table
+189757006,[M]Blue nevus NOS (morphologic abnormality),n,via Query Table
+462391000000102,[X]Secondary malignant neoplasm of other specified sites (disorder),n,via Query Table
+396781000000105,[M]Villous adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+635031000000102,Malignant neoplasm of intrahepatic bile ducts NOS (disorder),n,via Query Table
+271486002,Acute erythremia and erythroleukemia (disorder),n,via Query Table
+409231000000104,[X]Malignant neoplasm of mesothelial and soft tissue (disorder),n,via Query Table
+189563000,[M]Verrucous carcinoma NOS (morphologic abnormality),n,via Query Table
+416274001,Primary malignant clear cell tumor of ovary (disorder),n,via Query Table
+833601000000108,Non-Hodgkin's lymphoma - disorder,n,via Query Table
+94377002,Secondary malignant neoplasm of leg (disorder),n,via Query Table
+543431000000104,Malignant neoplasm of axilla NOS (disorder),n,via Query Table
+579251000000108,Malignant neoplasm of urinary bladder NOS (disorder),n,via Query Table
+571181000000107,Myeloid sarcoma NOS (disorder),n,via Query Table
+443641000000102,[M]Subacute lymphoid leukaemia,n,via Query Table
+368681000000101,Siewert type II adenocarcinoma ,n,via Query Table
+579211000000109,"Malignant neoplasm of penis, part unspecified (disorder)",n,via Query Table
+396491000000102,[M]Follicular adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+450991000000108,"[X]Malignant neoplasm of peritoneum, unspecified (disorder)",n,via Query Table
+541671000000101,Secondary and unspecified malignant neoplasm of lymph nodes in multiple sites (disorder),n,via Query Table
+426031000000107,[M]Clear cell adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+408861000000102,[M]Papillary adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+662421000000106,Acute leukemia NOS (disorder),n,via Query Table
+834561000000106,Benign fibroma of prostate,n,via Query Table
+190028007,[M]Aleukemic leukemia NOS (morphologic abnormality),n,via Query Table
+190137005,"[X]Malignant neoplasm, overlapping lesion of brain and other part of central nervous system (disorder)",n,via Query Table
+189932005,[M]Medulloepithelioma NOS (morphologic abnormality),n,via Query Table
+449791000000103,[M]Basal cell carcinoma NOS (morphologic abnormality),n,via Query Table
+579311000000104,Malignant neoplasm of orbit NOS (disorder),n,via Query Table
+189631001,[M]Oxyphilic adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+832521000000108,Acute monoblastic leukaemia,n,via Query Table
+546351000000108,Chronic myeloid leukemia NOS (disorder),n,via Query Table
+1884006,Molar pregnancy with choriocarcinoma (disorder),n,via Query Table
+397631000000103,[X]Malignant neoplasm of ill-defined sites within the digestive system (disorder),n,via Query Table
+189555001,[M]Small cell carcinoma NOS (morphologic abnormality),n,via Query Table
+662431000000108,Chronic leukemia NOS (disorder),n,via Query Table
+190102007,"[X]Malignant neoplasm of bone and articular cartilage, unspecified (disorder)",n,via Query Table
+190107001,"[X]Malignant neoplasm of skin, unspecified (disorder)",n,via Query Table
+463341000000103,[M]Basophilic leukaemia NOS (morphologic abnormality),n,via Query Table
+390651000000106,[X]Neoplasm of uncertain and unknown behaviour of other myelodysplastic syndromes (disorder),n,via Query Table
+189916007,[M]Spongioblastoma NOS (morphologic abnormality),n,via Query Table
+254630009,Clear cell carcinoma of lung (disorder),n,via Query Table
+478201000000109,[M]Seminoma NOS (morphologic abnormality),n,via Query Table
+477851000000107,[M]Lymphoid leukaemias (morphologic abnormality),n,via Query Table
+186722007,HIV disease resulting in Kaposi's sarcoma (disorder),n,via Query Table
+832621000000109,"Hodgkin's disease, lymphocytic depletion",n,via Query Table
+821881000000100,Benign fibroma of prostate (disorder),n,via Query Table
+634621000000108,Other monocytic leukemia (disorder),n,via Query Table
+547121000000104,Secondary and unspecified malignant neoplasm of popliteal lymph nodes (disorder),n,via Query Table
+401221000000100,[M]Malignant histiocytosis (morphologic abnormality),n,via Query Table
+663651000000108,Malignant neoplasm of anus unspecified (disorder),n,via Query Table
+557091000000102,"Malignant neoplasm of middle lobe, bronchus or lung NOS (disorder)",n,via Query Table
+402535002,Basal cell carcinoma with sweat gland differentiation (disorder),n,via Query Table
+255070009,"Malignant tumor of oral cavity, lips, salivary glands (disorder)",n,via Query Table
+635011000000105,Malignant neoplasm of connective and soft tissue of pelvis NOS (disorder),n,via Query Table
+190052000,[M]Basophilic leukemias (morphologic abnormality),n,via Query Table
+536091000000103,Secondary and unspecified malignant neoplasm of intrathoracic lymph nodes NOS (disorder),n,via Query Table
+431561000000103,(Mesothelioma of lung) or ([X]mesothelioma of other sites),n,via Query Table
+833141000000104,Enteropathy-associated T-cell lymphoma,n,via Query Table
+814981000000100,"Anaplastic large cell lymphoma, ALK-negative (disorder)",n,via Query Table
+450861000000108,[M]Mesenchymal nephroblastoma (morphologic abnormality),n,via Query Table
+578281000000109,Malignant lymphoma NOS of intrathoracic lymph nodes (disorder),n,via Query Table
+698151000000107,Ca colon NOS (disorder),n,via Query Table
+578441000000102,Hodgkin's paragranuloma NOS (disorder),n,via Query Table
+569311000000107,Secondary and unspecified malignant neoplasm of facial lymph nodes (disorder),n,via Query Table
+537991000000100,Malignant neoplasm of palate unspecified (disorder),n,via Query Table
+401121000000109,[X]Unspecified B-cell non-Hodgkin's lymphoma,n,via Query Table
+833091000000105,[M] Refractory anaemia with sideroblasts,n,via Query Table
+189640002,[M]Mixed cell adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+23746000,Intracystic carcinoma (morphologic abnormality),n,via Query Table
+539711000000102,Nodular lymphoma NOS (disorder),n,via Query Table
+570611000000103,Malignant neoplasm of vagina NOS (disorder),n,via Query Table
+833431000000104,[M]Erythroleukaemia,n,via Query Table
+538011000000106,Secondary and unspecified malignant neoplasm of external iliac lymph nodes (disorder),n,via Query Table
+534631000000101,"Malignant neoplasm of lip, inner aspect NOS (disorder)",n,via Query Table
+269543002,Ca rectum with Ca anus (disorder),n,via Query Table
+424721000000102,[M]Renal adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+306870009,Ca rectum + Ca anus NOS (disorder),n,via Query Table
+189700001,[M]Mucinous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+397346005,Acute bilineal leukemia (morphologic abnormality),n,via Query Table
+533471000000103,Secondary malignant neoplasm of other respiratory organs (disorder),n,via Query Table
+688151000000106,Secondary malignant neoplasm of other specified sites (disorder),n,via Query Table
+437781000000108,[M]Pituitary adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+454781000000102,[M] Immunoproliferative small intestinal disease (morphologic abnormality),n,via Query Table
+408621000000109,[M]Villous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+188251003,Hypernephroma (disorder),n,via Query Table
+412771000000104,"[X]Malignant neoplasm of peripheral nerves of trunk, unspecified (disorder)",n,via Query Table
+189808004,[M]Carcinosarcoma NOS (morphologic abnormality),n,via Query Table
+190032001,[M]Compound leukemia NOS (morphologic abnormality),n,via Query Table
+956541000000108,Malignant Melanoma Stage IV M1b ,n,via Query Table
+437871000000101,[M]Papillary carcinoma NOS (morphologic abnormality),n,via Query Table
+95262001,Sézary's disease of lymph nodes of multiple sites (disorder),n,via Query Table
+189623006,[M]Papillary adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+569351000000106,"Secondary and unspecified malignant neoplasm of lymph nodes of head, face and neck NOS (disorder)",n,via Query Table
+190133009,"[X]Malignant neoplasm of eye, brain and other parts of central nervous system (disorder)",n,via Query Table
+190105009,"[X]Malignant melanoma of skin, unspecified (disorder)",n,via Query Table
+190098004,[X]Malignant neoplasm of bone and articular cartilage (disorder),n,via Query Table
+450191000000106,[M]Sarcomatosis NOS (morphologic abnormality),n,via Query Table
+74153005,Molar pregnancy with invasive hydatidiform mole (disorder),n,via Query Table
+832591000000106,"Hodgkin's disease, lymphocytic predominance - nodular",n,via Query Table
+432271000000102,"[X]Malignant neoplasm of meninges, unspecified",n,via Query Table
+253076000,Melanotic neuroectodermal tumor of infancy (morphologic abnormality),n,via Query Table
+546861000000101,Malignant melanoma of lower limb or hip NOS (disorder),n,via Query Table
+815311000000105,Acute myeloid leukemia with myelodysplasia-related changes (disorder),n,via Query Table
+426751000000103,[M]Epithelial nephroblastoma (morphologic abnormality),n,via Query Table
+277608004,"Hodgkin's disease, lymphocytic predominance - nodular (disorder)",n,via Query Table
+443621000000109,"[X]Malignant neoplasm of central nervous system, unspecified (disorder)",n,via Query Table
+85530002,Heterophilic leukemia (morphologic abnormality),n,via Query Table
+863771000000102,Clinical stage B chronic lymphocytic leukaemia ,n,via Query Table
+450041000000102,[X]Other Hodgkin's disease (disorder),n,via Query Table
+833381000000105,Follicular lymphoma grade 3b,n,via Query Table
+573481000000104,Malignant neoplasm of colon NOS (disorder),n,via Query Table
+657371000000107,Malignant neoplasm of epiglottis NOS (disorder),n,via Query Table
+408351000000109,[M]Oxyphilic adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+190006007,[M]Microglioma (morphologic abnormality),n,via Query Table
+578451000000104,Hodgkin's granuloma of unspecified site (disorder),n,via Query Table
+760981000000108,"Basal cell carcinoma, micronodular (morphologic abnormality)",n,via Query Table
+863141000000107,Non-small cell carcinoma (morphologic abnormality),n,via Query Table
+397811000000105,[M]Spindle cell melanoma NOS (morphologic abnormality),n,via Query Table
+189934006,[M]Retinoblastomas (morphologic abnormality),n,via Query Table
+543421000000101,"Malignant neoplasm of head, neck and face NOS (disorder)",n,via Query Table
+368671000000103,Siewert type I adenocarcinoma ,n,via Query Table
+337671000000108,Clark melanoma level 2,n,via Query Table
+557081000000104,"Malignant neoplasm of upper lobe, bronchus or lung NOS (disorder)",n,via Query Table
+189835008,[M]Adenomatoid tumor NOS (morphologic abnormality),n,via Query Table
+814851000000101,Diffuse follicle centre lymphoma (disorder),n,via Query Table
+203436008,Osteoporosis in multiple myelomatosis (disorder),n,via Query Table
+408321000000104,[M]Myoma and myosarcoma (morphologic abnormality),n,via Query Table
+190029004,"[M]leukemia unspecified, NOS (morphologic abnormality)",n,via Query Table
+189939001,[M]Neuroepitheliomatous neoplasm NOS (morphologic abnormality),n,via Query Table
+833061000000104,Anaplastic lymphoma kinase negative anaplastic large cell lymphoma,n,via Query Table
+832581000000109,Secondary malignant neoplasm of liver and intrahepatic bile duct,n,via Query Table
+534801000000106,Malignant neoplasm of other specified part of esophagus (disorder),n,via Query Table
+834551000000108,Adenoma - prostate,n,via Query Table
+189552003,"[M]Carcinoma, undifferentiated type, NOS (morphologic abnormality)",n,via Query Table
+425161000000108,[M]Sebaceous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+189629005,[M]Pituitary adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+620441000000107,Malignant neoplasm of liver and intrahepatic bile ducts NOS (disorder),n,via Query Table
+189805001,[M]Epithelial nephroblastoma (morphologic abnormality),n,via Query Table
+424671000000107,[M]Endometrioid adenomas and carcinomas (morphologic abnormality),n,via Query Table
+189661009,[M]Skin appendage carcinoma (morphologic abnormality),n,via Query Table
+534681000000102,Malignant neoplasm of dorsum of tongue NOS (disorder),n,via Query Table
+190091005,[X]Malignant neoplasm of respiratory and intrathoracic organs (disorder),n,via Query Table
+390281000000103,[X]Kaposi's sarcoma of other sites (disorder),n,via Query Table
+557501000000103,Mast cell malignancy of unspecified site (disorder),n,via Query Table
+188678009,Diffuse non-Hodgkin's lymphoblastic (diffuse) lymphoma (disorder),n,via Query Table
+462491000000106,[M]Oligodendroglioma NOS (morphologic abnormality),n,via Query Table
+778091000000101,"Basal cell carcinoma, infiltrative",n,via Query Table
+832601000000100,"Hodgkin's disease, nodular sclerosis",n,via Query Table
+833501000000109,Primary cutaneous CD30 antigen positive large T-cell lymphoma,n,via Query Table
+189636006,[M]Renal adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+190164006,"[X]Malignant neoplasm of lymphoid, hematopoietic and related tissue, unspecified (disorder)",n,via Query Table
+269507008,[M]Neuroblastoma NOS (morphologic abnormality),n,via Query Table
+269501009,[M]Adenomatous and adenocarcinomatous polyps of colon (morphologic abnormality),n,via Query Table
+189609009,"[M]Carcinoid tumor, malignant (morphologic abnormality)",n,via Query Table
+579291000000100,Malignant neoplasm of eyeball NOS (disorder),n,via Query Table
+833641000000106,[M]Plasmacytoma NOS,n,via Query Table
+463221000000103,[M]Retinoblastoma NOS (morphologic abnormality),n,via Query Table
+558021000000101,Secondary and unspecified malignant neoplasm of internal mammary lymph nodes (disorder),n,via Query Table
+666491000000108,Malignant neoplasm of other sites of tongue (disorder),n,via Query Table
+189692006,[M]Mucinous cystadenocarcinoma NOS (morphologic abnormality),n,via Query Table
+477491000000102,[M]Tubular adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+549611000000107,Malignant neoplasm of other site of cervix (disorder),n,via Query Table
+778081000000103,"Basal cell carcinoma, micronodular",n,via Query Table
+541021000000108,"Hodgkin's disease, mixed cellularity NOS (disorder)",n,via Query Table
+687921000000103,Disseminated malignancy NOS (disorder),n,via Query Table
+565581000000109,Secondary and unspecified malignant neoplasm of anterior mediastinal lymph nodes (disorder),n,via Query Table
+537941000000105,Malignant neoplasm of gum NOS (disorder),n,via Query Table
+548991000000100,Malignant neoplasm of cerebral meninges NOS (disorder),n,via Query Table
+778041000000106,"[M]Malignant lymphoma, large cell, diffuse NOS",n,via Query Table
+579241000000105,Malignant neoplasm of other site of urinary bladder (disorder),n,via Query Table
+875391000000109,Non-small cell carcinoma,n,via Query Table
+189927009,[M]Neuroepitheliomatous neoplasms (morphologic abnormality),n,via Query Table
+417681000000107,"[X]Non-Hodgkin's lymphoma, unspecified type",n,via Query Table
+634561000000104,"Malignant neoplasm of auditory tube, middle ear and mastoid air cells NOS (disorder)",n,via Query Table
+189764008,[M]Sarcoma NOS (morphologic abnormality),n,via Query Table
+188657006,Letterer-Siwe disease of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+84350008,AIDS with immunoblastic sarcoma (disorder),n,via Query Table
+189628002,[M]Pituitary adenomas and carcinomas (morphologic abnormality),n,via Query Table
+408911000000106,[X]Malignant neoplasm of thyroid and other endocrine glands (disorder),n,via Query Table
+579301000000101,Secondary and unspecified malignant neoplasm of submental lymph nodes (disorder),n,via Query Table
+190086009,[X]Malignant neoplasm of digestive organs (disorder),n,via Query Table
+187737000,Malignant neoplasm of prepylorus of stomach (disorder),n,via Query Table
+549521000000102,Malignant neoplasm of female breast NOS (disorder),n,via Query Table
+557491000000109,Letterer-Siwe disease NOS (disorder),n,via Query Table
+569291000000106,Secondary and unspecified malignant neoplasm of deep parotid lymph nodes (disorder),n,via Query Table
+833331000000106,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue,n,via Query Table
+815191000000104,"Atypical chronic myeloid leukaemia, BCR/ABL-negative (morphologic abnormality)",n,via Query Table
+546881000000105,Malignant melanoma of skin NOS (disorder),n,via Query Table
+578251000000103,Malignant mast cell tumor NOS (disorder),n,via Query Table
+418829009,Primary malignant neoplasm of lacrimal drainage structure (disorder),n,via Query Table
+557121000000101,Malignant neoplasm of other specified pleura (disorder),n,via Query Table
+189632008,[M]Clear cell adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+439151000000109,[X]Secondary and unspecified malignant neoplasm lymph nodes of multiple regions (disorder),n,via Query Table
+190051007,[M]Other myeloid leukemia NOS (morphologic abnormality),n,via Query Table
+539701000000104,Nodular lymphoma of unspecified site (disorder),n,via Query Table
+564921000000101,Malignant neoplasm of upper limb NOS (disorder),n,via Query Table
+192581000000107,Malignant sacral teratoma,n,via Query Table
+189642005,[M]Follicular adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+189573003,[M]Basal cell carcinoma NOS (morphologic abnormality),n,via Query Table
+956361000000102,Malignant Melanoma Stage IB ,n,via Query Table
+389851000000102,[M]Strumal neoplasms (morphologic abnormality),n,via Query Table
+186725009,Human immunodeficiency virus disease resulting in multiple malignant neoplasms (disorder),n,via Query Table
+188085009,Malignant neoplasm of eyelid including canthus (disorder),n,via Query Table
+426711000000102,[M]Pancreatic adenomas and carcinomas (morphologic abnormality),n,via Query Table
+472961000000101,[M]Aleukaemic lymphoid leukaemia (morphologic abnormality),n,via Query Table
+546691000000106,Secondary malignant neoplasm of retroperitoneum or peritoneum NOS (disorder),n,via Query Table
+450141000000101,[X]Malignant neoplasm of bone and articular cartilage (disorder),n,via Query Table
+689131000000106,Bladder papilloma NOS (disorder),n,via Query Table
+428971000000106,"[M]Lymphogranuloma, malignant (morphologic abnormality)",n,via Query Table
+56346006,Lucke frog kidney carcinoma (disorder),n,via Query Table
+561581000000107,Malignant neoplasm of other specified site of eye (disorder),n,via Query Table
+188636003,Sezary's disease of spleen (disorder),n,via Query Table
+439171000000100,"[X]Malignant neoplasm of peripheral nerves and autonomic nervous system, unspecified (disorder)",n,via Query Table
+833361000000101,Follicular lymphoma grade 3,n,via Query Table
+401561000000106,[M]Monocytoid B-cell lymphoma,n,via Query Table
+566521000000100,Malignant neoplasm of anterior epiglottis NOS (disorder),n,via Query Table
+635001000000108,"Malignant neoplasm of rectum, rectosigmoid junction and anus NOS (disorder)",n,via Query Table
+254523008,Malignant tumor of arytenoid (disorder),n,via Query Table
+134179007,[M]Malignant histiocytosis (morphologic abnormality),n,via Query Table
+557651000000103,Reticulosarcoma NOS (disorder),n,via Query Table
+94149003,"Acute megakaryoblastic leukemia, FAB M7 (disorder)",n,via Query Table
+174581000000106,Cancer hospital treatment completed,n,via Query Table
+540291000000105,Malignant neoplasm of skin of lower limb or hip NOS (disorder),n,via Query Table
+189671006,[M]Sebaceous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+540281000000108,Malignant neoplasm of skin of upper limb or shoulder NOS (disorder),n,via Query Table
+93852003,Primary malignant neoplasm of lacrimal duct (disorder),n,via Query Table
+832631000000106,Lymphocyte-rich classical Hodgkin lymphoma,n,via Query Table
+833021000000107,Other types of follicular non-Hodgkin's lymphoma,n,via Query Table
+189819001,[M]Brenner tumor NOS (morphologic abnormality),n,via Query Table
+815451000000102,Primary cutaneous CD30 antigen positive large T-cell lymphoma (disorder),n,via Query Table
+396731000000106,[M]Lobular carcinoma NOS (morphologic abnormality),n,via Query Table
+253063006,Fibrous astrocytoma (morphologic abnormality),n,via Query Table
+438251000000108,"[M]leukemia unspecified, NOS (morphologic abnormality)",n,via Query Table
+546831000000106,Malignant neoplasm of other specified sites of pancreas (disorder),n,via Query Table
+424631000000105,[M]Adenomatous or adenocarcinomatous polyps of the colon NOS (morphologic abnormality),n,via Query Table
+573431000000103,Reticulosarcoma or lymphosarcoma NOS (disorder),n,via Query Table
+760641000000105,"Basal cell carcinoma, nodular (morphologic abnormality)",n,via Query Table
+534851000000107,Malignant neoplasm of greater curve of stomach unspecified (disorder),n,via Query Table
+189830003,[M]Clear cell sarcoma of tendons and aponeuroses (morphologic abnormality),n,via Query Table
+396791000000107,"[M]Papillary cystadenocarcinoma, NOS (morphologic abnormality)",n,via Query Table
+438291000000100,[M]Sebaceous adenoma and adenocarcinoma (morphologic abnormality),n,via Query Table
+170961000000104,Cancer pain and symptom management,n,via Query Table
+757841000000103,Grade 3 (Stage pTa) papillary urothelial/transitional cell carcinoma,n,via Query Table
+437201000000108,[M]Tibial adamantinoma (morphologic abnormality),n,via Query Table
+373627005,Bronchioloalveolar carcinoma (disorder),n,via Query Table
+190011009,[M] Gamma heavy chain disease (morphologic abnormality),n,via Query Table
+189600008,[M]Adenomatous or adenocarcinomatous polyp NOS (morphologic abnormality),n,via Query Table
+189601007,[M]Tubular adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+778071000000100,"Basal cell carcinoma, nodular",n,via Query Table
+190112000,"[X]Kaposi's sarcoma, unspecified (disorder)",n,via Query Table
+561431000000107,Malignant neoplasm of palate NOS (disorder),n,via Query Table
+832611000000103,"Hodgkin's disease, mixed cellularity",n,via Query Table
+89706008,AIDS with Burkitt's tumor (disorder),n,via Query Table
+863131000000103,Peripheral neuroectodermal tumour (morphologic abnormality),n,via Query Table
+449421003,Malignant neoplasm of placenta (disorder),n,via Query Table
+472951000000104,[M]Subacute lymphoid leukaemia (morphologic abnormality),n,via Query Table
+399491000000106,[M] Myxoid chondrosarcoma (morphologic abnormality),n,via Query Table
+833491000000103,Malignant lymphoma - lymphoblastic,n,via Query Table
+93450001,Erythroleukemia in remission (disorder),n,via Query Table
+189681005,[M]Cystadenocarcinoma NOS (morphologic abnormality),n,via Query Table
+337261000000103,Clark melanoma level 5,n,via Query Table
+213981000000105,High grade prostatic intraepithelial neoplasia,n,via Query Table
+457571000000102,[M]Subacute myeloid leukaemia (morphologic abnormality),n,via Query Table
+833521000000100,Cutaneous lymphoma,n,via Query Table
+189935007,[M]Retinoblastoma NOS (morphologic abnormality),n,via Query Table
+190057006,[M]Monocytic leukemias (morphologic abnormality),n,via Query Table
+188756007,Acute panmyelosis (disorder),n,via Query Table
+541891000000101,Lymphosarcoma of unspecified site (disorder),n,via Query Table
+189553008,"[M]Carcinoma, anaplastic type, NOS (morphologic abnormality)",n,via Query Table
+956341000000103,Malignant Melanoma Stage IA ,n,via Query Table
+579231000000101,Secondary and unspecified malignant neoplasm of mastoid lymph nodes (disorder),n,via Query Table
+189630000,[M]Oxyphilic adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+539541000000105,Secondary and unspecified malignant neoplasm of inferior tracheobronchial lymph nodes (disorder),n,via Query Table
+190139008,"[X]Malignant neoplasm - pluriglandular involvement, unspecified (disorder)",n,via Query Table
+427051000000102,[X]Malignant neoplasm of overlapping lesion of male genital organs (disorder),n,via Query Table
+408661000000101,[X]Other specified types of non-Hodgkin's lymphoma (disorder),n,via Query Table
+190035004,[M]Subacute lymphoid leukemia (morphologic abnormality),n,via Query Table
+966311000000107,Active surveillance of prostate cancer (regime/therapy),n,via Query Table
+269478004,Chronic erythremia (disorder),n,via Query Table
+546841000000102,Malignant melanoma of face NOS (disorder),n,via Query Table
+533411000000108,Malignant neoplasm of ovary and other uterine adnexa (disorder),n,via Query Table
+545241000000108,Secondary and unspecified malignant neoplasm of superficial cervical lymph nodes (disorder),n,via Query Table
+189921005,[M]Medulloblastoma NOS (morphologic abnormality),n,via Query Table
+916281000000108,Malignant melanoma of eye,n,via Query Table
+540301000000109,Malignant neoplasm of other specified skin sites (disorder),n,via Query Table
+541001000000104,Secondary and unspecified malignant neoplasm of intra-abdominal lymph nodes (disorder),n,via Query Table
+867931000000106,[M]Juvenile myelomonocytic leukaemia (morphologic abnormality),n,via Query Table
+471861000000102,"[X]Malignant neoplasm of bones and articular cartilage of limb, unspecified",n,via Query Table
+425941000000105,"[X]Malignant neoplasm of intestinal tract, part unspecified (disorder)",n,via Query Table
+561461000000102,Malignant neoplasm of mouth NOS (disorder),n,via Query Table
+414141000000102,[M]Glioblastoma multiforme (& NOS),n,via Query Table
+411551000000106,[X]Kaposi's sarcoma of multiple organs (disorder),n,via Query Table
+276611000000108,Malignant neoplasm of descended testis NOS (disorder),n,via Query Table
+833371000000108,Follicular lymphoma grade 3a,n,via Query Table
+645061000000108,"Malignant neoplasm of lip unspecified, mucosa (disorder)",n,via Query Table
+832911000000106,Acute myeloblastic leukaemia,n,via Query Table
+426741000000101,[M]Skin appendage adenoma and carcinoma (morphologic abnormality),n,via Query Table
+189715000,[M] Intracystic carcinoma NOS (morphologic abnormality),n,via Query Table
+189832006,[M]Mesothelial neoplasms (morphologic abnormality),n,via Query Table
+855201000000106,Prostatic intraepithelial neoplasia,n,via Query Table
+408771000000104,[M]Compound leukaemia (morphologic abnormality),n,via Query Table
+757251000000101,Diffuse malignant lymphoma - large cell,n,via Query Table
+478611000000108,"[X]Malignant neoplasm of skin, unspecified (disorder)",n,via Query Table
+396121000000105,[M]Adenomatoid tumour NOS (morphologic abnormality),n,via Query Table
+565961000000108,Malignant lymphoma NOS of intrapelvic lymph nodes (disorder),n,via Query Table
+566041000000100,Malignant neoplasm of pituitary gland or craniopharyngeal duct NOS (disorder),n,via Query Table
+804391000000100,Enchondroma (morphologic abnormality),n,via Query Table
+188759000,Lymphosarcoma cell leukemia (disorder),n,via Query Table
+189652009,[M]Endometrioid adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+175601000000101,Date cancer diagnosis received in primary care,n,via Query Table
+429391000000101,"[X]Malignant neoplasm of peripheral nerves of trunk, unspecified (disorder)",n,via Query Table
+397641000000107,[X]Malignant neoplasm of respiratory and intrathoracic organs (disorder),n,via Query Table
+413526008,"Anaplastic large cell lymphoma, T/Null cell, primary cutaneous type (morphologic abnormality)",n,via Query Table
+573341000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of unspecified site (disorder),n,via Query Table
+396241000000108,[M]Pituitary adenomas and carcinomas (morphologic abnormality),n,via Query Table
+190132004,"[X]Malignant neoplasm of urinary organ, unspecified (disorder)",n,via Query Table
+832661000000101,B-cell chronic lymphocytic leukaemia,n,via Query Table
+462461000000100,[X]Malignant neoplasm of female genital organs (disorder),n,via Query Table
+556151000000108,Malignant lymphoma NOS of unspecified site (disorder),n,via Query Table
+189593006,[M]Hepatobiliary adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+420631000000103,[M]Acute lymphoid leukaemia (morphologic abnormality),n,via Query Table
+561451000000100,Malignant neoplasm of other specified mouth parts (disorder),n,via Query Table
+550111000000106,Malignant neoplasm of main bronchus NOS (disorder),n,via Query Table
+269503007,[M]Malignant melanoma NOS (morphologic abnormality),n,via Query Table
+389781000000104,[X]Malignant neoplasm without specification of site (disorder),n,via Query Table
+187959005,Malignant neoplasm of long bones of leg (disorder),n,via Query Table
+188624009,Mycosis fungoides of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+188526000,Hodgkin's paragranuloma of intra-abdominal lymph nodes (disorder),n,via Query Table
+359626007,"Acute myelogenous leukemia without differentiation, FAB M0 (disorder)",n,via Query Table
+704561000000101,Carcinoma of ovary and other uterine adnexa (disorder),n,via Query Table
+539731000000105,Mycosis fungoides of unspecified site (disorder),n,via Query Table
+389861000000104,[M]Medulloblastoma NOS (morphologic abnormality),n,via Query Table
+189818009,[M]Brenner tumors (morphologic abnormality),n,via Query Table
+461881000000104,[M]Plasma cell leukaemias (morphologic abnormality),n,via Query Table
+570661000000101,Malignant neoplasm of undescended testis NOS (disorder),n,via Query Table
+539521000000103,Malignant neoplasm of cerebral ventricle NOS (disorder),n,via Query Table
+396811000000108,[M]Seminomas (morphologic abnormality),n,via Query Table
+409691000000100,[M]Aleukaemic leukaemia NOS (morphologic abnormality),n,via Query Table
+437231000000102,[M]Adenomatous and adenocarcinomatous polyps (morphologic abnormality),n,via Query Table
+573631000000101,"Malignant neoplasm of upper respiratory tract, part unspecified (disorder)",n,via Query Table
+313430005,Teratoma of descended testis (disorder),n,via Query Table
+190024009,[M]leukemias unspecified (morphologic abnormality),n,via Query Table
+573521000000104,Malignant neoplasm of vulva unspecified (disorder),n,via Query Table
+190007003,[M]Histiocytic medullary reticulosis (morphologic abnormality),n,via Query Table
+190063002,[M]Miscellaneous leukemias (morphologic abnormality),n,via Query Table
+36449005,Acute erythremia (morphologic abnormality),n,via Query Table
+409151000000100,[M]Carcinosarcoma NOS (morphologic abnormality),n,via Query Table
+186709004,Human immunodeficiency virus with secondary cancers (disorder),n,via Query Table
+187979002,Malignant neoplasm of short bones of leg NOS (disorder),n,via Query Table
+189584005,"[M]Adenocarcinoma, metastatic, NOS (morphologic abnormality)",n,via Query Table
+134166003,[M]Rhabdomyosarcoma NOS (morphologic abnormality),n,via Query Table
+189837000,"[M]Mesothelioma, unspecified (morphologic abnormality)",n,via Query Table
+408591000000106,[X]Polyneuropathy in neoplastic disease classified elsewhere (disorder),n,via Query Table
+189585006,[M]Pancreatic adenomas and carcinomas (morphologic abnormality),n,via Query Table
+313431009,Teratoma of undescended testis (disorder),n,via Query Table
+189930002,[M]Ganglioneuromatous neoplasm NOS (morphologic abnormality),n,via Query Table
+534641000000105,Malignant neoplasm of other sites of lip (disorder),n,via Query Table
+389831000000109,[X]Malignant neoplasm of other specified female genital organs (disorder),n,via Query Table
+190070002,[M]Miscellaneous leukemia NOS (morphologic abnormality),n,via Query Table
+127216000,Angioimmunoblastic lymphadenopathy with dysproteinemia (disorder),n,via Query Table
+425131000000103,[M]Acute megakaryoblastic leukaemia (morphologic abnormality),n,via Query Table
+190147008,[X]Secondary malignant neoplasm of bladder and other and unspecified urinary organs (disorder),n,via Query Table
+189619003,[M]Papillary adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+539511000000109,Malignant neoplasm of temporal lobe NOS (disorder),n,via Query Table
+188619006,"Mycosis fungoides of the lymph nodes of head, face and neck (disorder)",n,via Query Table
+691161000000101,Ca larynx - NOS (disorder),n,via Query Table
+415461000000108,[M]Malignant lymphomatous polyposis (morphologic abnormality),n,via Query Table
+556031000000100,Malignant neoplasm of specified site of pancreas NOS (disorder),n,via Query Table
+552161000000107,Malignant neoplasm of skin of other and unspecified part of face NOS (disorder),n,via Query Table
+564901000000105,Malignant neoplasm of thorax NOS (disorder),n,via Query Table
+412761000000106,"[X]Malignant neoplasm, overlapping lesion of brain and other part of central nervous system",n,via Query Table
+757711000000109,Grade 2 (Stage pTa) papillary urothelial/transitional cell carcinoma,n,via Query Table
+438691000000102,[M]Monocytoid B-cell lymphoma (morphologic abnormality),n,via Query Table
+534841000000109,Malignant neoplasm of lesser curve of stomach unspecified (disorder),n,via Query Table
+455771000000103,[X]Malignant neoplasm of ill-defined sites within the respiratory system (disorder),n,via Query Table
+396671000000104,"[X]Malignant neoplasm of endocrine gland, unspecified (disorder)",n,via Query Table
+540241000000100,"Malignant neoplasm of intestinal tract, part unspecified (disorder)",n,via Query Table
+578481000000105,"Hodgkin's, lymphocytic-histiocytic predominance NOS (disorder)",n,via Query Table
+636481000000103,"Malignant neoplasm of lip unspecified, frenulum (disorder)",n,via Query Table
+884611000000101,Bowel scope (flexible sigmoidoscopy) screen: cancer detected ,n,via Query Table
+437811000000106,[X]other malignant neoplasm of skin of other and unspecified parts of face (disorder),n,via Query Table
+538001000000109,Secondary and unspecified malignant neoplasm of common iliac lymph nodes (disorder),n,via Query Table
+478151000000104,[M]Embryonal carcinoma NOS (morphologic abnormality),n,via Query Table
+636471000000100,"Malignant neoplasm of lip unspecified, inner aspect (disorder)",n,via Query Table
+833471000000102,Acute myeloid leukaemia with 11q23 abnormality,n,via Query Table
+399501000000100,[X]Other leukaemia of unspecified cell type (disorder),n,via Query Table
+539571000000104,Secondary and unspecified malignant neoplasm of paratracheal lymph nodes (disorder),n,via Query Table
+479021000000100,[M]Subacute leukaemia NOS (morphologic abnormality),n,via Query Table
+574411000000109,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intrapelvic lymph nodes (disorder),n,via Query Table
+566541000000107,Malignant neoplasm of other specified site of oropharynx NOS (disorder),n,via Query Table
+255117000,Metastasis to respiratory and intrathoracic organ (disorder),n,via Query Table
+188656002,"Letterer-Siwe disease of lymph nodes of head, face and neck (disorder)",n,via Query Table
+235965006,Malignant cystic tumor of exocrine pancreas (disorder),n,via Query Table
+431831000000105,[M]Acute lymphoid leukaemia,n,via Query Table
+707761000000104,Neuroblastoma,n,via Query Table
+189813000,[M] Clear cell sarcoma of kidney (morphologic abnormality),n,via Query Table
+546851000000104,Malignant melanoma of scalp and neck NOS (disorder),n,via Query Table
+573651000000108,"Malignant neoplasm of rib, sternum and clavicle NOS (disorder)",n,via Query Table
+438701000000102,"[X]Malignant neoplasm of urinary organ, unspecified (disorder)",n,via Query Table
+430991000000109,[M]Rhabdomyosarcoma NOS (morphologic abnormality),n,via Query Table
+537951000000108,Malignant neoplasm of other sites of floor of mouth (disorder),n,via Query Table
+93866008,Primary malignant neoplasm of leg (disorder),n,via Query Table
+255044008,Malignant pinealoma (disorder),n,via Query Table
+464261000000109,[M]Mycosis fungoides NOS (morphologic abnormality),n,via Query Table
+546701000000106,Secondary malignant neoplasm of other digestive organ (disorder),n,via Query Table
+128645007,"Enteroglucagonoma, malignant (morphologic abnormality)",n,via Query Table
+815671000000108,"Extranodal NK/T-cell lymphoma, nasal type (disorder)",n,via Query Table
+557151000000106,"Malignant neoplasm of other site of heart, thymus and mediastinum (disorder)",n,via Query Table
+397431000000100,[M]Neuroepithelioma NOS (morphologic abnormality),n,via Query Table
+956421000000102,Malignant Melanoma Stage IIC ,n,via Query Table
+391381000000100,[M]Histiocytic medullary reticulosis (morphologic abnormality),n,via Query Table
+832921000000100,5Q minus syndrome,n,via Query Table
+756621000000106,Epithelioid trophoblastic tumour,n,via Query Table
+190022008,[M]Burkitt's tumors (morphologic abnormality),n,via Query Table
+190039005,[M]Plasma cell leukemia NOS (morphologic abnormality),n,via Query Table
+462251000000102,[X]Malignant neoplasm of overlapping lesion of bone and articular cartilage of limbs (disorder),n,via Query Table
+564891000000109,Malignant neoplasm of intrathoracic site NOS (disorder),n,via Query Table
+190009000,[M] Alpha heavy chain disease (morphologic abnormality),n,via Query Table
+547161000000107,Secondary and unspecified malignant neoplasm of circumflex iliac lymph nodes (disorder),n,via Query Table
+278190000,Erythremia (morphologic abnormality),n,via Query Table
+477871000000103,[X]Other types of diffuse non-Hodgkin's lymphoma (disorder),n,via Query Table
+454411000000101,"[X]Malignant neoplasm of mediastinum, part unspecified",n,via Query Table
+579261000000106,Malignant neoplasm of renal pelvis NOS (disorder),n,via Query Table
+93840005,Primary malignant neoplasm of intrahepatic bile ducts (disorder),n,via Query Table
+190165007,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+834571000000104,Benign myoma of prostate,n,via Query Table
+428301000000104,"[X]Malignant neoplasm of male genital organ, unspecified (disorder)",n,via Query Table
+269506004,[M]Glioblastoma NOS (morphologic abnormality),n,via Query Table
+437771000000106,[M]Transitional cell carcinoma NOS (morphologic abnormality),n,via Query Table
+467881000000109,[X]Malignant neoplasm of overlapping lesion of bone and articular cartilage,n,via Query Table
+703541000000100,Secondary carcinoma NOS (disorder),n,via Query Table
+462451000000103,[M]Sweat gland adenocarcinoma (morphologic abnormality),n,via Query Table
+93639006,Malignant melanoma of skin of leg (disorder),n,via Query Table
+541881000000103,Malignant melanoma of upper limb or shoulder NOS (disorder),n,via Query Table
+426191000000107,[M]Clear cell sarcoma of tendons and aponeuroses (morphologic abnormality),n,via Query Table
+189682003,[M]Cystadenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+956441000000109,Malignant Melanoma Stage IIIA ,n,via Query Table
+540251000000102,Malignant neoplasm of spleen NEC (disorder),n,via Query Table
+367051000000101,Mantle cell lymphoma (morphologic abnormality),n,via Query Table
+547151000000109,Secondary and unspecified malignant neoplasm of internal iliac lymph nodes (disorder),n,via Query Table
+634591000000105,Malignant neoplasm of laryngeal cartilage NOS (disorder),n,via Query Table
+190053005,[M]Basophilic leukemia NOS (morphologic abnormality),n,via Query Table
+533491000000104,"Secondary and unspecified malignant neoplasm of lymph nodes of head, face and neck (disorder)",n,via Query Table
+760591000000101,Superficial basal cell carcinoma (disorder),n,via Query Table
+550091000000101,Malignant neoplasm of larynx NOS (disorder),n,via Query Table
+538041000000107,Secondary and unspecified malignant neoplasm of supratrochlear lymph nodes (disorder),n,via Query Table
+187894002,Malignant neoplasm of other and ill-defined sites within the respiratory and intrathoracic organs (disorder),n,via Query Table
+540321000000100,Malignant neoplasm of nipple or areola of female breast NOS (disorder),n,via Query Table
+189633003,[M]Clear cell adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+189649001,[M]Endometrioid adenomas and carcinomas (morphologic abnormality),n,via Query Table
+404031000000109,[M]Aleukaemic myeloid leukaemia (morphologic abnormality),n,via Query Table
+425211000000103,[M]Neuroepitheliomatous neoplasms (morphologic abnormality),n,via Query Table
+549561000000105,"Malignant neoplasm of bone, connective tissue, skin and breast otherwise specified (disorder)",n,via Query Table
+541111000000101,Secondary and unspecified malignant neoplasm of celiac lymph nodes (disorder),n,via Query Table
+175641000000103,Cancer rehabilitation and readaption,n,via Query Table
+462971000000102,[M]Skin appendage adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+189889005,[M]Chondromatous neoplasm NOS (morphologic abnormality),n,via Query Table
+833461000000109,Acute myeloid leukaemia with myelodysplasia-related changes,n,via Query Table
+419591000000104,"[X]Malignant neoplasm - pluriglandular involvement, unspecified",n,via Query Table
+190135002,"[X]Malignant neoplasm of central nervous system, unspecified (disorder)",n,via Query Table
+302852008,Plasmacytoma (disorder),n,via Query Table
+188651007,Leukemic reticuloendotheliosis of spleen (disorder),n,via Query Table
+546821000000109,Malignant neoplasm of gallbladder and extrahepatic bile ducts NOS (disorder),n,via Query Table
+534811000000108,Malignant neoplasm of bones of skull and face NOS (disorder),n,via Query Table
+539741000000101,Mycosis fungoides NOS (disorder),n,via Query Table
+569321000000101,Secondary and unspecified malignant neoplasm of anterior cervical lymph nodes (disorder),n,via Query Table
+666511000000100,Malignant neoplasm of spleen NOS (disorder),n,via Query Table
+389731000000103,[M]Miscellaneous leukaemias (morphologic abnormality),n,via Query Table
+326681000000109,Clark melanoma level 2 (finding),n,via Query Table
+389761000000108,"[X]Myelodysplastic syndrome, unspecified (disorder)",n,via Query Table
+294311000000101,Bowel cancer detected through national screening programme ,n,via Query Table
+253036005,Precancerous melanosis (morphologic abnormality),n,via Query Table
+556221000000107,Malignant neoplasms of lymphoid and histiocytic tissue NOS (disorder),n,via Query Table
+430841000000108,[M]Angioendotheliomatosis,n,via Query Table
+673771000000103,Plasmacytoma NOS (disorder),n,via Query Table
+366059005,Letterer-Siwe disease (disorder),n,via Query Table
+557131000000104,Malignant neoplasm of pleura NOS (disorder),n,via Query Table
+634991000000101,Malignant neoplasm of connective and soft tissue of thorax NOS (disorder),n,via Query Table
+956401000000106,Malignant Melanoma Stage IIB ,n,via Query Table
+534661000000106,"Malignant neoplasm of lip, vermilion border NOS (disorder)",n,via Query Table
+557661000000100,Malignant lymphoma NOS of spleen (disorder),n,via Query Table
+269569008,Ca skull/face/jaw bone (disorder),n,via Query Table
+615431000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+189885004,[M]Chondroma NOS (morphologic abnormality),n,via Query Table
+537981000000102,Malignant neoplasm of vestibule of mouth NOS (disorder),n,via Query Table
+675601000000100,Carcinoma of breast NOS (disorder),n,via Query Table
+579321000000105,Malignant neoplasm of lacrimal duct NOS (disorder),n,via Query Table
+550081000000103,"Malignant neoplasm of larynx, other specified site (disorder)",n,via Query Table
+468681000000109,[M] Small cell osteosarcoma (morphologic abnormality),n,via Query Table
+549581000000101,Malignant neoplasm of head NOS (disorder),n,via Query Table
+189659000,[M]Skin appendage adenoma and carcinoma (morphologic abnormality),n,via Query Table
+463381000000106,[M]Ceruminous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+410571000000108,[M]Miscellaneous leukaemia NOS (morphologic abnormality),n,via Query Table
+255100007,Mycosis fungoides of skin (disorder),n,via Query Table
+190034000,[M]Acute lymphoid leukemia (morphologic abnormality),n,via Query Table
+190166008,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas (disorder),n,via Query Table
+439141000000106,[M]Ganglioneuromatous neoplasms (morphologic abnormality),n,via Query Table
+833621000000104,Cutaneous/peripheral T-cell lymphoma,n,via Query Table
+337701000000107,Clark melanoma level 5,n,via Query Table
+832651000000104,B-cell acute lymphoblastic leukaemia,n,via Query Table
+359636004,"Acute myelogenous leukemia without maturation, FAB M1 (disorder)",n,via Query Table
+189612007,"[M]Carcinoid tumor, nonargentaffin, malignant (morphologic abnormality)",n,via Query Table
+575521000000103,Malignant neoplasm of short bones of leg NOS (disorder),n,via Query Table
+94178002,Secondary malignant neoplasm of arm (disorder),n,via Query Table
+451111000000105,"[M]Carcinoma, undifferentiated type, NOS (morphologic abnormality)",n,via Query Table
+556061000000105,Burkitt's lymphoma NOS (disorder),n,via Query Table
+294321000000107,Bowel cancer detected through national screening programme ,n,via Query Table
+569281000000109,Secondary malignant neoplasm of other urinary organ NOS (disorder),n,via Query Table
+700064004,Familial nonpolyposis colorectal cancer (disorder),n,via Query Table
+190151005,"[X]Malignant neoplasms of lymphoid, hematopoietic and related tissue (disorder)",n,via Query Table
+833171000000105,Mantle cell lymphoma,n,via Query Table
+815091000000103,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue [MALT-lymphoma] (disorder),n,via Query Table
+255014005,Medulloepithelioma of ciliary body (disorder),n,via Query Table
+390781000000108,[M]Oxyphilic adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+36425007,Comedocarcinoma (morphologic abnormality),n,via Query Table
+307652003,Idiopathic thrombocythemia (disorder),n,via Query Table
+918261000000103,Lymphangiosarcoma of skin,n,via Query Table
+169931000000107,Cancer hospital treatment completed,n,via Query Table
+78010001,"Malignant lymphoma, large B-cell, diffuse, immunoblastic (morphologic abnormality)",n,via Query Table
+190036003,[M]Aleukemic lymphoid leukemia (morphologic abnormality),n,via Query Table
+337251000000101,Clark melanoma level 4,n,via Query Table
+572601000000104,Malignant neoplasm of other site of female breast NOS (disorder),n,via Query Table
+399211000000101,"[X]Non-Hodgkin's lymphoma, unspecified type (disorder)",n,via Query Table
+578501000000101,"Hodgkin's disease, nodular sclerosis NOS (disorder)",n,via Query Table
+478171000000108,[M]Papillary adenomas and adenocarcinomas (morphologic abnormality),n,via Query Table
+477841000000109,[M]Compound leukaemia NOS (morphologic abnormality),n,via Query Table
+704551000000104,Primary malignant neoplasm of ovary and other uterine adnexa (disorder),n,via Query Table
+555731000000108,Secondary and unspecified malignant neoplasm of sacral lymph nodes (disorder),n,via Query Table
+198651000000100,High grade prostatic intraepithelial neoplasia (disorder),n,via Query Table
+189881008,[M] Myxoid chondrosarcoma (morphologic abnormality),n,via Query Table
+541731000000108,Secondary malignant neoplasm of respiratory or digestive system NOS (disorder),n,via Query Table
+569271000000107,Secondary and unspecified malignant neoplasm of occipital lymph nodes (disorder),n,via Query Table
+812871000000103,Juvenile myelomonocytic leukaemia (disorder),n,via Query Table
+189673009,[M]Ceruminous adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+392061000000102,[M] Clear cell sarcoma of kidney (morphologic abnormality),n,via Query Table
+190054004,[M]Eosinophilic leukemias (morphologic abnormality),n,via Query Table
+532061000000105,"Malignant neoplasm of skin of chest, excluding breast (disorder)",n,via Query Table
+190148003,[X]Secondary malignant neoplasm of other and unspecified parts of nervous system (disorder),n,via Query Table
+556161000000106,Secondary malignant neoplasm of brain or spinal cord NOS (disorder),n,via Query Table
+269509006,"[M]Lymphogranuloma, malignant (morphologic abnormality)",n,via Query Table
+557641000000101,Reticulosarcoma of unspecified site (disorder),n,via Query Table
+541011000000102,Hodgkin's sarcoma NOS (disorder),n,via Query Table
+832641000000102,Hodgkin's disease,n,via Query Table
+575501000000107,"Malignant neoplasm of pelvis, sacrum or coccyx NOS (disorder)",n,via Query Table
+337231000000108,Clark melanoma level 2,n,via Query Table
+190031008,[M]Compound leukemia (morphologic abnormality),n,via Query Table
+190047005,[M]Myeloid leukemias (morphologic abnormality),n,via Query Table
+815681000000105,Subcutaneous panniculitic T-cell lymphoma (disorder),n,via Query Table
+170981000000108,Cancer rehabilitation and readaption,n,via Query Table
+189920006,[M]Oligodendroglioma NOS (morphologic abnormality),n,via Query Table
+80440003,AIDS with malignant neoplasm (disorder),n,via Query Table
+189841001,[M]Seminoma NOS (morphologic abnormality),n,via Query Table
+189662002,[M]Skin appendage adenoma or carcinoma NOS (morphologic abnormality),n,via Query Table
+190090006,[X]Malignant neoplasm of ill-defined sites within the digestive system (disorder),n,via Query Table
+760951000000102,"Basal cell carcinoma, infiltrative (disorder)",n,via Query Table
+662441000000104,Subacute leukemia NOS (disorder),n,via Query Table
+833541000000107,Subcutaneous panniculitic T-cell lymphoma,n,via Query Table
+190069003,[M]Acute myelofibrosis (morphologic abnormality),n,via Query Table
+456171000000109,[X]Malignant neoplasm of overlapping lesion of female genital organs,n,via Query Table
+537931000000101,Malignant neoplasm of other sites of gum (disorder),n,via Query Table
+549621000000101,Malignant neoplasm of other site of cervix NOS (disorder),n,via Query Table
+425511000000100,[M]Chondromatous neoplasm NOS (morphologic abnormality),n,via Query Table
+445681000000106,[M]Lymphosarcoma cell leukaemia (morphologic abnormality),n,via Query Table
+887531000000102,Cervical smear - high grade dyskaryosis with features of invasive squamous carcinoma ,n,via Query Table
+956381000000106,Malignant Melanoma Stage IIA ,n,via Query Table
+863751000000106,Clinical stage A chronic lymphocytic leukaemia ,n,via Query Table
+389751000000105,[X]Malignant neoplasm of male genital organs (disorder),n,via Query Table
+542031000000104,Malignant neoplasm of nasopharynx NOS (disorder),n,via Query Table
+541691000000102,Malignant histiocytosis NOS (disorder),n,via Query Table
+425121000000100,[X]Malignant neoplasm of digestive organs (disorder),n,via Query Table
+408801000000101,[M]Apocrine adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+309431000000107,Squamous cell carcinoma of skin,n,via Query Table
+547131000000102,Secondary and unspecified malignant neoplasm of inguinal and lower limb lymph nodes NOS (disorder),n,via Query Table
+663661000000106,"Malignant neoplasm of lower lip, inner aspect NOS (disorder)",n,via Query Table
+538091000000102,Secondary and unspecified malignant neoplasm of superficial inguinal lymph nodes (disorder),n,via Query Table
+578391000000103,Malignant melanoma of ear and external auricular canal NOS (disorder),n,via Query Table
+397801000000108,"[M]Carcinoid tumor, nonargentaffin, NOS (morphologic abnormality)",n,via Query Table
+966321000000101,Active Surveillance of Prostate Cancer ,n,via Query Table
+450171000000107,[M]Sweat gland adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+190067001,[M]Acute megakaryoblastic leukemia (morphologic abnormality),n,via Query Table
+94563001,Secondary malignant neoplasm of skin of leg (disorder),n,via Query Table
+666471000000109,Malignant neoplasm of ventral tongue surface NOS (disorder),n,via Query Table
+687911000000109,Malignant neoplasm of testis NOS (disorder),n,via Query Table
+832811000000104,Primary mediastinal (thymic) large B-cell lymphoma,n,via Query Table
+275464006,Cerebral tumor - malignant (disorder),n,via Query Table
+711701000000107,"Trophoblastic tumour, epithelioid (morphologic abnormality)",n,via Query Table
+539531000000101,Malignant neoplasm of brainstem NOS (disorder),n,via Query Table
+390261000000107,[M]Eosinophilic leukaemia NOS (morphologic abnormality),n,via Query Table
+189761000,[M]Nevi or melanoma NOS (morphologic abnormality),n,via Query Table
+579201000000107,Malignant neoplasm of connective and soft tissue of upper limb and shoulder NOS (disorder),n,via Query Table
+189679008,[M]Cystadenoma and carcinoma (morphologic abnormality),n,via Query Table
+531581000000101,"Malignant neoplasm of skin of trunk, excluding scrotum (disorder)",n,via Query Table
+455781000000101,[X]Unspecified B-cell non-Hodgkin's lymphoma (disorder),n,via Query Table
+189884000,[M]Chondromatous neoplasms (morphologic abnormality),n,via Query Table
+450611000000107,[X]Other monocytic leukaemia (morphologic abnormality),n,via Query Table
+541031000000105,Hodgkin's lymphocytic depletion of unspecified site (disorder),n,via Query Table
+815101000000106,"Follicular lymphoma, grade 1 (morphologic abnormality)",n,via Query Table
+255106001,Teratoma of testis (disorder),n,via Query Table
+564931000000104,Malignant neoplasm of lower limb NOS (disorder),n,via Query Table
+337681000000105,Clark melanoma level 3,n,via Query Table
+190046001,[M]Lymphosarcoma cell leukemia NOS (morphologic abnormality),n,via Query Table
+189621008,[M]Papillary adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+461931000000107,[M]Myoma or myosarcoma NOS (morphologic abnormality),n,via Query Table
+462961000000109,[M]Skin appendage carcinoma (morphologic abnormality),n,via Query Table
+449881000000109,[M]Verrucous carcinoma NOS (morphologic abnormality),n,via Query Table
+533381000000106,Malignant neoplasm of corpus uteri NOS (disorder),n,via Query Table
+757351000000109,Hereditary nonpolyposis colon cancer,n,via Query Table
+578161000000107,"Malignant neoplasm of lip, unspecified, external (disorder)",n,via Query Table
+573641000000105,Malignant neoplasm of vertebral column NOS (disorder),n,via Query Table
+634631000000105,Other monocytic leukemia NOS (disorder),n,via Query Table
+690661000000104,Carcinoma of genital organs NOS (disorder),n,via Query Table
+573381000000109,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intra-abdominal lymph nodes (disorder),n,via Query Table
+190049008,[M]Aleukemic myeloid leukemia (morphologic abnormality),n,via Query Table
+190103002,[X]Melanoma and other malignant neoplasms of skin (disorder),n,via Query Table
+409561000000107,[M]Microglioma (morphologic abnormality),n,via Query Table
+438321000000105,[M]Papillary adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+389771000000101,"[M]Carcinoid tumor, malignant (morphologic abnormality)",n,via Query Table
+437801000000109,[M]Erythroleukemia NOS (morphologic abnormality),n,via Query Table
+849141000000100,Adult T-cell leukemia/lymphoma (disorder),n,via Query Table
+691151000000104,Ca pancreas NOS (disorder),n,via Query Table
+833591000000102,Low grade B-cell lymphoma,n,via Query Table
+668601000000102,Malignant neoplasm of pinna NEC (disorder),n,via Query Table
+640511000000108,Malignant lymphoma NOS (disorder),n,via Query Table
+547141000000106,Secondary and unspecified malignant neoplasm of intrapelvic lymph nodes (disorder),n,via Query Table
+190123001,"[X]Malignant neoplasm of uterine adnexa, unspecified (disorder)",n,via Query Table
+95256006,Sézary's disease of intra-abdominal lymph nodes (disorder),n,via Query Table
+127221002,Hematologic malignancy (disorder),n,via Query Table
+398701000000101,[M]Basophilic leukaemias (morphologic abnormality),n,via Query Table
+620431000000103,Malignant neoplasm of liver unspecified (disorder),n,via Query Table
+556141000000105,Malignant lymphoma otherwise specified (disorder),n,via Query Table
+565601000000100,Secondary and unspecified malignant neoplasm of superficial tracheobronchial lymph nodes (disorder),n,via Query Table
+439161000000107,[X]Secondary malignant neoplasm of other and unspecified respiratory organs (disorder),n,via Query Table
+564881000000107,Malignant neoplasm of chest wall NOS (disorder),n,via Query Table
+403961000000102,[M]Neutrophilic leukaemia (morphologic abnormality),n,via Query Table
+541131000000109,Secondary and unspecified malignant neoplasm of inferior mesenteric lymph nodes (disorder),n,via Query Table
+442921000000108,[M]Adenomatous and adenocarcinomatous polyps of colon (morphologic abnormality),n,via Query Table
+425191000000102,[M]Other monocytic leukaemia NOS (morphologic abnormality),n,via Query Table
+189685001,"[M]Serous cystadenocarcinoma, NOS (morphologic abnormality)",n,via Query Table
+478981000000107,[M]Clear cell adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+425221000000109,[M]Burkitt's tumour NOS (morphologic abnormality),n,via Query Table
+814201000000103,Primary mediastinal (thymic) large B-cell lymphoma (disorder),n,via Query Table
+778061000000107,Superficial basal cell carcinoma,n,via Query Table
+634581000000108,Malignant neoplasm of accessory sinus NOS (disorder),n,via Query Table
+705141000000109,Sézary's disease of unspecified site (disorder),n,via Query Table
+423348002,Secondary malignant neoplasm of lacrimal drainage system (disorder),n,via Query Table
+561481000000106,Malignant neoplasm of tonsillar fossa NOS (disorder),n,via Query Table
+573441000000107,Hodgkin's paragranuloma of unspecified site (disorder),n,via Query Table
+190144001,[X]Secondary and unspecified malignant neoplasm lymph nodes of multiple regions (disorder),n,via Query Table
+549531000000100,Malignant neoplasm of nipple or areola of male breast NOS (disorder),n,via Query Table
+832821000000105,Follicular non-Hodgkin's lymphoma,n,via Query Table
+451141000000106,[X]Secondary malignant neoplasm of other and unspecified digestive organs (disorder),n,via Query Table
+541651000000105,Secondary and unspecified malignant neoplasm of inferior epigastric lymph nodes (disorder),n,via Query Table
+368691000000104,Siewert type III adenocarcinoma ,n,via Query Table
+390901000000101,[X]Malignant neoplasm of overlapping lesion of peripheral nerves and autonomic nervous system (disorder),n,via Query Table
+538111000000107,Secondary and unspecified malignant neoplasm of deep inguinal lymph nodes (disorder),n,via Query Table
+534651000000108,"Malignant neoplasm of lip, unspecified, lipstick area (disorder)",n,via Query Table
+189551005,[M]Large cell carcinoma NOS (morphologic abnormality),n,via Query Table
+634931000000102,Malignant neoplasm of posterior wall of stomach NEC (disorder),n,via Query Table
+190012002,[M] Large cell lymphoma (morphologic abnormality),n,via Query Table
+855061000000104,Local recurrence of malignant tumour of urinary bladder,n,via Query Table
+408831000000107,[M]Monocytic leukaemias (morphologic abnormality),n,via Query Table
+190140005,"[X]Malignant neoplasm of endocrine gland, unspecified (disorder)",n,via Query Table
+533431000000100,Malignant neoplasm of pelvis NOS (disorder),n,via Query Table
+438271000000104,[M] Intracystic carcinoma NOS (morphologic abnormality),n,via Query Table
+93149008,Leukemic reticuloendotheliosis of lymph nodes of inguinal region AND/OR lower limb (disorder),n,via Query Table
+190131006,[X]Malignant neoplasm of urinary tract (disorder),n,via Query Table
+93147005,Leukemic reticuloendotheliosis of lymph nodes of axilla AND/OR upper limb (disorder),n,via Query Table
+389491000000107,"[M]Adenocarcinoma, metastatic, NOS (morphologic abnormality)",n,via Query Table
+189779001,[M]Angiomyoliposarcoma (morphologic abnormality),n,via Query Table
+326711000000108,Clark melanoma level 5 (finding),n,via Query Table
+189611000,"[M]Carcinoid tumor, nonargentaffin, NOS (morphologic abnormality)",n,via Query Table
+188658001,Letterer-Siwe disease of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+571191000000109,Other myeloid leukemia (disorder),n,via Query Table
+569331000000104,Secondary and unspecified malignant neoplasm of deep cervical lymph nodes (disorder),n,via Query Table
+74739000,Brenner tumor (morphologic abnormality),n,via Query Table
+397121000000107,[M]Eosinophilic leukaemias (morphologic abnormality),n,via Query Table
+94541005,Secondary malignant neoplasm of skin of arm (disorder),n,via Query Table
+189796000,[M]Myoma and myosarcoma (morphologic abnormality),n,via Query Table
+326691000000106,Clark melanoma level 3 (finding),n,via Query Table
+833611000000105,[M]AngiocentricT-cell lymphoma,n,via Query Table
+389741000000107,[X]Malignant neoplasm of overlapping lesion of female genital organs (disorder),n,via Query Table
+187607001,"Malignant neoplasm of upper lip, buccal aspect (disorder)",n,via Query Table
+833121000000106,Hepatosplenic T-cell lymphoma,n,via Query Table
+648451000000106,"Ca lip, oral, pharynx NOS (disorder)",n,via Query Table
+538021000000100,Secondary and unspecified malignant neoplasm of intra-abdominal lymph nodes NOS (disorder),n,via Query Table
+695601000000109,Ca stomach NOS (disorder),n,via Query Table
+832681000000105,T-cell prolymphocytic leukaemia,n,via Query Table
+815031000000104,Hepatosplenic T-cell lymphoma (disorder),n,via Query Table
+657401000000109,Ca esophagus NOS (disorder),n,via Query Table
+189838005,[M]Mesothelial neoplasm NOS (morphologic abnormality),n,via Query Table
+190096000,[X]Malignant neoplasm of ill-defined sites within the respiratory system (disorder),n,via Query Table
+187895001,"Malignant neoplasm of upper respiratory tract, part unspecified (disorder)",n,via Query Table
+409841000000109,[M]Nevi and melanomas (morphologic abnormality),n,via Query Table
+134160009,[M]Dermatofibrosarcoma NOS (morphologic abnormality),n,via Query Table
+94363000,Secondary malignant neoplasm of lacrimal duct (disorder),n,via Query Table
+539391000000105,Malignant neoplasm of cerebrum NOS (disorder),n,via Query Table
+399607007,Chronic lymphocytic leukemia/small lymphocytic lymphoma (morphologic abnormality),n,via Query Table
+390401000000107,[X]Other specified leukaemias (disorder),n,via Query Table
+189754004,[M]Precancerous melanosis NOS (morphologic abnormality),n,via Query Table
+190079001,"[M]No microscopic confirmation of tumor, clinically malignant (morphologic abnormality)",n,via Query Table
+400151006,Congenital melanocytic nevus (morphologic abnormality),n,via Query Table
+556051000000107,Malignant neoplasm of retroperitoneum NOS (disorder),n,via Query Table
+557161000000109,"Malignant neoplasm of heart, thymus and mediastinum NOS (disorder)",n,via Query Table
+573621000000103,Malignant neoplasm of pharynx unspecified (disorder),n,via Query Table
+190048000,[M]Subacute myeloid leukemia (morphologic abnormality),n,via Query Table
+445691000000108,[M]Myeloid leukaemias (morphologic abnormality),n,via Query Table
+821891000000103,Benign myoma of prostate (disorder),n,via Query Table
+456651000000108,[M]Leukaemia NOS,n,via Query Table
+448922007,Secondary malignant neoplasm of large intestine and rectum (disorder),n,via Query Table
+190143007,[X]Malignant neoplasm of overlapping lesion of other and ill-defined sites (disorder),n,via Query Table
+440791000000107,[M]Neuroblastoma NOS (morphologic abnormality),n,via Query Table
+254853007,Clear cell tumor of ovary (disorder),n,via Query Table
+479031000000103,"[X]Malignant neoplasm of bronchus or lung, unspecified (disorder)",n,via Query Table
+557671000000107,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intrathoracic lymph nodes (disorder),n,via Query Table
+285768001,Acute myeloblastic leukemia with maturation (disorder),n,via Query Table
+189922003,[M]Cerebellar sarcoma NOS (morphologic abnormality),n,via Query Table
+189711009,[M]Medullary carcinoma NOS (morphologic abnormality),n,via Query Table
+189605003,[M]Adenomatous or adenocarcinomatous polyps of the colon NOS (morphologic abnormality),n,via Query Table
+190018003,"Plasma cell tumor, malignant (morphologic abnormality)",n,via Query Table
+956521000000101,Malignant Melanoma Stage IV M1a ,n,via Query Table
+833351000000104,Follicular lymphoma grade 2,n,via Query Table
+286892007,Ca breast - nipple/central (disorder),n,via Query Table
+170941000000100,Date cancer diagnosis received in primary care,n,via Query Table
+450971000000109,[M]leukemias unspecified (morphologic abnormality),n,via Query Table
+697551000000102,Carcinoma liver/biliary system NOS (disorder),n,via Query Table
+572191000000103,Hodgkin's granuloma NOS (disorder),n,via Query Table
+187600004,"Malignant neoplasm of upper lip, external (disorder)",n,via Query Table
+190026006,[M]Subacute leukemia NOS (morphologic abnormality),n,via Query Table
+190162005,[X]Other leukemia of unspecified cell type (disorder),n,via Query Table
+469881000000100,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+767511000000109,Secondary malignant neoplasm of large intestine and rectum (disorder),n,via Query Table
+326701000000106,Clark melanoma level 4 (finding),n,via Query Table
+467891000000106,"[X]Malignant neoplasm of peripheral nerves and autonomic nervous system, unspecified (disorder)",n,via Query Table
+438331000000107,"[M]Serous cystadenocarcinoma, NOS (morphologic abnormality)",n,via Query Table
+477531000000102,"[X]Malignant neoplasm of bone and articular cartilage, unspecified (disorder)",n,via Query Table
+189871009,[M] Epithelioid hemangioendothelioma NOS (morphologic abnormality),n,via Query Table
+189886003,[M]Chondrosarcoma NOS (morphologic abnormality),n,via Query Table
+190115003,"[X]Malignant neoplasm of peripheral nerves and autonomic nervous system, unspecified (disorder)",n,via Query Table
+189634009,[M]Clear cell adenoma or adenocarcinoma NOS (morphologic abnormality),n,via Query Table
+1051141000000100,Hereditary nonpolyposis colon cancer,n,via Query Table
+956561000000109,Malignant Melanoma Stage IV M1c ,n,via Query Table
+565971000000101,Malignant lymphoma NOS of lymph nodes of multiple sites (disorder),n,via Query Table
+863791000000103,Clinical stage C chronic lymphocytic leukaemia ,n,via Query Table
+409471000000101,[M]Hepatobiliary tract adenomas and carcinomas (morphologic abnormality),n,via Query Table
+408401000000103,[M]Medullary carcinoma NOS (morphologic abnormality),n,via Query Table
+543391000000107,Secondary and unspecified malignant neoplasm of axilla and upper limb lymph nodes NOS (disorder),n,via Query Table
+468291000000108,[M]Hairy naevus NOS (disorder),n,via Query Table
+134332001,Mesothelial tumor morphology (qualifier value),n,via Query Table
+313417009,[M]Tibial adamantinoma (morphologic abnormality),n,via Query Table
+398601000000108,[X]Malignant neoplasm of other specified male genital organs (disorder),n,via Query Table
+6357002,AIDS with primary lymphoma of the brain (disorder),n,via Query Table
+189666004,[M]Sweat gland adenocarcinoma (morphologic abnormality),n,via Query Table
+453011000000105,[M]Lymphosarcoma cell leukaemia NOS (morphologic abnormality),n,via Query Table
+833631000000102,Cutaneous/peripheral T-cell lymphoma,n,via Query Table
+478081000000106,[M]Brenner tumours (morphologic abnormality),n,via Query Table
+190138000,[X]Malignant neoplasm of thyroid and other endocrine glands (disorder),n,via Query Table
+285763005,Acute myeloblastic leukemia - undifferentiated (disorder),n,via Query Table

--- a/codelists/opensafely-haematological-cancer-snomed.csv
+++ b/codelists/opensafely-haematological-cancer-snomed.csv
@@ -1,0 +1,1439 @@
+id,name,active,notes
+128933000,Chronic leukemia - category (morphologic abnormality),y,direct mapping
+277610002,"Hodgkin's disease, nodular sclerosis - lymphocytic predominance (disorder)",y,direct mapping
+847481000000109,Follicular lymphoma grade 1 (disorder),y,direct mapping
+188733003,Chronic eosinophilic leukemia (disorder),y,direct mapping
+188612002,Nodular lymphoma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+277643003,High grade T-cell lymphoma (disorder),y,direct mapping
+188732008,Myeloid leukemia (disorder),y,direct mapping
+10639003,Solitary plasmacytoma of bone (morphologic abnormality),y,direct mapping
+188510001,"Burkitt's lymphoma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188517003,Burkitt's lymphoma of lymph nodes of multiple sites (disorder),y,direct mapping
+65399007,Langerhans cell histiocytosis (disorder),y,direct mapping
+188746008,Subacute monocytic leukemia (disorder),y,direct mapping
+93521006,Hodgkin's disease of intrapelvic lymph nodes (disorder),y,direct mapping
+189962004,"Malignant lymphoma, stem cell type (morphologic abnormality)",y,direct mapping
+314930007,Low grade T-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188514005,Burkitt's lymphoma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+93183001,Malignant histiocytosis of intrapelvic lymph nodes (disorder),y,direct mapping
+93134000,Letterer-Siwe disease of intrapelvic lymph nodes (disorder),y,direct mapping
+128799007,"Hodgkin lymphoma, lymphocyte-rich (morphologic abnormality)",y,direct mapping
+278052009,Malignant lymphoma of breast (disorder),y,direct mapping
+277567002,T-cell prolymphocytic leukemia (disorder),y,direct mapping
+45572000,"Hodgkin lymphoma, nodular sclerosis, grade 1 (morphologic abnormality)",y,direct mapping
+302845006,"Nodular malignant lymphoma, lymphocytic - well differentiated (disorder)",y,direct mapping
+93509007,"Hodgkin's disease, mixed cellularity of spleen (disorder)",y,direct mapping
+269476000,Nodular lymphoma (disorder),y,direct mapping
+41529000,"Hodgkin lymphoma, mixed cellularity (morphologic abnormality)",y,direct mapping
+1091921000000103,B-cell non-Hodgkin's lymphoma (disorder),y,direct mapping
+236512004,Leukemic infiltrate of kidney (disorder),y,direct mapping
+307650006,Histiocytic medullary reticulosis (disorder),y,direct mapping
+400001003,Primary cutaneous lymphoma (disorder),y,direct mapping
+118605002,"Hodgkin lymphoma, nodular lymphocyte predominance (disorder)",y,direct mapping
+127580003,Plasma cell neoplasm (morphologic abnormality),y,direct mapping
+277623009,Monocytoid B-cell lymphoma (disorder),y,direct mapping
+307634003,"Hodgkin's disease, lymphocytic depletion, reticular type (disorder)",y,direct mapping
+93150008,Leukemic reticuloendotheliosis of lymph nodes of multiple sites (disorder),y,direct mapping
+93197009,Malignant lymphoma of lymph nodes of multiple sites (disorder),y,direct mapping
+277642008,Low grade T-cell lymphoma (disorder),y,direct mapping
+713897006,Burkitt lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,direct mapping
+118600007,Malignant lymphoma (disorder),y,direct mapping
+93145002,Leukemic reticuloendotheliosis of intrapelvic lymph nodes (disorder),y,direct mapping
+64575004,"Malignant lymphoma, small lymphocytic (morphologic abnormality)",y,direct mapping
+847741000000106,Diffuse large B-cell lymphoma (disorder),y,direct mapping
+188500005,"Lymphosarcoma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+277618009,Follicular low grade B-cell lymphoma (disorder),y,direct mapping
+277632006,Diffuse malignant lymphoma - centroblastic polymorphic (disorder),y,direct mapping
+56944001,Lymphoma stage III (finding),y,direct mapping
+118599009,Hodgkin's disease (disorder),y,direct mapping
+109965004,"Diffuse non-Hodgkin's lymphoma, lymphoblastic (disorder)",y,direct mapping
+277637000,Large cell anaplastic lymphoma (disorder),y,direct mapping
+128831004,Chronic myelomonocytic leukemia (morphologic abnormality),y,direct mapping
+188580008,"Hodgkin's disease, mixed cellularity of intrapelvic lymph nodes (disorder)",y,direct mapping
+118614007,"Langerhans cell histiocytosis, disseminated (disorder)",y,direct mapping
+314927000,High grade T-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188565002,"Hodgkin's disease, nodular sclerosis of lymph nodes of head, face and neck (disorder)",y,direct mapping
+95224004,Reticulosarcoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+277625002,Follicular malignant lymphoma - small cleaved cell (disorder),y,direct mapping
+314929002,Diffuse low grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188613007,Nodular lymphoma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+188679001,Diffuse non-Hodgkin's lymphoma undifferentiated (diffuse) (disorder),y,direct mapping
+277473004,B-cell chronic lymphocytic leukemia (disorder),y,direct mapping
+188770007,Subacute myelomonocytic leukemia (disorder),y,direct mapping
+110002002,Mast cell leukemia (disorder),y,direct mapping
+847651000000100,Follicular lymphoma grade 3 (disorder),y,direct mapping
+43985008,"Hodgkin lymphoma, nodular sclerosis, grade 2 (morphologic abnormality)",y,direct mapping
+110007008,Adult T-cell leukemia/lymphoma (disorder),y,direct mapping
+93494007,"Hodgkin's disease, lymphocytic-histiocytic predominance of intrapelvic lymph nodes (disorder)",y,direct mapping
+71109004,"Hodgkin lymphoma, lymphocyte depletion, reticular (morphologic abnormality)",y,direct mapping
+815361000000107,Acute myeloid leukaemia with 11q23 abnormality (disorder),y,direct mapping
+109982002,Alpha heavy chain disease (disorder),y,direct mapping
+93554008,Hodgkin's sarcoma of spleen (disorder),y,direct mapping
+94708009,Mycosis fungoides of intrapelvic lymph nodes (disorder),y,direct mapping
+277653002,Peripheral T-cell lymphoma - pleomorphic medium and large cell (disorder),y,direct mapping
+93139005,Letterer-Siwe disease of lymph nodes of multiple sites (disorder),y,direct mapping
+93525002,Hodgkin's disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,direct mapping
+190955000,Histiocytosis X syndrome (disorder),y,direct mapping
+188567005,"Hodgkin's disease, nodular sclerosis of intra-abdominal lymph nodes (disorder)",y,direct mapping
+93146001,Leukemic reticuloendotheliosis of intrathoracic lymph nodes (disorder),y,direct mapping
+413441006,"Acute monocytic leukemia, FAB M5b (disorder)",y,direct mapping
+277549009,Chronic lymphocytic prolymphocytic leukemia syndrome (disorder),y,direct mapping
+93526001,Hodgkin's disease of lymph nodes of multiple sites (disorder),y,direct mapping
+277622004,Mucosa-associated lymphoma (disorder),y,direct mapping
+94712003,Mycosis fungoides of lymph nodes of inguinal region AND/OR lower limb (disorder),y,direct mapping
+188632001,Sézary's disease of intra-abdominal lymph nodes (disorder),y,direct mapping
+188487008,Lymphosarcoma and reticulosarcoma (disorder),y,direct mapping
+240531002,African Burkitt's lymphoma (disorder),y,direct mapping
+255101006,Sézary disease of skin (disorder),y,direct mapping
+274905008,"Malignant lymphoma - lymphocytic, intermediate differentiation (disorder)",y,direct mapping
+285769009,Acute promyelocytic leukemia - hypogranular variant (disorder),y,direct mapping
+95230004,Reticulosarcoma of lymph nodes of multiple sites (disorder),y,direct mapping
+188590000,"Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region and lower limb (disorder)",y,direct mapping
+277616008,Diffuse low grade B-cell lymphoma (disorder),y,direct mapping
+188493000,Reticulosarcoma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+188592008,"Hodgkin's disease, lymphocytic depletion of spleen (disorder)",y,direct mapping
+4950009,Sézary's disease (morphologic abnormality),y,direct mapping
+188737002,Chloroma (disorder),y,direct mapping
+52220008,"Acute megakaryoblastic leukemia, morphology (morphologic abnormality)",y,direct mapping
+188503007,Lymphosarcoma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+277589003,Atypical chronic myeloid leukemia (disorder),y,direct mapping
+93135004,Letterer-Siwe disease of intrathoracic lymph nodes (disorder),y,direct mapping
+188718006,"Malignant plasma cell neoplasm, extramedullary plasmacytoma (disorder)",y,direct mapping
+189982000,Reticulosarcoma morphology (morphologic abnormality),y,direct mapping
+277611003,"Hodgkin's disease, nodular sclerosis - mixed cellularity (disorder)",y,direct mapping
+277619001,B-cell prolymphocytic leukemia (disorder),y,direct mapping
+109977009,Peripheral T-cell lymphoma (disorder),y,direct mapping
+188663002,Mast cell malignancy of intrathoracic lymph nodes (disorder),y,direct mapping
+314931006,Nodular high grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+359631009,"Acute myeloid leukemia, minimal differentiation, FAB M0 (disorder)",y,direct mapping
+93196000,Malignant lymphoma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,direct mapping
+55020008,"Follicular lymphoma, grade 2 (morphologic abnormality)",y,direct mapping
+109995007,Myelodysplastic syndrome (disorder),y,direct mapping
+35287006,"Myeloid sarcoma, morphology (morphologic abnormality)",y,direct mapping
+188512009,Burkitt's lymphoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+188648000,Leukemic reticuloendotheliosis of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+863741000000108,Clinical stage A chronic lymphocytic leukaemia (disorder),y,direct mapping
+109976000,Lymphoepithelioid lymphoma (disorder),y,direct mapping
+188744006,Monocytic leukemia (disorder),y,direct mapping
+127225006,Chronic myelomonocytic leukemia (disorder),y,direct mapping
+188569008,"Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region and lower limb (disorder)",y,direct mapping
+847701000000108,Follicular lymphoma grade 3b (disorder),y,direct mapping
+93493001,"Hodgkin's disease, lymphocytic-histiocytic predominance of intra-abdominal lymph nodes (disorder)",y,direct mapping
+188745007,Chronic monocytic leukemia (disorder),y,direct mapping
+373168002,Reticulosarcoma (disorder),y,direct mapping
+426336007,Solitary osseous myeloma (disorder),y,direct mapping
+109980005,Malignant immunoproliferative disease (disorder),y,direct mapping
+188729005,Adult T-cell leukemia (disorder),y,direct mapping
+188589009,"Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla and upper limb (disorder)",y,direct mapping
+269475001,"Malignant tumor of lymphoid, hemopoietic AND/OR related tissue (disorder)",y,direct mapping
+303056000,"Malignant lymphoma, follicular center cell, cleaved (disorder)",y,direct mapping
+109978004,T-cell lymphoma (disorder),y,direct mapping
+188725004,Lymphoid leukemia (disorder),y,direct mapping
+91857003,"Acute lymphoid leukemia, disease (disorder)",y,direct mapping
+93495008,"Hodgkin's disease, lymphocytic-histiocytic predominance of intrathoracic lymph nodes (disorder)",y,direct mapping
+93140007,Letterer-Siwe disease of spleen (disorder),y,direct mapping
+188631008,Sézary's disease of intrathoracic lymph nodes (disorder),y,direct mapping
+128924002,Mast cell leukemia (morphologic abnormality),y,direct mapping
+188559002,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region and lower limb (disorder)",y,direct mapping
+112687003,"Hodgkin lymphoma, lymphocyte depletion (morphologic abnormality)",y,direct mapping
+188554007,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face and neck (disorder)",y,direct mapping
+110006004,Prolymphocytic leukemia (disorder),y,direct mapping
+739301006,Osteoporosis co-occurrent and due to multiple myeloma (disorder),y,direct mapping
+359648001,"Acute myeloid leukemia with maturation, FAB M2 (disorder)",y,direct mapping
+115245001,"Malignant lymphoma, follicular AND/OR nodular (morphologic abnormality)",y,direct mapping
+188748009,Aleukemic monocytic leukemia (disorder),y,direct mapping
+76422004,Lymphoma stage II (finding),y,direct mapping
+95225003,Reticulosarcoma of intrapelvic lymph nodes (disorder),y,direct mapping
+118608000,"Hodgkin's disease, nodular sclerosis (disorder)",y,direct mapping
+118617000,Burkitt's lymphoma (disorder),y,direct mapping
+74654000,Mantle cell lymphoma (morphologic abnormality),y,direct mapping
+188642004,Malignant histiocytosis of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+93530003,Hodgkin's granuloma of intrapelvic lymph nodes (disorder),y,direct mapping
+190818004,Waldenström macroglobulinemia (disorder),y,direct mapping
+277609007,"Hodgkin's disease, lymphocytic predominance - diffuse (disorder)",y,direct mapping
+277626001,Diffuse high grade B-cell lymphoma (disorder),y,direct mapping
+400122007,Primary cutaneous T-cell lymphoma (disorder),y,direct mapping
+188585003,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face and neck (disorder)",y,direct mapping
+277550009,Richter's syndrome (disorder),y,direct mapping
+314922006,B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188502002,Lymphosarcoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+188541000,Hodgkin's granuloma of lymph nodes of multiple sites (disorder),y,direct mapping
+95193005,Nodular lymphoma of spleen (disorder),y,direct mapping
+94714002,Mycosis fungoides of spleen (disorder),y,direct mapping
+188754005,Megakaryocytic leukemia (disorder),y,direct mapping
+188489006,"Reticulosarcoma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+8900005,Hypoproteinemia (disorder),y,direct mapping
+307633009,"Hodgkin's disease, lymphocytic depletion, diffuse fibrosis (disorder)",y,direct mapping
+277629008,Diffuse malignant lymphoma - large non-cleaved cell (disorder),y,direct mapping
+188691005,Malignant immunoproliferative small intestinal disease (disorder),y,direct mapping
+277474005,B-cell chronic lymphocytic leukemia variant (disorder),y,direct mapping
+303057009,"Malignant lymphoma, follicular center cell, non-cleaved (disorder)",y,direct mapping
+128841001,Polycythemia vera (morphologic abnormality),y,direct mapping
+94709001,Mycosis fungoides of intrathoracic lymph nodes (disorder),y,direct mapping
+109979007,B-cell lymphoma (disorder),y,direct mapping
+39795003,Hand-Schüller-Christian disease (disorder),y,direct mapping
+93549004,Hodgkin's sarcoma of intrathoracic lymph nodes (disorder),y,direct mapping
+13583002,Mast cell sarcoma (morphologic abnormality),y,direct mapping
+95210003,"Plasma cell leukemia, disease (disorder)",y,direct mapping
+91855006,"Acute leukemia, disease (disorder)",y,direct mapping
+93198004,Malignant lymphoma of spleen (disorder),y,direct mapping
+40411000,"Follicular lymphoma, grade 3 (morphologic abnormality)",y,direct mapping
+420788006,Intraocular non-Hodgkin malignant lymphoma (disorder),y,direct mapping
+445105005,Blastic plasmacytoid dendritic cell neoplasm (disorder),y,direct mapping
+93133006,Letterer-Siwe disease of intra-abdominal lymph nodes (disorder),y,direct mapping
+30440004,Lymphoma stage I (finding),y,direct mapping
+188506004,Lymphosarcoma of spleen (disorder),y,direct mapping
+30962008,Acute myelomonocytic leukemia (morphologic abnormality),y,direct mapping
+35562000,Waldenstrom's macroglobulinemia (morphologic abnormality),y,direct mapping
+443487006,Mantle cell lymphoma (disorder),y,direct mapping
+397009000,Mast cell malignancy (disorder),y,direct mapping
+93151007,Hairy cell leukemia of spleen (disorder),y,direct mapping
+307635002,"Hodgkin's disease, nodular sclerosis - cellular phase (disorder)",y,direct mapping
+277617004,High grade B-cell lymphoma (disorder),y,direct mapping
+188669003,Mast cell malignancy of lymph nodes of multiple sites (disorder),y,direct mapping
+188501009,Lymphosarcoma of intrathoracic lymph nodes (disorder),y,direct mapping
+277601005,Acute monoblastic leukemia (disorder),y,direct mapping
+118610003,"Hodgkin's disease, lymphocytic depletion (disorder)",y,direct mapping
+93527005,Hodgkin's disease of spleen (disorder),y,direct mapping
+314924007,Follicular low grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188515006,Burkitt's lymphoma of intrapelvic lymph nodes (disorder),y,direct mapping
+50102004,"Malignant lymphoma, mixed small and large cell, diffuse (morphologic abnormality)",y,direct mapping
+93188005,Malignant histiocytosis of lymph nodes of multiple sites (disorder),y,direct mapping
+445448008,Acute myeloid leukemia with myelodysplasia-related changes (disorder),y,direct mapping
+93138002,Letterer-Siwe disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,direct mapping
+14537002,"Hodgkin lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+307647008,"Malignant lymphoma, centroblastic type, follicular (disorder)",y,direct mapping
+109984001,Gamma heavy chain disease (disorder),y,direct mapping
+95188007,Nodular lymphoma of intrathoracic lymph nodes (disorder),y,direct mapping
+95187002,Nodular lymphoma of intrapelvic lymph nodes (disorder),y,direct mapping
+109991003,Acute myelofibrosis (disorder),y,direct mapping
+307592006,Basophilic leukemia (disorder),y,direct mapping
+14317002,"Acute myeloid leukemia, M6 type (morphologic abnormality)",y,direct mapping
+277575008,T-cell acute lymphoblastic leukemia (disorder),y,direct mapping
+109988003,Histiocytic sarcoma (disorder),y,direct mapping
+188736006,Subacute myeloid leukemia (disorder),y,direct mapping
+188641006,Malignant histiocytosis of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+21964009,"Malignant lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+278189009,Hypergranular promyelocytic leukemia (disorder),y,direct mapping
+188768003,Myelomonocytic leukemia (disorder),y,direct mapping
+188538009,Hodgkin's granuloma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+278453007,Acute biphenotypic leukemia (disorder),y,direct mapping
+128923008,"Prolymphocytic leukemia, no ICD-O subtype (morphologic abnormality)",y,direct mapping
+277614006,Prethymic and thymic T-cell lymphoma/leukemia (disorder),y,direct mapping
+1090241000000107,Angioimmunoblastic T-cell lymphoma with dysproteinaemia (disorder),y,direct mapping
+109989006,Multiple myeloma (disorder),y,direct mapping
+449220000,Diffuse follicle center lymphoma (disorder),y,direct mapping
+276836002,Primary cerebral lymphoma (disorder),y,direct mapping
+39086001,"Hodgkin lymphoma, nodular sclerosis, cellular phase (morphologic abnormality)",y,direct mapping
+95226002,Reticulosarcoma of intrathoracic lymph nodes (disorder),y,direct mapping
+308121000,Follicular non-Hodgkin's lymphoma (disorder),y,direct mapping
+118618005,Mycosis fungoides (disorder),y,direct mapping
+307617006,Neutrophilic leukemia (disorder),y,direct mapping
+847691000000108,Follicular lymphoma grade 3a (disorder),y,direct mapping
+449386007,Philadelphia chromosome negative chronic myelogenous leukemia (disorder),y,direct mapping
+302841002,Malignant lymphoma - small lymphocytic (disorder),y,direct mapping
+285839005,Acute myelomonocytic leukemia - eosinophilic variant (disorder),y,direct mapping
+414655002,Mature (peripheral) T-cell neoplasm (morphologic abnormality),y,direct mapping
+302848008,"Nodular malignant lymphoma, lymphocytic - intermediate differentiation (disorder)",y,direct mapping
+232075002,Lymphoma of retina (disorder),y,direct mapping
+31047003,Lymphomatoid papulosis (disorder),y,direct mapping
+302855005,Subacute leukemia (disorder),y,direct mapping
+118601006,Non-Hodgkin's lymphoma (disorder),y,direct mapping
+188504001,Lymphosarcoma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+188672005,Follicular non-Hodgkin's mixed small cleaved and large cell lymphoma (disorder),y,direct mapping
+445406001,Hepatosplenic T-cell lymphoma (disorder),y,direct mapping
+128812005,"Langerhans cell histiocytosis, disseminated (morphologic abnormality)",y,direct mapping
+314923001,Low grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+110004001,"Acute promyelocytic leukemia, FAB M3 (disorder)",y,direct mapping
+93143009,"Leukemia, disease (disorder)",y,direct mapping
+307637005,"Malignant lymphoma, centroblastic-centrocytic, follicular (disorder)",y,direct mapping
+188591001,"Hodgkin's disease, lymphocytic depletion of intrapelvic lymph nodes (disorder)",y,direct mapping
+93547002,Hodgkin's sarcoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+277580004,Non-secretory myeloma (disorder),y,direct mapping
+68979007,Heavy chain disease (disorder),y,direct mapping
+188726003,Subacute lymphoid leukemia (disorder),y,direct mapping
+93193008,Malignant lymphoma of intrathoracic lymph nodes (disorder),y,direct mapping
+93182006,Malignant histiocytosis of intra-abdominal lymph nodes (disorder),y,direct mapping
+285776004,Intermediate grade B-cell lymphoma (disorder),y,direct mapping
+307623001,Malignant lymphoma - lymphoplasmacytic (disorder),y,direct mapping
+188738007,Granulocytic sarcoma (disorder),y,direct mapping
+277545003,T-cell chronic lymphocytic leukemia (disorder),y,direct mapping
+275524009,Immunoproliferative neoplasm (disorder),y,direct mapping
+446643000,Sarcoma of dendritic cells (accessory cells) (disorder),y,direct mapping
+74189002,Hodgkin granuloma [obs] (morphologic abnormality),y,direct mapping
+277587001,Juvenile chronic myeloid leukemia (disorder),y,direct mapping
+51092000,B-cell chronic lymphocytic leukemia/small lymphocytic lymphoma (morphologic abnormality),y,direct mapping
+109975001,T-zone lymphoma (disorder),y,direct mapping
+103686008,Intestinal T-cell lymphoma (morphologic abnormality),y,direct mapping
+54087003,Hairy cell leukemia (morphologic abnormality),y,direct mapping
+92812005,"Chronic leukemia, disease (disorder)",y,direct mapping
+128832006,Juvenile myelomonocytic leukemia (morphologic abnormality),y,direct mapping
+118607005,"Hodgkin lymphoma, lymphocyte-rich (disorder)",y,direct mapping
+188662007,"Mast cell malignancy of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188665009,Mast cell malignancy of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+277570003,Lymphoma with spill (disorder),y,direct mapping
+188728002,Aleukemic lymphoid leukemia (disorder),y,direct mapping
+188634000,Sézary's disease of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+302842009,Diffuse malignant lymphoma - centroblastic (disorder),y,direct mapping
+188544008,"Hodgkin's sarcoma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+276811008,Gastric lymphoma (disorder),y,direct mapping
+46923007,Hodgkin sarcoma [obs] (morphologic abnormality),y,direct mapping
+863781000000100,Clinical stage C chronic lymphocytic leukaemia (disorder),y,direct mapping
+50150000,Malignant mastocytosis (morphologic abnormality),y,direct mapping
+277573001,Common acute lymphoblastic leukemia (disorder),y,direct mapping
+188660004,Malignant mast cell tumors (disorder),y,direct mapping
+95186006,Nodular lymphoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+448212009,Anaplastic lymphoma kinase negative anaplastic large cell lymphoma (disorder),y,direct mapping
+93194002,Malignant lymphoma of lymph nodes of axilla AND/OR upper limb (disorder),y,direct mapping
+19340000,"Malignant lymphoma, lymphoplasmacytic (morphologic abnormality)",y,direct mapping
+188537004,Hodgkin's granuloma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+95263006,Sézary's disease of spleen (disorder),y,direct mapping
+277604002,Acute eosinophilic leukemia (disorder),y,direct mapping
+52248008,"Hodgkin lymphoma, nodular sclerosis (morphologic abnormality)",y,direct mapping
+55150002,Follicular lymphoma (morphologic abnormality),y,direct mapping
+188548006,Hodgkin's sarcoma of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+188630009,"Sézary's disease of lymph nodes of head, face and neck (disorder)",y,direct mapping
+93191005,Malignant lymphoma of intra-abdominal lymph nodes (disorder),y,direct mapping
+738770003,Anaplastic lymphoma kinase positive anaplastic large cell lymphoma (disorder),y,direct mapping
+93531004,Hodgkin's granuloma of intrathoracic lymph nodes (disorder),y,direct mapping
+314926009,T-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+188640007,"Malignant histiocytosis of lymph nodes of head, face and neck (disorder)",y,direct mapping
+22197008,Burkitt cell leukemia (morphologic abnormality),y,direct mapping
+188575004,"Hodgkin's disease, mixed cellularity of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188566001,"Hodgkin's disease, nodular sclerosis of intrathoracic lymph nodes (disorder)",y,direct mapping
+16893006,"Hodgkin lymphoma, lymphocyte depletion, diffuse fibrosis (morphologic abnormality)",y,direct mapping
+188568000,"Hodgkin's disease, nodular sclerosis of lymph nodes of axilla and upper limb (disorder)",y,direct mapping
+404133000,Subcutaneous panniculitic cutaneous T-cell lymphoma (disorder),y,direct mapping
+109969005,"Diffuse non-Hodgkin's lymphoma, large cell (disorder)",y,direct mapping
+1091861000000100,"Follicular lymphoma, cutaneous follicle centre (disorder)",y,direct mapping
+109966003,"Diffuse non-Hodgkin's lymphoma, immunoblastic (disorder)",y,direct mapping
+277569004,Large granular lymphocytic leukemia (disorder),y,direct mapping
+93144003,Leukemic reticuloendotheliosis of intra-abdominal lymph nodes (disorder),y,direct mapping
+167934009,Bone marrow: myeloma cells (finding),y,direct mapping
+188578002,"Hodgkin's disease, mixed cellularity of lymph nodes of axilla and upper limb (disorder)",y,direct mapping
+93189002,Malignant histiocytosis of spleen (disorder),y,direct mapping
+277571004,B-cell acute lymphoblastic leukemia (disorder),y,direct mapping
+188734009,Chronic neutrophilic leukemia (disorder),y,direct mapping
+28054005,"Cutaneous T-cell lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+277551008,Splenic lymphoma with villous lymphocytes (disorder),y,direct mapping
+188577007,"Hodgkin's disease, mixed cellularity of intra-abdominal lymph nodes (disorder)",y,direct mapping
+307625008,Malignant lymphoma - centrocytic (disorder),y,direct mapping
+188741003,Aleukemic myeloid leukemia (disorder),y,direct mapping
+359640008,"Acute myeloid leukemia without maturation, FAB M1 (disorder)",y,direct mapping
+91861009,"Acute myeloid leukemia, disease (disorder)",y,direct mapping
+277624003,Follicular malignant lymphoma - mixed cell type (disorder),y,direct mapping
+128813000,Histiocytic sarcoma (morphologic abnormality),y,direct mapping
+277568007,Hairy cell leukemia variant (disorder),y,direct mapping
+118609008,"Hodgkin's disease, mixed cellularity (disorder)",y,direct mapping
+1929004,"Non-Hodgkin lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+188593003,"Hodgkin's disease, lymphocytic depletion of lymph nodes of multiple sites (disorder)",y,direct mapping
+189984004,"Reticulosarcoma, pleomorphic cell type (morphologic abnormality)",y,direct mapping
+90120004,Mycosis fungoides (morphologic abnormality),y,direct mapping
+188511002,Burkitt's lymphoma of intrathoracic lymph nodes (disorder),y,direct mapping
+94719007,"Myeloid sarcoma, disease (disorder)",y,direct mapping
+93195001,"Malignant lymphoma of lymph nodes of head, face AND/OR neck (disorder)",y,direct mapping
+66445009,Lymphoma stage IV (finding),y,direct mapping
+188637007,Sézary's disease of lymph nodes of multiple sites (disorder),y,direct mapping
+93500006,"Hodgkin's disease, lymphocytic-histiocytic predominance of spleen (disorder)",y,direct mapping
+188667001,Mast cell malignancy of intrapelvic lymph nodes (disorder),y,direct mapping
+285422003,Immunoglobulin D myeloma (disorder),y,direct mapping
+94710006,Mycosis fungoides of lymph nodes of axilla AND/OR upper limb (disorder),y,direct mapping
+445269007,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue (disorder),y,direct mapping
+188534006,"Hodgkin's granuloma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188576003,"Hodgkin's disease, mixed cellularity of intrathoracic lymph nodes (disorder)",y,direct mapping
+95231000,Reticulosarcoma of spleen (disorder),y,direct mapping
+188587006,"Hodgkin's disease, lymphocytic depletion of intra-abdominal lymph nodes (disorder)",y,direct mapping
+276815004,Lymphoma of intestine (disorder),y,direct mapping
+93518009,"Hodgkin's disease, nodular sclerosis of spleen (disorder)",y,direct mapping
+93192003,Malignant lymphoma of intrapelvic lymph nodes (disorder),y,direct mapping
+307636001,"Malignant lymphoma, mixed lymphocytic-histiocytic, nodular (disorder)",y,direct mapping
+277615007,Low grade B-cell lymphoma (disorder),y,direct mapping
+24072005,"Acute leukemia, morphology, including blast cell OR undifferentiated leukemia (morphologic abnormality)",y,direct mapping
+190817009,Macroglobulinemia (disorder),y,direct mapping
+444910004,Primary mediastinal (thymic) large B-cell lymphoma (disorder),y,direct mapping
+93520007,Hodgkin's disease of intra-abdominal lymph nodes (disorder),y,direct mapping
+128805001,"Natural killer-/T-cell lymphoma, nasal and nasal-type (morphologic abnormality)",y,direct mapping
+93548007,Hodgkin's sarcoma of intrapelvic lymph nodes (disorder),y,direct mapping
+92814006,"Chronic lymphoid leukemia, disease (disorder)",y,direct mapping
+277654008,Enteropathy-associated T-cell lymphoma (disorder),y,direct mapping
+188582000,"Hodgkin's disease, mixed cellularity of lymph nodes of multiple sites (disorder)",y,direct mapping
+77430005,Adult T-cell leukemia/lymphoma (morphologic abnormality),y,direct mapping
+277579002,Light chain myeloma (disorder),y,direct mapping
+32280000,"Lymphoid leukemia, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+277628000,Diffuse malignant lymphoma - large cleaved cell (disorder),y,direct mapping
+314925008,High grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+449108003,Philadelphia chromosome positive chronic myelogenous leukemia (disorder),y,direct mapping
+128922003,"Plasma cell leukemia, morphology (morphologic abnormality)",y,direct mapping
+70600005,"Hodgkin lymphoma, nodular lymphocyte predominance (morphologic abnormality)",y,direct mapping
+188570009,"Hodgkin's disease, nodular sclerosis of intrapelvic lymph nodes (disorder)",y,direct mapping
+94707004,Mycosis fungoides of intra-abdominal lymph nodes (disorder),y,direct mapping
+307646004,"Malignant lymphoma, lymphocytic, poorly differentiated, nodular (disorder)",y,direct mapping
+93184007,Malignant histiocytosis of intrathoracic lymph nodes (disorder),y,direct mapping
+413440007,Acute lymphoblastic leukemia - category (morphologic abnormality),y,direct mapping
+188586002,"Hodgkin's disease, lymphocytic depletion of intrathoracic lymph nodes (disorder)",y,direct mapping
+415112005,Plasmacytoma (disorder),y,direct mapping
+277651000,Peripheral T-cell lymphoma - pleomorphic small cell (disorder),y,direct mapping
+118615008,Malignant mast cell tumor (disorder),y,direct mapping
+190055003,Eosinophilic leukemia (morphologic abnormality),y,direct mapping
+445227008,Juvenile myelomonocytic leukemia (disorder),y,direct mapping
+77381001,Burkitt lymphoma (morphologic abnormality),y,direct mapping
+87163000,"Leukemia, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+188609000,"Nodular lymphoma of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188558005,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla and upper limb (disorder)",y,direct mapping
+128931003,Leukemia - category (morphologic abnormality),y,direct mapping
+847631000000107,Follicular lymphoma grade 2 (disorder),y,direct mapping
+303055001,"Malignant lymphoma, follicular center cell (disorder)",y,direct mapping
+128920006,Malignant histiocytosis (morphologic abnormality),y,direct mapping
+128803008,Marginal zone B-cell lymphoma (morphologic abnormality),y,direct mapping
+188536008,Hodgkin's granuloma of intra-abdominal lymph nodes (disorder),y,direct mapping
+277664004,Malignant lymphoma of testis (disorder),y,direct mapping
+314934003,Diffuse high grade B-cell lymphoma morphology (morphologic abnormality),y,direct mapping
+63364005,"Chronic myelogenous leukemia, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+277613000,Cutaneous/peripheral T-cell lymphoma (disorder),y,direct mapping
+835009,Angioimmunoblastic T-cell lymphoma (morphologic abnormality),y,direct mapping
+188513004,Burkitt's lymphoma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+28950004,"Acute promyelocytic leukemia, t(15;17)(q22;q11-12) (morphologic abnormality)",y,direct mapping
+93523009,Hodgkin's disease of lymph nodes of axilla AND/OR upper limb (disorder),y,direct mapping
+17788007,"Acute myeloid leukemia, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+92818009,"Chronic myeloid leukemia, disease (disorder)",y,direct mapping
+189985003,"Reticulosarcoma, nodular (morphologic abnormality)",y,direct mapping
+188668006,Mast cell malignancy of spleen (disorder),y,direct mapping
+95192000,Nodular lymphoma of lymph nodes of multiple sites (disorder),y,direct mapping
+277572006,Pre B-cell acute lymphoblastic leukemia (disorder),y,direct mapping
+109962001,Diffuse non-Hodgkin's lymphoma (disorder),y,direct mapping
+37064009,Hyperproteinemia (disorder),y,direct mapping
+302856006,Aleukemic leukemia (disorder),y,direct mapping
+22331004,"Acute monocytic leukemia, morphology (morphologic abnormality)",y,direct mapping
+307622006,Prolymphocytic lymphosarcoma (disorder),y,direct mapping
+128929007,Non-Hodgkin lymphoma - category (morphologic abnormality),y,direct mapping
+188633006,Sézary's disease of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+277543005,Malignant white blood cell disorder (disorder),y,direct mapping
+118602004,Hodgkin's granuloma (disorder),y,direct mapping
+188674006,Diffuse malignant lymphoma - small non-cleaved cell (disorder),y,direct mapping
+188498009,Lymphosarcoma (disorder),y,direct mapping
+188664008,Mast cell malignancy of intra-abdominal lymph nodes (disorder),y,direct mapping
+277627005,Nodular high grade B-cell lymphoma (disorder),y,direct mapping
+820601000000103,Refractory anaemia with multilineage dysplasia (disorder),y,direct mapping
+188579005,"Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region and lower limb (disorder)",y,direct mapping
+414166008,"Extranodal natural killer/T-cell lymphoma, nasal type (disorder)",y,direct mapping
+118606001,Hodgkin's sarcoma (disorder),y,direct mapping
+285421005,Immunoglobulin G myeloma (disorder),y,direct mapping
+863761000000109,Clinical stage B chronic lymphocytic leukaemia (disorder),y,direct mapping
+128875000,Primary cutaneous CD30 antigen positive large T-cell lymphoma (disorder),y,direct mapping
+118611004,Sézary's disease (disorder),y,direct mapping
+307341004,Atypical hairy cell leukemia (disorder),y,direct mapping
+188666005,Mast cell malignancy of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+46732000,"Malignant lymphoma, large B-cell, diffuse, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+188645002,"Leukemic reticuloendotheliosis of lymph nodes of head, face and neck (disorder)",y,direct mapping
+188551004,Hodgkin's sarcoma of lymph nodes of multiple sites (disorder),y,direct mapping
+93136003,Letterer-Siwe disease of lymph nodes of axilla AND/OR upper limb (disorder),y,direct mapping
+93524003,"Hodgkin's disease of lymph nodes of head, face AND/OR neck (disorder)",y,direct mapping
+188676008,Malignant lymphoma - mixed small and large cell (disorder),y,direct mapping
+307624007,Diffuse malignant lymphoma - centroblastic-centrocytic (disorder),y,direct mapping
+277602003,Acute megakaryoblastic leukemia (disorder),y,direct mapping
+118612006,Malignant histiocytosis (disorder),y,direct mapping
+93451002,"Erythroleukemia, FAB M6 (disorder)",y,direct mapping
+236513009,Lymphoma of kidney (disorder),y,direct mapping
+188675007,Malignant lymphoma - small cleaved cell (disorder),y,direct mapping
+69077002,Acute basophilic leukemia (morphologic abnormality),y,direct mapping
+188649008,Leukemic reticuloendotheliosis of lymph nodes of inguinal region and lower limb (disorder),y,direct mapping
+188516007,Burkitt's lymphoma of spleen (disorder),y,direct mapping
+93536009,Hodgkin's granuloma of spleen (disorder),y,direct mapping
+188507008,Lymphosarcoma of lymph nodes of multiple sites (disorder),y,direct mapping
+118613001,Hairy cell leukemia (disorder),y,direct mapping
+188547001,Hodgkin's sarcoma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+109992005,Polycythemia vera (disorder),y,direct mapping
+442537007,Non-Hodgkin lymphoma associated with Human immunodeficiency virus infection (disorder),y,direct mapping
+188572001,"Hodgkin's disease, nodular sclerosis of lymph nodes of multiple sites (disorder)",y,direct mapping
+37810007,"Myeloid leukemia, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+303017006,"Malignant lymphoma, convoluted cell type (disorder)",y,direct mapping
+414628006,Lymphoid neoplasm (morphologic abnormality),y,direct mapping
+188635004,Sézary's disease of intrapelvic lymph nodes (disorder),y,direct mapping
+188627002,Mycosis fungoides of lymph nodes of multiple sites (disorder),y,direct mapping
+285420006,Immunoglobulin A myeloma (disorder),y,direct mapping
+277641001,Follicular malignant lymphoma - large cell (disorder),y,direct mapping
+55921005,"Multiple myeloma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,direct mapping
+277612005,"Hodgkin's disease, nodular sclerosis - lymphocytic depletion (disorder)",y,direct mapping
+234577004,Lipochrome histiocytosis - familial (disorder),y,direct mapping
+278051002,Malignant lymphoma of thyroid gland (disorder),y,direct mapping
+110005000,"Acute myelomonocytic leukemia, FAB M4 (disorder)",y,direct mapping
+188492005,Reticulosarcoma of lymph nodes of axilla and upper limb (disorder),y,direct mapping
+188562004,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of multiple sites (disorder)",y,direct mapping
+129000002,"Langerhans cell histiocytosis, unifocal (disorder)",y,direct mapping
+188505000,Lymphosarcoma of intrapelvic lymph nodes (disorder),y,direct mapping
+93522004,Hodgkin's disease of intrathoracic lymph nodes (disorder),y,direct mapping
+313427003,Lambda light chain myeloma (disorder),y,direct mapping
+277574007,Null cell acute lymphoblastic leukemia (disorder),y,direct mapping
+128930002,Hodgkin lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+92513005,Burkitt's tumor of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+419662008,Primary cutaneous follicle center cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+449419008,Follicular non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+702446006,Core binding factor acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+426248008,Aleukemic lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+404105000,Lymphomatoid papulosis type C (anaplastic large-cell lymphoma-like) (disorder),y,descendant of concept mapped from leaf
+103685007,Hepatosplenic gamma-delta cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+734142002,B-cell lymphoma with features intermediate between diffuse large B-cell lymphoma and Burkitt lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93208003,Malignant mast cell tumor of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+448867004,Diffuse non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+450916006,Mixed phenotype acute leukemia with myeloid and B-cell lymphoid phenotypes (morphologic abnormality),y,descendant of concept mapped from leaf
+93514006,"Hodgkin's disease, nodular sclerosis of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+397356009,Indolent systemic mastocytosis (morphologic abnormality),y,descendant of concept mapped from leaf
+734522002,Acute myeloid leukemia with FMS-like tyrosine kinase-3 mutation (disorder),y,descendant of concept mapped from leaf
+413527004,"Anaplastic large cell lymphoma, T/Null cell, primary systemic type (morphologic abnormality)",y,descendant of concept mapped from leaf
+425037004,"Low grade lymphoma, stage 1 (finding)",y,descendant of concept mapped from leaf
+427056005,Subacute leukemia in remission (disorder),y,descendant of concept mapped from leaf
+449217008,Diffuse non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+128820007,"Prolymphocytic leukemia, B-cell type (morphologic abnormality)",y,descendant of concept mapped from leaf
+450935006,Myeloid leukemia associated with Down Syndrome (morphologic abnormality),y,descendant of concept mapped from leaf
+413843002,Chronic myeloid leukemia in myeloid blast crisis (disorder),y,descendant of concept mapped from leaf
+93185008,Malignant histiocytosis of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+93186009,"Malignant histiocytosis of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+448269008,Lymphoma of lesser curvature of stomach (disorder),y,descendant of concept mapped from leaf
+237865009,Primary amyloidosis of light chain type (disorder),y,descendant of concept mapped from leaf
+128833001,Aggressive natural killer-cell leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+109970006,"Follicular non-Hodgkin's lymphoma, small cleaved cell (disorder)",y,descendant of concept mapped from leaf
+190030009,Compound leukemias (disorder),y,descendant of concept mapped from leaf
+418152006,Precursor B-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+415111003,Plasma cell neoplasm (disorder),y,descendant of concept mapped from leaf
+419879004,Atypical Burkitt's lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94718004,Myeloid sarcoma in remission (disorder),y,descendant of concept mapped from leaf
+763884007,Splenic diffuse red pulp small B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+397400006,Burkitt lymphoma/leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+450958009,"Malignant lymphoma, diffuse large B-cell, immunoblastic (morphologic abnormality)",y,descendant of concept mapped from leaf
+110460003,"Plasma cell tumor, benign (morphologic abnormality)",y,descendant of concept mapped from leaf
+115246000,Specified cutaneous AND/OR peripheral T cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+721304007,Refractory thrombocytopenia (disorder),y,descendant of concept mapped from leaf
+109985000,Immunoproliferative small intestinal disease (disorder),y,descendant of concept mapped from leaf
+426217000,Aleukemic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+109964000,"Diffuse non-Hodgkin's lymphoma, undifferentiated (disorder)",y,descendant of concept mapped from leaf
+35601003,Monoclonal gammopathy of undetermined significance (morphologic abnormality),y,descendant of concept mapped from leaf
+404126000,CD-30 positive pleomorphic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+734076008,Diffuse large B-cell lymphoma associated with chronic inflammation (morphologic abnormality),y,descendant of concept mapped from leaf
+285424002,Immunoglobulin G monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+239940004,Lymphomatoid granulomatosis (disorder),y,descendant of concept mapped from leaf
+93487009,"Hodgkin's disease, lymphocytic depletion of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+92813000,Chronic lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+450917002,Mixed phenotype acute leukemia with myeloid and T-cell lymphoid phenotypes (morphologic abnormality),y,descendant of concept mapped from leaf
+724650000,Primary follicular dendritic cell sarcoma (disorder),y,descendant of concept mapped from leaf
+450956008,B lymphoblastic leukemia lymphoma with t(1;19)(q23;p13.3); E2A-PBX1 (TCF3-PBX1) (morphologic abnormality),y,descendant of concept mapped from leaf
+413587002,Smoldering myeloma (disorder),y,descendant of concept mapped from leaf
+444597005,Extranodal marginal zone lymphoma of mucosa-associated lymphoid tissue of stomach (disorder),y,descendant of concept mapped from leaf
+721311006,Systemic Epstein-Barr virus positive T-cell lymphoproliferative disease of childhood (disorder),y,descendant of concept mapped from leaf
+91858008,Acute monocytic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+404132005,Pleomorphic small/medium-sized cell cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+404125001,CD-30 positive anaplastic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+425657001,Osteosclerotic myeloma (disorder),y,descendant of concept mapped from leaf
+447766003,Lymphoma of pyloric antrum of stomach (disorder),y,descendant of concept mapped from leaf
+413847001,Chronic phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+93169003,Lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+450920005,B lymphoblastic leukemia / lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+450937003,Acute myeloid leukemia (megakaryoblastic) with t(1;22)(p13;q13); RBM15-MKL1 (morphologic abnormality),y,descendant of concept mapped from leaf
+128807009,Precursor B-cell lymphoblastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+449072004,Lymphoma of gastrointestinal tract (disorder),y,descendant of concept mapped from leaf
+449053004,Lymphoma of lower esophagus (disorder),y,descendant of concept mapped from leaf
+718721006,Congenital analbuminemia (disorder),y,descendant of concept mapped from leaf
+716788007,Epstein-Barr virus positive diffuse large B-cell lymphoma of elderly (disorder),y,descendant of concept mapped from leaf
+80570006,Acute panmyelosis with myelofibrosis (morphologic abnormality),y,descendant of concept mapped from leaf
+44255004,Lymphoma stage IIIe (finding),y,descendant of concept mapped from leaf
+449216004,Diffuse non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+397467006,"Follicular lymphoma, cutaneous follicle center sub-type (morphologic abnormality)",y,descendant of concept mapped from leaf
+93532006,Hodgkin's granuloma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+82546001,Reactive immunoproliferative disease (disorder),y,descendant of concept mapped from leaf
+93545005,Hodgkin's paragranuloma of spleen (disorder),y,descendant of concept mapped from leaf
+736322001,Pediatric follicular lymphoma (disorder),y,descendant of concept mapped from leaf
+404148006,Diffuse large B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+404104001,Lymphomatoid papulosis type B - mycosis fungoides-like (disorder),y,descendant of concept mapped from leaf
+722953004,B-cell lymphoma unclassifiable with features intermediate between Burkitt lymphoma and diffuse large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+699657009,Hepatosplenic gamma-delta cell lymphoma (disorder),y,descendant of concept mapped from leaf
+448386004,Non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+397351004,"Post-transplant lymphoproliferative disorder, polymorphic (morphologic abnormality)",y,descendant of concept mapped from leaf
+448254007,Non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+109994006,Essential thrombocythemia (disorder),y,descendant of concept mapped from leaf
+724647003,Diffuse large B-cell lymphoma co-occurrent with chronic inflammation caused by Epstein-Barr virus (disorder),y,descendant of concept mapped from leaf
+404114005,Erythrodermic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+93552007,Hodgkin's sarcoma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+6381009,Heavy chain disease (morphologic abnormality),y,descendant of concept mapped from leaf
+93207008,Malignant mast cell tumor of spleen (disorder),y,descendant of concept mapped from leaf
+128932005,Acute leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+93516008,"Hodgkin's disease, nodular sclerosis of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+713718006,Diffuse non-Hodgkin immunoblastic lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+448709005,Non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+404150003,Mantle cell B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+254792006,Proliferating angioendotheliomatosis (disorder),y,descendant of concept mapped from leaf
+97361000119109,Hypoalbuminemia due to protein calorie malnutrition (disorder),y,descendant of concept mapped from leaf
+371012000,"Acute lymphoblastic leukemia, transitional pre-B-cell (disorder)",y,descendant of concept mapped from leaf
+3172003,"Peripheral T-cell lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+413443009,Acute myeloid leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+449218003,Lymphoma of sigmoid colon (disorder),y,descendant of concept mapped from leaf
+189509003,"Refractory anemia without sideroblasts, so stated (disorder)",y,descendant of concept mapped from leaf
+721302006,Refractory anemia with ringed sideroblasts associated with marked thrombocytosis (disorder),y,descendant of concept mapped from leaf
+92811003,Chronic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+721310007,Aggressive natural killer-cell leukemia (disorder),y,descendant of concept mapped from leaf
+450914009,Mixed phenotype acute leukemia with t(9;22)(q34;q11.2); BCR-ABL1 (morphologic abnormality),y,descendant of concept mapped from leaf
+103690005,Acute myeloid leukemia without maturation (morphologic abnormality),y,descendant of concept mapped from leaf
+702786004,Follicular non-Hodgkin's lymphoma diffuse follicle center sub-type grade 1 (disorder),y,descendant of concept mapped from leaf
+93551000,"Hodgkin's sarcoma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+397345009,Acute leukemia of ambiguous lineage (morphologic abnormality),y,descendant of concept mapped from leaf
+404110001,Hypomelanotic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+414791003,"Myelodysplastic syndrome, unclassified by World Health Organization classification (disorder)",y,descendant of concept mapped from leaf
+397011009,Mast cell malignancy of lymph nodes (disorder),y,descendant of concept mapped from leaf
+397350003,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue (morphologic abnormality),y,descendant of concept mapped from leaf
+119247004,Hypoalbuminemia (disorder),y,descendant of concept mapped from leaf
+446688004,Leukemic infiltration (morphologic abnormality),y,descendant of concept mapped from leaf
+414553000,Kappa light chain myeloma (disorder),y,descendant of concept mapped from leaf
+109971005,"Follicular non-Hodgkin's lymphoma, mixed small cleaved cell and large cell (disorder)",y,descendant of concept mapped from leaf
+738527001,Myeloid and/or lymphoid neoplasm associated with platelet derived growth factor receptor alpha rearrangement (disorder),y,descendant of concept mapped from leaf
+419094004,Immunodeficiency-associated Burkitt's lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+449074003,Lymphoma of small intestine (disorder),y,descendant of concept mapped from leaf
+404103007,Lymphomatoid papulosis type A (CD-30 positive type) (disorder),y,descendant of concept mapped from leaf
+415156005,Precursor T-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+404139001,Leukemic infiltration of skin in hairy-cell leukemia (disorder),y,descendant of concept mapped from leaf
+449075002,Lymphoma of cardioesophageal junction (disorder),y,descendant of concept mapped from leaf
+397342007,Acute myeloid leukemia with multilineage dysplasia without antecedent myelodysplastic syndrome (morphologic abnormality),y,descendant of concept mapped from leaf
+426885008,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head (disorder)",y,descendant of concept mapped from leaf
+404131003,CD-30 negative T-immunoblastic cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+404155008,Granulocytic sarcoma affecting skin (disorder),y,descendant of concept mapped from leaf
+404144008,Primary cutaneous diffuse large cell B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+709471005,Periodontitis co-occurrent with leukemia (disorder),y,descendant of concept mapped from leaf
+93519001,"Hodgkin's disease, nodular sclerosis of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+92511007,Burkitt's tumor of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+449307001,Follicular non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+426370008,Subacute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+397015000,Systemic mastocytosis with associated clonal hematological non-mast cell lineage disease (disorder),y,descendant of concept mapped from leaf
+415113000,Plasmacytoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+404136008,Aggressive natural killer-cell leukemia involving skin (disorder),y,descendant of concept mapped from leaf
+450907007,Hydroa vacciniforme-like lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+404137004,Precursor B-cell lymphoblastic lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+404113004,Tumor stage mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+13048006,Orbital lymphoma (disorder),y,descendant of concept mapped from leaf
+448553002,Lymphoma of pelvis (disorder),y,descendant of concept mapped from leaf
+448663003,Diffuse non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+188531003,Hodgkin's paragranuloma of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+419586003,"Primary cutaneous T-cell lymphoma, large cell, CD30-negative (morphologic abnormality)",y,descendant of concept mapped from leaf
+766935007,Primary bone lymphoma (disorder),y,descendant of concept mapped from leaf
+448317000,Follicular non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+413537009,Angioimmunoblastic T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+414654003,Mature (peripheral) B-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+450954006,B lymphoblastic leukemia lymphoma with hypodiploidy (Hypodiploid ALL) (morphologic abnormality),y,descendant of concept mapped from leaf
+123313007,"Alpha heavy chain disease, enteric form (disorder)",y,descendant of concept mapped from leaf
+418789003,Primary cutaneous plasmacytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+127070008,Malignant histiocytic disorder (disorder),y,descendant of concept mapped from leaf
+702476004,Therapy-related myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+450959001,T-cell/histiocyte rich large B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+450915005,Mixed phenotype acute leukemia with t(v;11q23); MLL rearranged (morphologic abnormality),y,descendant of concept mapped from leaf
+404120006,Localized pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+420028002,Primary cutaneous marginal zone B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+61301000119102,Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+404111002,Lymphomatoid papulosis-associated mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+447989004,Non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+419386004,Pagetoid reticulosis (morphologic abnormality),y,descendant of concept mapped from leaf
+397347001,Precursor B-lymphoblastic leukemia/lymphoblastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93205000,Malignant mast cell tumor of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+425869007,"Acute promyelocytic leukemia, FAB M3, in remission (disorder)",y,descendant of concept mapped from leaf
+448231003,Follicular non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+425941003,Pre B-cell acute lymphoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+25050002,"Alpha heavy chain disease, respiratory form (disorder)",y,descendant of concept mapped from leaf
+93190006,Malignant histiocytosis of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+722954005,B-cell lymphoma unclassifiable with features intermediate between classical Hodgkin lymphoma and diffuse large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+702977001,Follicular non-Hodgkin's lymphoma diffuse follicle center cell sub-type grade 2 (disorder),y,descendant of concept mapped from leaf
+93201009,Malignant mast cell tumor of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+762315004,Therapy related acute myeloid leukemia due to and following administration of antineoplastic agent (disorder),y,descendant of concept mapped from leaf
+715950008,Anaplastic lymphoma kinase positive large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+721313009,Indeterminate dendritic cell neoplasm (disorder),y,descendant of concept mapped from leaf
+128874001,Cutaneous CD30+ lymphoproliferative disorder (disorder),y,descendant of concept mapped from leaf
+448774004,Non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+448384001,Non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+415285009,Refractory cytopenia with multilineage dysplasia (disorder),y,descendant of concept mapped from leaf
+450929006,Acute myeloid leukemia with inv(3)(q21q26.2) or t(3;3)(q21;q26.2); RPN1-EVI1 (morphologic abnormality),y,descendant of concept mapped from leaf
+404172001,Mast cell leukemia affecting skin (disorder),y,descendant of concept mapped from leaf
+20224008,Delta heavy chain disease (disorder),y,descendant of concept mapped from leaf
+61291000119103,Disorder of central nervous system co-occurrent and due to acute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+733598001,Acute myeloid leukemia with t(6;9)(p23;q34) translocation (disorder),y,descendant of concept mapped from leaf
+414780005,Mucosa-associated lymphoid tissue lymphoma of orbit (disorder),y,descendant of concept mapped from leaf
+415110002,Plasma cell myeloma/plasmacytoma (disorder),y,descendant of concept mapped from leaf
+714463003,Primary effusion lymphoma co-occurrent with infection caused by Human herpesvirus 8 (disorder),y,descendant of concept mapped from leaf
+450909005,Plasmablastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+285428004,Immunoglobulin D monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+128824003,Precursor T-cell lymphoblastic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+94688000,Mixed cell type lymphosarcoma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+441313008,Indolent multiple myeloma (disorder),y,descendant of concept mapped from leaf
+447100004,Marginal zone lymphoma (disorder),y,descendant of concept mapped from leaf
+110000005,Refractory anemia with excess blasts in transformation (disorder),y,descendant of concept mapped from leaf
+699818003,T-cell large granular lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+766048008,Acute myeloid leukemia and myelodysplastic syndrome related to radiation (disorder),y,descendant of concept mapped from leaf
+93542008,"Hodgkin's paragranuloma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+93550004,Hodgkin's sarcoma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+402880009,Primary cutaneous large T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+450950002,B lymphoblastic leukemia lymphoma with t(9;22)(q34;q11.2); BCR-ABL1 (morphologic abnormality),y,descendant of concept mapped from leaf
+94716000,Myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+399456004,Plasma cell myeloma/plasmacytoma (morphologic abnormality),y,descendant of concept mapped from leaf
+404138009,Small lymphocytic B-cell lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+762690000,Classical Hodgkin lymphoma (disorder),y,descendant of concept mapped from leaf
+713483007,Reticulosarcoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+84631004,"Lymphoproliferative disease, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+415109007,Plasma cell myeloma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+734066005,Diffuse large B-cell lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+734141009,Splenic B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+449058008,Follicular non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+450908002,Primary cutaneous gamma-delta T-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+415284008,Refractory anemia with excess blasts-2 (disorder),y,descendant of concept mapped from leaf
+415283002,Refractory anemia with excess blasts-1 (disorder),y,descendant of concept mapped from leaf
+103682005,Subcutaneous panniculitic T-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+724645006,T-cell hystiocyte rich large B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+93496009,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+128798004,Composite Hodgkin and non-Hodgkin lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448217003,Follicular non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+128806000,Precursor cell lymphoblastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93555009,Hodgkin's sarcoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+447656001,Lymphoma of pylorus of stomach (disorder),y,descendant of concept mapped from leaf
+95264000,Sézary's disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+766046007,Acute myeloid leukemia and myelodysplastic syndrome related to topoisomerase type 2 inhibitor (disorder),y,descendant of concept mapped from leaf
+404121005,Generalized pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+718195003,Inherited predisposition to essential thrombocythemia (disorder),y,descendant of concept mapped from leaf
+404115006,Bullous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+703820005,Acute myeloid leukemia with mutated NPM1 (morphologic abnormality),y,descendant of concept mapped from leaf
+734524001,Acute myeloid leukemia with FMS-like tyrosine kinase-3 mutation (morphologic abnormality),y,descendant of concept mapped from leaf
+93137007,"Letterer-Siwe disease of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+413840004,Chronic lymphoid leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+92509003,Burkitt's tumor of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+721555001,Follicular lymphoma of small intestine (disorder),y,descendant of concept mapped from leaf
+93515007,"Hodgkin's disease, nodular sclerosis of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+402881008,Primary cutaneous B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+404143002,Primary cutaneous follicular center B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+449065000,Diffuse non-Hodgkin's lymphoma of nose (disorder),y,descendant of concept mapped from leaf
+93497000,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+721306009,Therapy related acute myeloid leukemia and myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+413616009,B-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+112241002,Lymphoma stage III 1 (finding),y,descendant of concept mapped from leaf
+5701003,Lymphoma stage IIe (finding),y,descendant of concept mapped from leaf
+94686001,Mixed cell type lymphosarcoma of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+419770008,Endemic Burkitt's lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+12341000132100,"B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and Burkitt lymphoma (morphologic abnormality)",y,descendant of concept mapped from leaf
+445925008,Lymphomatous infiltration (morphologic abnormality),y,descendant of concept mapped from leaf
+128827005,Acute myeloid leukemia with multilineage dysplasia (morphologic abnormality),y,descendant of concept mapped from leaf
+109968002,"Diffuse non-Hodgkin's lymphoma, small cell (disorder)",y,descendant of concept mapped from leaf
+89487002,Lymphoma stage Ie (finding),y,descendant of concept mapped from leaf
+765136002,Primary cutaneous CD8 positive aggressive epidermotropic cytotoxic T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+91860005,Acute myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+93206004,Malignant mast cell tumor of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+763666008,Splenic marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+448376000,Non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+404151004,Leukemic infiltration of skin in myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+94687005,Mixed cell type lymphosarcoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+449177007,Diffuse non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+426124006,"Acute myeloid leukemia with maturation, FAB M2, in remission (disorder)",y,descendant of concept mapped from leaf
+404154007,Leukemic infiltration of skin in monocytic leukemia (disorder),y,descendant of concept mapped from leaf
+404145009,Primary cutaneous anaplastic large cell B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+128800006,Primary effusion lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+404152006,Leukemic infiltration of skin in acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+93501005,"Hodgkin's disease, lymphocytic-histiocytic predominance of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+128821006,"Prolymphocytic leukemia, T-cell type (morphologic abnormality)",y,descendant of concept mapped from leaf
+733895005,Primary cutaneous CD8 positive aggressive epidermotropic cytotoxic T-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+420302007,Reticulosarcoma associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+724649000,Langerhans cell sarcoma (disorder),y,descendant of concept mapped from leaf
+763477007,Primary lymphoma of conjunctiva (disorder),y,descendant of concept mapped from leaf
+427642009,T-cell acute lymphoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+285430002,Light chain monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+93543003,Hodgkin's paragranuloma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+95194004,Nodular lymphoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+404109006,Follicular mucinosis type mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+404127009,CD-30 positive T-immunoblastic cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+450943001,"Post transplant lymphoproliferative disorder, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+128830003,Therapy-related acute myeloid leukemia and myelodysplastic syndrome (morphologic abnormality),y,descendant of concept mapped from leaf
+448738008,Non-Hodgkin's lymphoma of soft tissue (disorder),y,descendant of concept mapped from leaf
+441559006,Mantle cell lymphoma of spleen (disorder),y,descendant of concept mapped from leaf
+128808004,Precursor T-cell lymphoblastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+413842007,Chronic myeloid leukemia in lymphoid blast crisis (disorder),y,descendant of concept mapped from leaf
+404134006,Anaplastic large T-cell systemic malignant lymphoma (disorder),y,descendant of concept mapped from leaf
+448672006,Follicular non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+93506000,"Hodgkin's disease, mixed cellularity of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+93187000,Malignant histiocytosis of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+448319002,Diffuse non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+725391003,Acute myeloid leukemia with t(8;16)(p11;p13) translocation (morphologic abnormality),y,descendant of concept mapped from leaf
+128823009,Precursor B-cell lymphoblastic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+404118008,Syringotropic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+714251006,Philadelphia chromosome-negative precursor B-cell acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+449221001,Diffuse non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+397344008,"Therapy-related acute myeloid leukemia and myelodysplastic syndrome, topoisomerase type II inhibitor-related type (morphologic abnormality)",y,descendant of concept mapped from leaf
+448468003,Diffuse non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+404147001,Follicular center B-cell lymphoma (nodal/systemic with skin involvement) (disorder),y,descendant of concept mapped from leaf
+449059000,Follicular non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+449222008,Follicular non-Hodgkin's lymphoma of stomach (disorder),y,descendant of concept mapped from leaf
+404135007,Angiocentric natural killer/T-cell malignant lymphoma involving skin (disorder),y,descendant of concept mapped from leaf
+421246008,Precursor T-cell lymphoblastic lymphoma (disorder),y,descendant of concept mapped from leaf
+763309005,Acute myeloid leukemia with nucleophosmin 1 somatic mutation (disorder),y,descendant of concept mapped from leaf
+450928003,Acute myeloid leukemia with t(6;9)(p23;q34); DEK-NUP214 (morphologic abnormality),y,descendant of concept mapped from leaf
+430338009,Smoldering chronic lymphocytic leukemia (disorder),y,descendant of concept mapped from leaf
+103688009,Acute myeloid leukemia with abnormal marrow eosinophils and inv(16)(p13q22) or t(16;16)(p13;q22) (morphologic abnormality),y,descendant of concept mapped from leaf
+735332000,Primary cutaneous diffuse large cell B-cell lymphoma of lower extremity (disorder),y,descendant of concept mapped from leaf
+427141003,Malignant lymphoma in remission (disorder),y,descendant of concept mapped from leaf
+722795004,Meningeal leukemia (disorder),y,descendant of concept mapped from leaf
+404119000,Pagetoid reticulosis (disorder),y,descendant of concept mapped from leaf
+450949002,"B lymphoblastic leukemia lymphoma, no International Classification of Diseases for Oncology subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+404106004,Lymphomatoid papulosis with Hodgkin's disease (disorder),y,descendant of concept mapped from leaf
+74053007,Lymphoma stage IIIs (finding),y,descendant of concept mapped from leaf
+404153001,Leukemic infiltration of skin in chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+285426000,Immunoglobulin M monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+449418000,Follicular non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+734044003,Anaplastic lymphoma kinase positive anaplastic large cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+449173006,Diffuse non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+413389003,Accelerated phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+413442004,Acute monocytic/monoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+93142004,Leukemia in remission (disorder),y,descendant of concept mapped from leaf
+450953000,B lymphoblastic leukemia lymphoma with hyperdiploidy (morphologic abnormality),y,descendant of concept mapped from leaf
+110459008,"Malignant lymphoma, metastatic (morphologic abnormality)",y,descendant of concept mapped from leaf
+763796007,Megakaryoblastic acute myeloid leukemia with t(1;22)(p13;q13) (disorder),y,descendant of concept mapped from leaf
+397357000,"Systemic mastocytosis with associated clonal, hematologic non-mast-cell lineage disease (morphologic abnormality)",y,descendant of concept mapped from leaf
+91856007,Acute lymphoid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+128802003,Splenic marginal zone B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+425688002,Philadelphia chromosome-positive acute lymphoblastic leukemia (disorder),y,descendant of concept mapped from leaf
+725437002,Chronic lymphocytic leukemia genetic mutation variant (disorder),y,descendant of concept mapped from leaf
+449219006,Follicular non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+60620005,Epsilon heavy chain disease (disorder),y,descendant of concept mapped from leaf
+128822004,"Precursor cell lymphoblastic leukemia, no ICD-O subtype (morphologic abnormality)",y,descendant of concept mapped from leaf
+725390002,Acute myeloid leukemia with t(8;16)(p11;p13) translocation (disorder),y,descendant of concept mapped from leaf
+724644005,Myeloid leukemia co-occurrent with Down syndrome (disorder),y,descendant of concept mapped from leaf
+702785000,Large cell anaplastic lymphoma T cell and Null cell type (disorder),y,descendant of concept mapped from leaf
+92508006,Burkitt's tumor of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+764940002,Inherited acute myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+450910000,Anaplastic lymphoma kinase positive large B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93507009,"Hodgkin's disease, mixed cellularity of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+404108003,Poikilodermatous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+404149003,"Lymphoplasmacytic B-cell lymphoma, nodal/systemic with skin involvement (disorder)",y,descendant of concept mapped from leaf
+404128004,CD-30 negative cutaneous T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+415286005,Refractory cytopenia with multilineage dysplasia and ringed sideroblasts (disorder),y,descendant of concept mapped from leaf
+277597005,Myelodysplastic syndrome with isolated del(5q) (disorder),y,descendant of concept mapped from leaf
+762691001,Classical Hodgkin lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+413841000,Chronic myeloid leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+46744002,"Follicular lymphoma, grade 1 (morphologic abnormality)",y,descendant of concept mapped from leaf
+398623004,Refractory anemia with excess blasts (disorder),y,descendant of concept mapped from leaf
+95261008,Sézary's disease of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+721303001,Refractory neutropenia (disorder),y,descendant of concept mapped from leaf
+450911001,Large B-cell lymphoma arising in human herpesvirus type 8 associated multicentric Castleman disease (morphologic abnormality),y,descendant of concept mapped from leaf
+397469009,"Follicular lymphoma, diffuse follicle center cell sub-type, grade 2 (morphologic abnormality)",y,descendant of concept mapped from leaf
+448372003,Non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+724648008,Plasmablastic lymphoma (disorder),y,descendant of concept mapped from leaf
+404116007,Mycosis fungoides with systemic infiltration (disorder),y,descendant of concept mapped from leaf
+404140004,Primary cutaneous marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+418265009,Primary cutaneous B-cell lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+721308005,Acute leukemia of ambiguous lineage (disorder),y,descendant of concept mapped from leaf
+93505001,"Hodgkin's disease, mixed cellularity of lymph nodes of axilla AND/OR upper limb (disorder)",y,descendant of concept mapped from leaf
+84633001,Lymphoma stage IIIse (finding),y,descendant of concept mapped from leaf
+426642002,"Erythroleukemia, FAB M6 in remission (disorder)",y,descendant of concept mapped from leaf
+404117003,Spongiotic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+721314003,Fibroblastic reticular cell neoplasm (disorder),y,descendant of concept mapped from leaf
+449063007,Follicular non-Hodgkin's lymphoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+448213004,Diffuse non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+93203007,Malignant mast cell tumor of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+93537000,Hodgkin's granuloma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+95260009,"Sézary's disease of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+397352006,"Primary cutaneous anaplastic large T-cell lymphoma, CD30-positive (morphologic abnormality)",y,descendant of concept mapped from leaf
+94071006,Primary malignant neoplasm of spleen (disorder),y,descendant of concept mapped from leaf
+92515003,Burkitt's tumor of spleen (disorder),y,descendant of concept mapped from leaf
+93528000,Hodgkin's disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+415701004,T-cell AND/OR NK-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+397340004,Acute myeloid leukemia with recurrent genetic abnormality (morphologic abnormality),y,descendant of concept mapped from leaf
+448465000,Diffuse non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+109996008,"Myelodysplastic syndrome: Refractory anemia, without ringed sideroblasts, without excess blasts (disorder)",y,descendant of concept mapped from leaf
+103689001,"Acute myeloid leukemia, minimal differentiation (morphologic abnormality)",y,descendant of concept mapped from leaf
+450955007,B lymphoblastic leukemia lymphoma with t(5;14)(q31;q32); IL3-IGH (morphologic abnormality),y,descendant of concept mapped from leaf
+448555009,Lymphoma of body of stomach (disorder),y,descendant of concept mapped from leaf
+128834007,Chronic neutrophilic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+449292003,Non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+713516007,Primary effusion lymphoma (disorder),y,descendant of concept mapped from leaf
+239297008,Lymphomatoid granulomatosis of the lung (disorder),y,descendant of concept mapped from leaf
+440422002,Asymptomatic multiple myeloma (disorder),y,descendant of concept mapped from leaf
+404157000,Specific skin infiltration in Hodgkin's disease (disorder),y,descendant of concept mapped from leaf
+449176003,Diffuse non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+419018000,Primary cutaneous large T-cell lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+703818007,Acute monoblastic and monocytic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+765328000,Classic mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+397358005,Aggressive systemic mastocytosis (morphologic abnormality),y,descendant of concept mapped from leaf
+450913003,Mixed phenotype acute leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+93204001,"Malignant mast cell tumor of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+116821000119104,Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of upper limb (disorder),y,descendant of concept mapped from leaf
+109967007,"Diffuse non-Hodgkin's lymphoma, small cleaved cell (disorder)",y,descendant of concept mapped from leaf
+119248009,Hyperalbuminemia (disorder),y,descendant of concept mapped from leaf
+426955004,Philadelphia chromosome-positive acute lymphoblastic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+255102004,Angioendotheliomatosis (disorder),y,descendant of concept mapped from leaf
+103691009,Acute myeloid leukemia with maturation (morphologic abnormality),y,descendant of concept mapped from leaf
+93199007,Malignant lymphoma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+116811000119106,Non-Hodgkin lymphoma of central nervous system metastatic to lymph node of lower limb (disorder),y,descendant of concept mapped from leaf
+415287001,Relapsing chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+763719001,Hydroa vacciniforme-like lymphoma (disorder),y,descendant of concept mapped from leaf
+448220006,Non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+61493004,Mu heavy chain disease (disorder),y,descendant of concept mapped from leaf
+733081008,Reactive plasmacytic hyperplasia (morphologic abnormality),y,descendant of concept mapped from leaf
+413990004,Diffuse large B-cell lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+93489007,"Hodgkin's disease, lymphocytic depletion of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+733917002,Pediatric follicular lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+128817004,Immunoglobulin deposition disease (morphologic abnormality),y,descendant of concept mapped from leaf
+307649006,Microglioma (disorder),y,descendant of concept mapped from leaf
+404141000,Primary cutaneous immunocytoma (disorder),y,descendant of concept mapped from leaf
+128801005,Mediastinal large B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+128935007,Lymphoid leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+94690004,"Mixed cell type lymphosarcoma of lymph nodes of head, face, and neck (disorder)",y,descendant of concept mapped from leaf
+447658000,Lymphoma of fundus of stomach (disorder),y,descendant of concept mapped from leaf
+92510008,Burkitt's tumor of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+92817004,Chronic myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+447806008,Lymphoma of cardia of stomach (disorder),y,descendant of concept mapped from leaf
+94148006,Megakaryocytic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+128828000,"Acute myeloid leukemia, t(8;21) (q22;q22) (morphologic abnormality)",y,descendant of concept mapped from leaf
+397343002,"Therapy-related acute myeloid leukemia and myelodysplastic syndrome, alkylating agent-related type (morphologic abnormality)",y,descendant of concept mapped from leaf
+420519005,Malignant lymphoma of the eye region (disorder),y,descendant of concept mapped from leaf
+703387000,Acute myeloid leukemia with normal karyotype (disorder),y,descendant of concept mapped from leaf
+93488004,"Hodgkin's disease, lymphocytic depletion of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+448354009,Non-Hodgkin's lymphoma of intestine (disorder),y,descendant of concept mapped from leaf
+92514004,Burkitt's tumor of lymph nodes of multiple sites (disorder),y,descendant of concept mapped from leaf
+448371005,Non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+397349003,Nodal marginal zone B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+75339006,Lymphoma stage III 2 (finding),y,descendant of concept mapped from leaf
+1091891000000106,B-cell Hodgkin's lymphoma (disorder),y,descendant of concept mapped from leaf
+419392005,Primary cutaneous lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+93152000,Leukemic reticuloendotheliosis of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+12311000132101,Refractory acute lymphoid leukemia (disorder),y,descendant of concept mapped from leaf
+698646006,Acute monoblastic leukemia in remission (disorder),y,descendant of concept mapped from leaf
+92512000,"Burkitt's tumor of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+450952005,B lymphoblastic leukemia lymphoma with t(12;21)(p13;q22); TEL-AML1 (ETV6-RUNX1) (morphologic abnormality),y,descendant of concept mapped from leaf
+414785000,Multiple solitary plasmacytomas (disorder),y,descendant of concept mapped from leaf
+128921005,"Plasmacytoma, extramedullary (not occurring in bone) (morphologic abnormality)",y,descendant of concept mapped from leaf
+128825002,"Chronic myelogenous leukemia, BCR/ABL positive (morphologic abnormality)",y,descendant of concept mapped from leaf
+188529007,Hodgkin's paragranuloma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+715664005,Interdigitating dendritic cell sarcoma (disorder),y,descendant of concept mapped from leaf
+93200005,Malignant mast cell tumor of intra-abdominal lymph nodes (disorder),y,descendant of concept mapped from leaf
+721305008,Acute myeloid leukemia due to recurrent genetic abnormality (disorder),y,descendant of concept mapped from leaf
+404169008,Malignant histiocytosis involving skin (disorder),y,descendant of concept mapped from leaf
+94715001,Mycosis fungoides of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+397348006,Precursor T cell lymphoblastic leukemia/lymphoblastic lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448607004,Diffuse non-Hodgkin's lymphoma of uterine cervix (disorder),y,descendant of concept mapped from leaf
+705061009,Childhood myelodysplastic syndrome (disorder),y,descendant of concept mapped from leaf
+718200007,Primary pulmonary lymphoma (disorder),y,descendant of concept mapped from leaf
+448865007,Follicular non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+418628003,Follicular mycosis fungoides (morphologic abnormality),y,descendant of concept mapped from leaf
+404123008,Leukemic infiltration of skin (T-cell prolymphocytic leukemia) (disorder),y,descendant of concept mapped from leaf
+716789004,Epstein-Barr virus positive diffuse large B-cell lymphoma of elderly (morphologic abnormality),y,descendant of concept mapped from leaf
+133751000119102,Lymphoma of colon (disorder),y,descendant of concept mapped from leaf
+404107008,Patch/plaque stage mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+109972003,"Follicular non-Hodgkin's lymphoma, large cell (disorder)",y,descendant of concept mapped from leaf
+426071002,Hodgkin's disease in remission (disorder),y,descendant of concept mapped from leaf
+766045006,Acute myeloid leukemia and myelodysplastic syndrome related to alkylating agent (disorder),y,descendant of concept mapped from leaf
+404142007,Primary cutaneous plasmacytoma (disorder),y,descendant of concept mapped from leaf
+733627006,Primary cutaneous gamma-delta-positive T-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+188524002,Hodgkin's paragranuloma of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+421283008,Primary lymphoma of brain associated with acquired immunodeficiency syndrome (disorder),y,descendant of concept mapped from leaf
+404112009,Granulomatous mycosis fungoides (disorder),y,descendant of concept mapped from leaf
+448561007,Follicular non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+128818009,Acute biphenotypic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+815121000000102,Follicular lymphoma grade 3a (morphologic abnormality),y,descendant of concept mapped from leaf
+420063007,Sporadic Burkitt's lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+448995000,Follicular non-Hodgkin's lymphoma of central nervous system (disorder),y,descendant of concept mapped from leaf
+12351000132102,"B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and Hodgkin lymphoma (morphologic abnormality)",y,descendant of concept mapped from leaf
+20447006,Plasma cell dyscrasia with polyneuropathy (disorder),y,descendant of concept mapped from leaf
+94711005,"Mycosis fungoides of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+53237008,"Anaplastic large cell lymphoma, T cell and Null cell type (morphologic abnormality)",y,descendant of concept mapped from leaf
+422853008,Lymphoma of retroperitoneal space (disorder),y,descendant of concept mapped from leaf
+427658007,"Acute myelomonocytic leukemia, FAB M4, in remission (disorder)",y,descendant of concept mapped from leaf
+726721002,Nodal marginal zone B-cell lymphoma (disorder),y,descendant of concept mapped from leaf
+449318001,Non-Hodgkin's lymphoma of prostate (disorder),y,descendant of concept mapped from leaf
+277577000,Monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+404122003,Leukemic infiltration of skin (chronic T-cell lymphocytic leukemia) (disorder),y,descendant of concept mapped from leaf
+95209008,Plasma cell leukemia in remission (disorder),y,descendant of concept mapped from leaf
+419283005,Primary cutaneous T-cell lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+285423008,Immunoglobulin A monoclonal gammopathy of uncertain significance (disorder),y,descendant of concept mapped from leaf
+128826001,"Atypical chronic myeloid leukemia, BCR/ABL negative (morphologic abnormality)",y,descendant of concept mapped from leaf
+444911000,Acute myeloid leukemia with t(9:11)(p22;q23); MLLT3-MLL (disorder),y,descendant of concept mapped from leaf
+419563005,"Primary cutaneous T-cell lymphoma, pleomorphic small/medium-sized (morphologic abnormality)",y,descendant of concept mapped from leaf
+448447004,Non-Hodgkin's lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+419035001,Mature T-cell AND/OR natural killer-cell neoplasm (morphologic abnormality),y,descendant of concept mapped from leaf
+764855007,Acute myeloid leukemia with CCAAT/enhancer binding protein alpha somatic mutation (disorder),y,descendant of concept mapped from leaf
+703819004,Acute myeloid leukemia with mutated CEBPA (morphologic abnormality),y,descendant of concept mapped from leaf
+93492006,"Hodgkin's disease, lymphocytic depletion of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+815131000000100,Follicular lymphoma grade 3b (morphologic abnormality),y,descendant of concept mapped from leaf
+93533001,"Hodgkin's granuloma of lymph nodes of head, face AND/OR neck (disorder)",y,descendant of concept mapped from leaf
+92516002,Burkitt's tumor of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+413836008,Chronic eosinophilic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+12301000132103,Acute lymphoid leukemia relapse (disorder),y,descendant of concept mapped from leaf
+93498005,"Hodgkin's disease, lymphocytic-histiocytic predominance of lymph nodes of inguinal region AND/OR lower limb (disorder)",y,descendant of concept mapped from leaf
+93202002,Malignant mast cell tumor of intrathoracic lymph nodes (disorder),y,descendant of concept mapped from leaf
+402882001,Hodgkin's disease affecting skin (disorder),y,descendant of concept mapped from leaf
+448387008,Non-Hodgkin's lymphoma of testis (disorder),y,descendant of concept mapped from leaf
+425749006,Subacute myeloid leukemia in remission (disorder),y,descendant of concept mapped from leaf
+703626001,"Anaplastic large cell lymphoma, T/Null cell, primary systemic type (disorder)",y,descendant of concept mapped from leaf
+93534007,Hodgkin's granuloma of lymph nodes of inguinal region AND/OR lower limb (disorder),y,descendant of concept mapped from leaf
+109998009,Refractory anemia with ringed sideroblasts (disorder),y,descendant of concept mapped from leaf
+721762007,Adult T-cell leukemia/lymphoma of skin (disorder),y,descendant of concept mapped from leaf
+450951003,B lymphoblastic leukemia lymphoma with t(v;11q23); MLL rearranged (morphologic abnormality),y,descendant of concept mapped from leaf
+93510002,"Hodgkin's disease, mixed cellularity of extranodal AND/OR solid organ site (disorder)",y,descendant of concept mapped from leaf
+448560008,Diffuse non-Hodgkin's lymphoma of extranodal site (disorder),y,descendant of concept mapped from leaf
+115244002,Malignant lymphoma - category (morphologic abnormality),y,descendant of concept mapped from leaf
+441962003,Large cell lymphoma of intrapelvic lymph nodes (disorder),y,descendant of concept mapped from leaf
+58961005,Lethal midline granuloma (disorder),y,descendant of concept mapped from leaf
+94704006,Multiple myeloma in remission (disorder),y,descendant of concept mapped from leaf
+307340003,Monosomy 7 syndrome (disorder),y,descendant of concept mapped from leaf
+733860007,Pediatric nodal marginal zone lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+187822008,Fibrosarcoma of spleen (disorder),y,descendant of concept mapped from leaf
+128934006,Myeloid leukemia - category (morphologic abnormality),y,descendant of concept mapped from leaf
+399648005,Intravascular large B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+734067001,Splenic diffuse red pulp small B-cell lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+404129007,CD-30 negative anaplastic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+723889003,B lymphoblastic leukemia lymphoma with t(9:22) (q34;q11.2); BCR-ABL 1 (disorder),y,descendant of concept mapped from leaf
+703821009,T lymphoblastic leukemia/lymphoma (morphologic abnormality),y,descendant of concept mapped from leaf
+128829008,"Acute myeloid leukemia, 11q23 abnormalities (morphologic abnormality)",y,descendant of concept mapped from leaf
+93546006,Hodgkin's paragranuloma of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+371134001,"Malignant lymphoma, large cell, polymorphous, immunoblastic (disorder)",y,descendant of concept mapped from leaf
+93141006,Letterer-Siwe disease of extranodal AND/OR solid organ site (disorder),y,descendant of concept mapped from leaf
+413656006,Blastic phase chronic myeloid leukemia (disorder),y,descendant of concept mapped from leaf
+447805007,Lymphoma of greater curvature of stomach (disorder),y,descendant of concept mapped from leaf
+128819001,T-cell large granular lymphocytic leukemia (morphologic abnormality),y,descendant of concept mapped from leaf
+404130002,CD-30 negative pleomorphic large T-cell cutaneous lymphoma (disorder),y,descendant of concept mapped from leaf
+448666006,Follicular non-Hodgkin's lymphoma of bone (disorder),y,descendant of concept mapped from leaf
+127220001,Malignant lymphoma of lymph nodes (disorder),y,descendant of concept mapped from leaf
+93541001,Hodgkin's paragranuloma of lymph nodes of axilla AND/OR upper limb (disorder),y,descendant of concept mapped from leaf
+397468001,"Follicular lymphoma, diffuse follicle center sub-type, grade 1 (morphologic abnormality)",y,descendant of concept mapped from leaf
+91854005,Acute leukemia in remission (disorder),y,descendant of concept mapped from leaf
+397341000,Acute myeloid leukemia with multilineage dysplasia following a myelodysplastic syndrome or myelodysplastic syndrome/myeloproliferative disorder (morphologic abnormality),y,descendant of concept mapped from leaf
+448609001,Diffuse non-Hodgkin's lymphoma of ovary (disorder),y,descendant of concept mapped from leaf
+713325002,Primary cerebral lymphoma co-occurrent with human immunodeficiency virus infection (disorder),y,descendant of concept mapped from leaf
+404124002,Leukemic infiltration of skin (T-cell lymphoblastic leukemia) (disorder),y,descendant of concept mapped from leaf
+189972001,"[M]Malignant lymphoma, lymphocytic, poorly differentiated NOS (morphologic abnormality)",n,via Query Table
+189968000,"[M]Malignant lymphoma, lymphocytic, well differentiated NOS (morphologic abnormality)",n,via Query Table
+189970009,"[M]Malignant lymphoma, centrocytic (morphologic abnormality)",n,via Query Table
+815101000000106,"Follicular lymphoma, grade 1 (morphologic abnormality)",n,via Query Table
+662451000000101,Sézary's disease NOS (disorder),n,via Query Table
+397346005,Acute bilineal leukemia (morphologic abnormality),n,via Query Table
+468691000000106,[M]Other myeloid leukaemia NOS (morphologic abnormality),n,via Query Table
+833001000000103,Diffuse follicle centre lymphoma,n,via Query Table
+190164006,"[X]Malignant neoplasm of lymphoid, hematopoietic and related tissue, unspecified (disorder)",n,via Query Table
+26328002,Disseminated eosinophilic collagen disease (disorder),n,via Query Table
+662421000000106,Acute leukemia NOS (disorder),n,via Query Table
+190025005,[M]leukemia NOS (morphologic abnormality),n,via Query Table
+190167004,[X]Unspecified B-cell non-Hodgkin's lymphoma (disorder),n,via Query Table
+190045002,[M]Lymphosarcoma cell leukemia (morphologic abnormality),n,via Query Table
+190054004,[M]Eosinophilic leukemias (morphologic abnormality),n,via Query Table
+615441000000105,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+832681000000105,T-cell prolymphocytic leukaemia,n,via Query Table
+189997002,"[M]Malignant lymphoma, lymphocytic, intermediate differentiation, nodular (morphologic abnormality)",n,via Query Table
+832921000000100,5Q minus syndrome,n,via Query Table
+188619006,"Mycosis fungoides of the lymph nodes of head, face and neck (disorder)",n,via Query Table
+450041000000102,[X]Other Hodgkin's disease (disorder),n,via Query Table
+471231000000108,"[M]Malignant lymphoma, mixed lymphocytic - histiocytic NOS (& [diffuse reticulolymphosarcoma])",n,via Query Table
+473041000000109,"[M]Malignant lymphoma, lymphocytic, intermediate differentiation, nodular (morphologic abnormality)",n,via Query Table
+188759000,Lymphosarcoma cell leukemia (disorder),n,via Query Table
+190075007,[M]Monocytoid B-cell lymphoma (morphologic abnormality),n,via Query Table
+815091000000103,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue [MALT-lymphoma] (disorder),n,via Query Table
+573341000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of unspecified site (disorder),n,via Query Table
+833581000000104,Non-Hodgkin's lymphoma - disorder,n,via Query Table
+127221002,Hematologic malignancy (disorder),n,via Query Table
+190022008,[M]Burkitt's tumors (morphologic abnormality),n,via Query Table
+615431000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+189980008,"[M]Malignant lymphoma, small cell, non-cleaved, diffuse (morphologic abnormality)",n,via Query Table
+237759003,"Langerhans cell histiocytosis, unifocal, bone (disorder)",n,via Query Table
+461871000000101,"[M]Lymphomas, NOS or diffuse (morphologic abnormality)",n,via Query Table
+399607007,Chronic lymphocytic leukemia/small lymphocytic lymphoma (morphologic abnormality),n,via Query Table
+863751000000106,Clinical stage A chronic lymphocytic leukaemia ,n,via Query Table
+188623003,Mycosis fungoides of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+455781000000101,[X]Unspecified B-cell non-Hodgkin's lymphoma (disorder),n,via Query Table
+556221000000107,Malignant neoplasms of lymphoid and histiocytic tissue NOS (disorder),n,via Query Table
+338011000000108,Mucosa-associated lymphoma,n,via Query Table
+541031000000105,Hodgkin's lymphocytic depletion of unspecified site (disorder),n,via Query Table
+833381000000105,Follicular lymphoma grade 3b,n,via Query Table
+233693005,Pulmonary histiocytosis X (disorder),n,via Query Table
+134177009,"[M]Hodgkin's disease, lymphocytic depletion NOS (morphologic abnormality)",n,via Query Table
+190004005,[M]Mycosis fungoides NOS (morphologic abnormality),n,via Query Table
+127216000,Angioimmunoblastic lymphadenopathy with dysproteinemia (disorder),n,via Query Table
+477871000000103,[X]Other types of diffuse non-Hodgkin's lymphoma (disorder),n,via Query Table
+867941000000102,[M]Juvenile myelomonocytic leukaemia ,n,via Query Table
+190007003,[M]Histiocytic medullary reticulosis (morphologic abnormality),n,via Query Table
+863771000000102,Clinical stage B chronic lymphocytic leukaemia ,n,via Query Table
+633331000000104,"Histiocytosis, unspecified (disorder)",n,via Query Table
+190162005,[X]Other leukemia of unspecified cell type (disorder),n,via Query Table
+443641000000102,[M]Subacute lymphoid leukaemia,n,via Query Table
+565971000000101,Malignant lymphoma NOS of lymph nodes of multiple sites (disorder),n,via Query Table
+464771000000108,"[X]Other specified malignant neoplasms of lymphoid, haematopoietic and related tissue (disorder)",n,via Query Table
+812871000000103,Juvenile myelomonocytic leukaemia (disorder),n,via Query Table
+833361000000101,Follicular lymphoma grade 3,n,via Query Table
+89706008,AIDS with Burkitt's tumor (disorder),n,via Query Table
+188657006,Letterer-Siwe disease of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+833391000000107,Cutaneous follicle centre lymphoma,n,via Query Table
+189974000,"[M]Malignant lymphoma, centroblastic type NOS (morphologic abnormality)",n,via Query Table
+274907000,Plasma cell tumor (morphologic abnormality),n,via Query Table
+472871000000100,[M] Gamma heavy chain disease (morphologic abnormality),n,via Query Table
+457571000000102,[M]Subacute myeloid leukaemia (morphologic abnormality),n,via Query Table
+254042000,Ayala's disease (disorder),n,via Query Table
+398701000000101,[M]Basophilic leukaemias (morphologic abnormality),n,via Query Table
+190009000,[M] Alpha heavy chain disease (morphologic abnormality),n,via Query Table
+408661000000101,[X]Other specified types of non-Hodgkin's lymphoma (disorder),n,via Query Table
+95262001,Sézary's disease of lymph nodes of multiple sites (disorder),n,via Query Table
+571191000000109,Other myeloid leukemia (disorder),n,via Query Table
+478121000000109,"[M]Lymphoma, diffuse or NOS (morphologic abnormality)",n,via Query Table
+815141000000109,"Follicular lymphoma, cutaneous follicle centre (morphologic abnormality)",n,via Query Table
+578481000000105,"Hodgkin's, lymphocytic-histiocytic predominance NOS (disorder)",n,via Query Table
+539581000000102,"Hodgkin's disease, lymphocytic depletion NOS (disorder)",n,via Query Table
+397121000000107,[M]Eosinophilic leukaemias (morphologic abnormality),n,via Query Table
+189960007,"[M]Malignant lymphoma, diffuse NOS (morphologic abnormality)",n,via Query Table
+190050008,[M]Neutrophilic leukemia (morphologic abnormality),n,via Query Table
+190073000,Chronic lymphoproliferative disease (morphologic abnormality),n,via Query Table
+408771000000104,[M]Compound leukaemia (morphologic abnormality),n,via Query Table
+469881000000100,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+578251000000103,Malignant mast cell tumor NOS (disorder),n,via Query Table
+134176000,"[M]Malignant lymphoma, small cleaved cell, diffuse (morphologic abnormality)",n,via Query Table
+450181000000109,"[M]Malignant lymphoma, small cell, non-cleaved, diffuse (morphologic abnormality)",n,via Query Table
+93148000,"Leukemic reticuloendotheliosis of lymph nodes of head, face AND/OR neck (disorder)",n,via Query Table
+422052002,Burkitt's lymphoma associated with acquired immunodeficiency syndrome (disorder),n,via Query Table
+188528004,Hodgkin's paragranuloma of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+833021000000107,Other types of follicular non-Hodgkin's lymphoma,n,via Query Table
+190151005,"[X]Malignant neoplasms of lymphoid, hematopoietic and related tissue (disorder)",n,via Query Table
+571181000000107,Myeloid sarcoma NOS (disorder),n,via Query Table
+6426003,Autosomal dominant analbuminemia (disorder),n,via Query Table
+190013007,[M]Angioendotheliomatosis (morphologic abnormality),n,via Query Table
+312939009,Ocular lymphoma (disorder),n,via Query Table
+441161000000109,"[M]Malignant lymphoma, follicular centre cell NOS (morphologic abnormality)",n,via Query Table
+433141000000108,"[M]Malignant lymphoma, centrocytic (morphologic abnormality)",n,via Query Table
+190069003,[M]Acute myelofibrosis (morphologic abnormality),n,via Query Table
+285763005,Acute myeloblastic leukemia - undifferentiated (disorder),n,via Query Table
+541011000000102,Hodgkin's sarcoma NOS (disorder),n,via Query Table
+277608004,"Hodgkin's disease, lymphocytic predominance - nodular (disorder)",n,via Query Table
+438251000000108,"[M]leukemia unspecified, NOS (morphologic abnormality)",n,via Query Table
+389361000000109,[M]Erythroleukemias (morphologic abnormality),n,via Query Table
+190052000,[M]Basophilic leukemias (morphologic abnormality),n,via Query Table
+189977007,"[M]Malignant lymphoma, large cell, cleaved, diffuse (morphologic abnormality)",n,via Query Table
+557641000000101,Reticulosarcoma of unspecified site (disorder),n,via Query Table
+190018003,"Plasma cell tumor, malignant (morphologic abnormality)",n,via Query Table
+438691000000102,[M]Monocytoid B-cell lymphoma (morphologic abnormality),n,via Query Table
+413526008,"Anaplastic large cell lymphoma, T/Null cell, primary cutaneous type (morphologic abnormality)",n,via Query Table
+662431000000108,Chronic leukemia NOS (disorder),n,via Query Table
+390401000000107,[X]Other specified leukaemias (disorder),n,via Query Table
+190166008,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas (disorder),n,via Query Table
+189967005,"[M]Malignant lymphoma, follicular center cell NOS (morphologic abnormality)",n,via Query Table
+438681000000104,"[M]Malignant lymphoma, large cell, cleaved, diffuse (morphologic abnormality)",n,via Query Table
+190070002,[M]Miscellaneous leukemia NOS (morphologic abnormality),n,via Query Table
+557491000000109,Letterer-Siwe disease NOS (disorder),n,via Query Table
+403911000000104,"[M]Hodgkin,s disease, nodular sclerosis, mixed cellularity (morphologic abnormality)",n,via Query Table
+95258007,Sézary's disease of intrathoracic lymph nodes (disorder),n,via Query Table
+186723002,Human immunodeficiency virus disease resulting in Burkitt's lymphoma (disorder),n,via Query Table
+833481000000100,[M]Adult T-cell leukaemia/lymphoma,n,via Query Table
+450971000000109,[M]leukemias unspecified (morphologic abnormality),n,via Query Table
+478111000000103,"[M]Malignant lymphoma, large cell, non-cleaved, diffuse (morphologic abnormality)",n,via Query Table
+833081000000108,"Refractory anaemia without sideroblasts, so stated",n,via Query Table
+462401000000104,"[X]Malignant neoplasms of lymphoid, haematopoietic and related tissue (disorder)",n,via Query Table
+93450001,Erythroleukemia in remission (disorder),n,via Query Table
+832691000000107,Heavy chain disease,n,via Query Table
+578441000000102,Hodgkin's paragranuloma NOS (disorder),n,via Query Table
+477841000000109,[M]Compound leukaemia NOS (morphologic abnormality),n,via Query Table
+479021000000100,[M]Subacute leukaemia NOS (morphologic abnormality),n,via Query Table
+833401000000105,[M]Letterer - Siwe disease,n,via Query Table
+431831000000105,[M]Acute lymphoid leukaemia,n,via Query Table
+269499001,Neoplasm of uncertain behavior of plasma cells (disorder),n,via Query Table
+471831000000107,[M]Hodgkin's disease NOS,n,via Query Table
+833141000000104,Enteropathy-associated T-cell lymphoma,n,via Query Table
+673771000000103,Plasmacytoma NOS (disorder),n,via Query Table
+757251000000101,Diffuse malignant lymphoma - large cell,n,via Query Table
+815011000000107,Anaplastic lymphoma kinase positive anaplastic large cell lymphoma (disorder),n,via Query Table
+401121000000109,[X]Unspecified B-cell non-Hodgkin's lymphoma,n,via Query Table
+833411000000107,Sarcoma of dendritic cells,n,via Query Table
+833501000000109,Primary cutaneous CD30 antigen positive large T-cell lymphoma,n,via Query Table
+574421000000103,Other immunoproliferative neoplasms (disorder),n,via Query Table
+190002009,"[M]Lymphoma, nodular or follicular NOS (morphologic abnormality)",n,via Query Table
+472961000000101,[M]Aleukaemic lymphoid leukaemia (morphologic abnormality),n,via Query Table
+409571000000100,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+390261000000107,[M]Eosinophilic leukaemia NOS (morphologic abnormality),n,via Query Table
+480071000000101,"[M]Malignant lymphoma, follicular centre cell, cleaved NOS (morphologic abnormality)",n,via Query Table
+573471000000101,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of spleen (disorder),n,via Query Table
+188651007,Leukemic reticuloendotheliosis of spleen (disorder),n,via Query Table
+634631000000105,Other monocytic leukemia NOS (disorder),n,via Query Table
+84350008,AIDS with immunoblastic sarcoma (disorder),n,via Query Table
+815671000000108,"Extranodal NK/T-cell lymphoma, nasal type (disorder)",n,via Query Table
+557501000000103,Mast cell malignancy of unspecified site (disorder),n,via Query Table
+188527009,Hodgkin's paragranuloma of lymph nodes of axilla and upper limb (disorder),n,via Query Table
+833631000000102,Cutaneous/peripheral T-cell lymphoma,n,via Query Table
+190035004,[M]Subacute lymphoid leukemia (morphologic abnormality),n,via Query Table
+578281000000109,Malignant lymphoma NOS of intrathoracic lymph nodes (disorder),n,via Query Table
+849141000000100,Adult T-cell leukemia/lymphoma (disorder),n,via Query Table
+464261000000109,[M]Mycosis fungoides NOS (morphologic abnormality),n,via Query Table
+190047005,[M]Myeloid leukemias (morphologic abnormality),n,via Query Table
+463091000000106,[M] Peripheral T-cell lymphoma NOS (morphologic abnormality),n,via Query Table
+466481000000108,"[M]Hodgkin's disease, nodular sclerosis NOS (morphologic abnormality)",n,via Query Table
+389231000000105,[M]Plasma cell tumours (morphologic abnormality),n,via Query Table
+419471000000104,[M]Lymphosarcoma cell leukaemia,n,via Query Table
+416501000000103,"[M]Malignant lymphoma, lymphocytic, well differentiated NOS (morphologic abnormality)",n,via Query Table
+389731000000103,[M]Miscellaneous leukaemias (morphologic abnormality),n,via Query Table
+189975004,"[M]Malignant lymphoma, follicular center cell, non-cleaved NOS (morphologic abnormality)",n,via Query Table
+395671000000107,[M] Alpha heavy chain disease (morphologic abnormality),n,via Query Table
+573381000000109,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intra-abdominal lymph nodes (disorder),n,via Query Table
+188521005,Hodgkin's paragranuloma (disorder),n,via Query Table
+814981000000100,"Anaplastic large cell lymphoma, ALK-negative (disorder)",n,via Query Table
+190029004,"[M]leukemia unspecified, NOS (morphologic abnormality)",n,via Query Table
+190051007,[M]Other myeloid leukemia NOS (morphologic abnormality),n,via Query Table
+403961000000102,[M]Neutrophilic leukaemia (morphologic abnormality),n,via Query Table
+578451000000104,Hodgkin's granuloma of unspecified site (disorder),n,via Query Table
+546321000000103,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of multiple sites (disorder),n,via Query Table
+190067001,[M]Acute megakaryoblastic leukemia (morphologic abnormality),n,via Query Table
+438671000000101,"[M]Malignant lymphoma, centroblastic type NOS (morphologic abnormality)",n,via Query Table
+815161000000105,Sarcoma of dendritic cells (accessory cells) (disorder),n,via Query Table
+190222001,[X]Neoplasm of uncertain and unknown behavior of other myelodysplastic syndromes (disorder),n,via Query Table
+833101000000102,Anaplastic lymphoma kinase positive anaplastic large cell lymphoma,n,via Query Table
+390651000000106,[X]Neoplasm of uncertain and unknown behaviour of other myelodysplastic syndromes (disorder),n,via Query Table
+833601000000108,Non-Hodgkin's lymphoma - disorder,n,via Query Table
+94149003,"Acute megakaryoblastic leukemia, FAB M7 (disorder)",n,via Query Table
+815681000000105,Subcutaneous panniculitic T-cell lymphoma (disorder),n,via Query Table
+420441000000109,[M]Acute myelofibrosis (morphologic abnormality),n,via Query Table
+269478004,Chronic erythremia (disorder),n,via Query Table
+833541000000107,Subcutaneous panniculitic T-cell lymphoma,n,via Query Table
+634641000000101,Monocytic leukemia NOS (disorder),n,via Query Table
+190026006,[M]Subacute leukemia NOS (morphologic abnormality),n,via Query Table
+833521000000100,Cutaneous lymphoma,n,via Query Table
+401561000000106,[M]Monocytoid B-cell lymphoma,n,via Query Table
+189991001,[M]Hodgkin's paragranuloma (morphologic abnormality),n,via Query Table
+189976003,[M]Malignant lymphomatous polyposis (morphologic abnormality),n,via Query Table
+833461000000109,Acute myeloid leukaemia with myelodysplasia-related changes,n,via Query Table
+415461000000108,[M]Malignant lymphomatous polyposis (morphologic abnormality),n,via Query Table
+359626007,"Acute myelogenous leukemia without differentiation, FAB M0 (disorder)",n,via Query Table
+539731000000105,Mycosis fungoides of unspecified site (disorder),n,via Query Table
+473031000000100,"[M]Malignant lymphoma, centroblastic-centrocytic, follicular (morphologic abnormality)",n,via Query Table
+573361000000100,"Unspecified malignant neoplasm of lymphoid and histiocytic tissue of lymph nodes of head, face and neck (disorder)",n,via Query Table
+397451000000107,"[X]Malignant neoplasm of lymphoid, haematopoietic and related tissue, unspecified (disorder)",n,via Query Table
+189969008,"[M]Malignant lymphoma, lymphocytic, intermediate differentiation NOS (morphologic abnormality)",n,via Query Table
+188636003,Sezary's disease of spleen (disorder),n,via Query Table
+833621000000104,Cutaneous/peripheral T-cell lymphoma,n,via Query Table
+410671000000109,"[M]Malignant lymphoma, lymphocytic, intermediate differentiation NOS (morphologic abnormality)",n,via Query Table
+134179007,[M]Malignant histiocytosis (morphologic abnormality),n,via Query Table
+389761000000108,"[X]Myelodysplastic syndrome, unspecified (disorder)",n,via Query Table
+399081000000101,"[M]Malignant lymphoma, mixed lymphocytic-histiocytic NOS (morphologic abnormality)",n,via Query Table
+477851000000107,[M]Lymphoid leukaemias (morphologic abnormality),n,via Query Table
+309831004,[M]Hodgkin's disease NOS (morphologic abnormality),n,via Query Table
+134178004,"[M]Hodgkin's disease, nodular sclerosis NOS (morphologic abnormality)",n,via Query Table
+833641000000106,[M]Plasmacytoma NOS,n,via Query Table
+428971000000106,"[M]Lymphogranuloma, malignant (morphologic abnormality)",n,via Query Table
+539701000000104,Nodular lymphoma of unspecified site (disorder),n,via Query Table
+455391000000100,[M]Hodgkin's disease NOS (& [lymphogranuloma malignant]),n,via Query Table
+445691000000108,[M]Myeloid leukaemias (morphologic abnormality),n,via Query Table
+832661000000101,B-cell chronic lymphocytic leukaemia,n,via Query Table
+573431000000103,Reticulosarcoma or lymphosarcoma NOS (disorder),n,via Query Table
+833171000000105,Mantle cell lymphoma,n,via Query Table
+203436008,Osteoporosis in multiple myelomatosis (disorder),n,via Query Table
+409691000000100,[M]Aleukaemic leukaemia NOS (morphologic abnormality),n,via Query Table
+541021000000108,"Hodgkin's disease, mixed cellularity NOS (disorder)",n,via Query Table
+398271000000103,"[M]Malignant lymphoma, follicular centre cell, non-cleaved, follicular (morphologic abnormality)",n,via Query Table
+404146005,Primary cutaneous diffuse large cell B-cell lymphoma of the leg (disorder),n,via Query Table
+815271000000105,"Chronic myeloid leukaemia, BCR/ABL-positive (morphologic abnormality)",n,via Query Table
+875231000000102,Monoclonal gammopathy of uncertain significance,n,via Query Table
+190016004,[M]Plasma cell tumors (morphologic abnormality),n,via Query Table
+425131000000103,[M]Acute megakaryoblastic leukaemia (morphologic abnormality),n,via Query Table
+189998007,"[M]Malignant lymphoma, follicular center cell, cleaved, follicular (morphologic abnormality)",n,via Query Table
+565911000000106,Malignant lymphoma NOS of intra-abdominal lymph nodes (disorder),n,via Query Table
+396201000000105,"[M]Malignant lymphoma, undifferentiated cell type NOS (morphologic abnormality)",n,via Query Table
+832671000000108,B-cell prolymphocytic leukaemia,n,via Query Table
+462371000000101,"[X]Refractory anemia, unspecified (disorder)",n,via Query Table
+190056002,[M]Eosinophilic leukemia NOS (morphologic abnormality),n,via Query Table
+832821000000105,Follicular non-Hodgkin's lymphoma,n,via Query Table
+190048000,[M]Subacute myeloid leukemia (morphologic abnormality),n,via Query Table
+190063002,[M]Miscellaneous leukemias (morphologic abnormality),n,via Query Table
+833491000000103,Malignant lymphoma - lymphoblastic,n,via Query Table
+433531000000109,"[M]Malignant lymphoma, centroblastic-centrocytic, diffuse (morphologic abnormality)",n,via Query Table
+832611000000103,"Hodgkin's disease, mixed cellularity",n,via Query Table
+833591000000102,Low grade B-cell lymphoma,n,via Query Table
+391381000000100,[M]Histiocytic medullary reticulosis (morphologic abnormality),n,via Query Table
+402761000000108,"[X]Refractory anaemia, unspecified",n,via Query Table
+833611000000105,[M]AngiocentricT-cell lymphoma,n,via Query Table
+705141000000109,Sézary's disease of unspecified site (disorder),n,via Query Table
+833511000000106,True histiocytic lymphoma,n,via Query Table
+307652003,Idiopathic thrombocythemia (disorder),n,via Query Table
+421835000,Immunoblastic lymphoma associated with acquired immunodeficiency syndrome (disorder),n,via Query Table
+410571000000108,[M]Miscellaneous leukaemia NOS (morphologic abnormality),n,via Query Table
+15118008,AIDS with reticulosarcoma (disorder),n,via Query Table
+557661000000100,Malignant lymphoma NOS of spleen (disorder),n,via Query Table
+95259004,Sézary's disease of lymph nodes of axilla AND/OR upper limb (disorder),n,via Query Table
+578501000000101,"Hodgkin's disease, nodular sclerosis NOS (disorder)",n,via Query Table
+832641000000102,Hodgkin's disease,n,via Query Table
+189999004,"[M]Malignant lymphoma, lymphocytic, poorly differentiated, nodular (morphologic abnormality)",n,via Query Table
+573441000000107,Hodgkin's paragranuloma of unspecified site (disorder),n,via Query Table
+443951000000105,"[M]Malignant lymphoma, nodular NOS (& [Brill - Symmers' disease])",n,via Query Table
+557691000000106,Burkitt's lymphoma of unspecified site (disorder),n,via Query Table
+832521000000108,Acute monoblastic leukaemia,n,via Query Table
+832591000000106,"Hodgkin's disease, lymphocytic predominance - nodular",n,via Query Table
+189510008,Refractory anemia with sideroblasts (disorder),n,via Query Table
+188526000,Hodgkin's paragranuloma of intra-abdominal lymph nodes (disorder),n,via Query Table
+271385002,"[X]Non-Hodgkin's lymphoma, unspecified type (disorder)",n,via Query Table
+477541000000106,[X]Other myeloid leukaemia (morphologic abnormality),n,via Query Table
+271486002,Acute erythremia and erythroleukemia (disorder),n,via Query Table
+190006007,[M]Microglioma (morphologic abnormality),n,via Query Table
+189973006,[M]Prolymphocytic lymphosarcoma (morphologic abnormality),n,via Query Table
+634601000000104,Other myeloid leukemia NOS (disorder),n,via Query Table
+557651000000103,Reticulosarcoma NOS (disorder),n,via Query Table
+190033006,[M]Lymphoid leukemias (morphologic abnormality),n,via Query Table
+93147005,Leukemic reticuloendotheliosis of lymph nodes of axilla AND/OR upper limb (disorder),n,via Query Table
+401221000000100,[M]Malignant histiocytosis (morphologic abnormality),n,via Query Table
+555741000000104,Malignant histiocytosis of unspecified site (disorder),n,via Query Table
+638271000000102,Macroglobulinemia NOS (disorder),n,via Query Table
+269509006,"[M]Lymphogranuloma, malignant (morphologic abnormality)",n,via Query Table
+189966001,"[M]Malignant lymphoma, centroblastic-centrocytic, diffuse (morphologic abnormality)",n,via Query Table
+359636004,"Acute myelogenous leukemia without maturation, FAB M1 (disorder)",n,via Query Table
+574411000000109,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intrapelvic lymph nodes (disorder),n,via Query Table
+449751000000106,[M]Angioendotheliomatosis (morphologic abnormality),n,via Query Table
+815191000000104,"Atypical chronic myeloid leukaemia, BCR/ABL-negative (morphologic abnormality)",n,via Query Table
+189978002,"[M]Malignant lymphoma, large cell, non-cleaved, diffuse (morphologic abnormality)",n,via Query Table
+833341000000102,Follicular lymphoma grade 1,n,via Query Table
+461881000000104,[M]Plasma cell leukaemias (morphologic abnormality),n,via Query Table
+404031000000109,[M]Aleukaemic myeloid leukaemia (morphologic abnormality),n,via Query Table
+391691000000109,[M]Prolymphocytic lymphosarcoma (morphologic abnormality),n,via Query Table
+396711000000103,"[M]Malignant lymphoma, lymphocytic, poorly differentiated, nodular (morphologic abnormality)",n,via Query Table
+833441000000108,"Atypical chronic myeloid leukaemia, BCR/ABL negative",n,via Query Table
+190012002,[M] Large cell lymphoma (morphologic abnormality),n,via Query Table
+457421000000102,"[M]Malignant lymphoma, lymphocytic, well differentiated, nodular (morphologic abnormality)",n,via Query Table
+188656002,"Letterer-Siwe disease of lymph nodes of head, face and neck (disorder)",n,via Query Table
+640511000000108,Malignant lymphoma NOS (disorder),n,via Query Table
+832531000000105,Juvenile myelomonocytic leukaemia,n,via Query Table
+277600006,Acute myeloblastic leukemia (disorder),n,via Query Table
+190046001,[M]Lymphosarcoma cell leukemia NOS (morphologic abnormality),n,via Query Table
+541891000000101,Lymphosarcoma of unspecified site (disorder),n,via Query Table
+277648007,Angiocentric T-cell lymphoma (disorder),n,via Query Table
+450981000000106,[M]leukemia NOS (morphologic abnormality),n,via Query Table
+833111000000100,Refractory anaemia with multilineage dysplasia,n,via Query Table
+463341000000103,[M]Basophilic leukaemia NOS (morphologic abnormality),n,via Query Table
+565961000000108,Malignant lymphoma NOS of intrapelvic lymph nodes (disorder),n,via Query Table
+453011000000105,[M]Lymphosarcoma cell leukaemia NOS (morphologic abnormality),n,via Query Table
+833531000000103,"Extranodal natural killer/T-cell lymphoma, nasal type",n,via Query Table
+190032001,[M]Compound leukemia NOS (morphologic abnormality),n,via Query Table
+188624009,Mycosis fungoides of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+541691000000102,Malignant histiocytosis NOS (disorder),n,via Query Table
+190024009,[M]leukemias unspecified (morphologic abnormality),n,via Query Table
+189993003,"Lymphoma, nodular or follicular (morphologic abnormality)",n,via Query Table
+456651000000108,[M]Leukaemia NOS,n,via Query Table
+189990000,"[M]Hodgkin's disease, nodular sclerosis, mixed cellularity (morphologic abnormality)",n,via Query Table
+285768001,Acute myeloblastic leukemia with maturation (disorder),n,via Query Table
+833451000000106,"Chronic myelogenous leukaemia, BCR/ABL positive",n,via Query Table
+36449005,Acute erythremia (morphologic abnormality),n,via Query Table
+190165007,"[X]Diffuse non-Hodgkin's lymphoma, unspecified (disorder)",n,via Query Table
+389331000000104,"[M]Malignant lymphoma, convoluted cell type NOS (morphologic abnormality)",n,via Query Table
+191333009,Essential thrombocytosis (disorder),n,via Query Table
+429221000000106,[M]Hodgkin's disease NOS (morphologic abnormality),n,via Query Table
+190028007,[M]Aleukemic leukemia NOS (morphologic abnormality),n,via Query Table
+277576009,Plasma cell disorder (disorder),n,via Query Table
+189995005,"[M]Malignant lymphoma, centroblastic-centrocytic, follicular (morphologic abnormality)",n,via Query Table
+457051000000103,"[M]Hodgkin,s disease, lymphocytic predominance, diffuse (morphologic abnormality)",n,via Query Table
+443501000000104,[M]Subacute myeloid leukaemia (disorder),n,via Query Table
+417681000000107,"[X]Non-Hodgkin's lymphoma, unspecified type",n,via Query Table
+189989009,"[M]Hodgkin's disease, lymphocytic predominance, diffuse (morphologic abnormality)",n,via Query Table
+634611000000102,Myeloid leukemia NOS (disorder),n,via Query Table
+832811000000104,Primary mediastinal (thymic) large B-cell lymphoma,n,via Query Table
+634621000000108,Other monocytic leukemia (disorder),n,via Query Table
+815311000000105,Acute myeloid leukemia with myelodysplasia-related changes (disorder),n,via Query Table
+815451000000102,Primary cutaneous CD30 antigen positive large T-cell lymphoma (disorder),n,via Query Table
+425221000000109,[M]Burkitt's tumour NOS (morphologic abnormality),n,via Query Table
+78010001,"Malignant lymphoma, large B-cell, diffuse, immunoblastic (morphologic abnormality)",n,via Query Table
+833331000000106,Extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue,n,via Query Table
+633321000000101,"Histiocytosis X, unspecified (disorder)",n,via Query Table
+832601000000100,"Hodgkin's disease, nodular sclerosis",n,via Query Table
+416901000000108,"[M]Malignant lymphoma, nodular NOS (morphologic abnormality)",n,via Query Table
+190036003,[M]Aleukemic lymphoid leukemia (morphologic abnormality),n,via Query Table
+572191000000103,Hodgkin's granuloma NOS (disorder),n,via Query Table
+367051000000101,Mantle cell lymphoma (morphologic abnormality),n,via Query Table
+833031000000109,Eosinophilic granuloma,n,via Query Table
+188678009,Diffuse non-Hodgkin's lymphoblastic (diffuse) lymphoma (disorder),n,via Query Table
+420631000000103,[M]Acute lymphoid leukaemia (morphologic abnormality),n,via Query Table
+190011009,[M] Gamma heavy chain disease (morphologic abnormality),n,via Query Table
+470351000000104,[M]Polycythemia vera (morphologic abnormality),n,via Query Table
+445681000000106,[M]Lymphosarcoma cell leukaemia (morphologic abnormality),n,via Query Table
+95256006,Sézary's disease of intra-abdominal lymph nodes (disorder),n,via Query Table
+556061000000105,Burkitt's lymphoma NOS (disorder),n,via Query Table
+190038002,[M]Plasma cell leukemias (morphologic abnormality),n,via Query Table
+95257002,Sézary's disease of intrapelvic lymph nodes (disorder),n,via Query Table
+6357002,AIDS with primary lymphoma of the brain (disorder),n,via Query Table
+833061000000104,Anaplastic lymphoma kinase negative anaplastic large cell lymphoma,n,via Query Table
+833691000000101,Hypereosinophilic syndrome,n,via Query Table
+450611000000107,[X]Other monocytic leukaemia (morphologic abnormality),n,via Query Table
+662441000000104,Subacute leukemia NOS (disorder),n,via Query Table
+832631000000106,Lymphocyte-rich classical Hodgkin lymphoma,n,via Query Table
+190039005,[M]Plasma cell leukemia NOS (morphologic abnormality),n,via Query Table
+556151000000108,Malignant lymphoma NOS of unspecified site (disorder),n,via Query Table
+832621000000109,"Hodgkin's disease, lymphocytic depletion",n,via Query Table
+190001002,"[M]Malignant lymphoma, follicular center cell, non-cleaved, follicular (morphologic abnormality)",n,via Query Table
+189981007,"[M]Lymphoma, diffuse or NOS (morphologic abnormality)",n,via Query Table
+188756007,Acute panmyelosis (disorder),n,via Query Table
+71390001,Plasma cell dyscrasia (disorder),n,via Query Table
+409561000000107,[M]Microglioma (morphologic abnormality),n,via Query Table
+832651000000104,B-cell acute lymphoblastic leukaemia,n,via Query Table
+302852008,Plasmacytoma (disorder),n,via Query Table
+408281000000107,[X]Other malignant immunoproliferative diseases (disorder),n,via Query Table
+557671000000107,Unspecified malignant neoplasm of lymphoid and histiocytic tissue of intrathoracic lymph nodes (disorder),n,via Query Table
+278190000,Erythremia (morphologic abnormality),n,via Query Table
+430841000000108,[M]Angioendotheliomatosis,n,via Query Table
+414451000000109,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas,n,via Query Table
+814851000000101,Diffuse follicle centre lymphoma (disorder),n,via Query Table
+255100007,Mycosis fungoides of skin (disorder),n,via Query Table
+814201000000103,Primary mediastinal (thymic) large B-cell lymphoma (disorder),n,via Query Table
+190019006,[M]Plasma cell tumor NOS (morphologic abnormality),n,via Query Table
+188561006,"Hodgkin's, lymphocytic-histiocytic predominance of spleen (disorder)",n,via Query Table
+190043009,[M]Erythroleukemia NOS (morphologic abnormality),n,via Query Table
+190053005,[M]Basophilic leukemia NOS (morphologic abnormality),n,via Query Table
+396701000000100,[M]Hodgkin's paragranuloma (morphologic abnormality),n,via Query Table
+269510001,"[M]Malignant lymphoma, nodular NOS (morphologic abnormality)",n,via Query Table
+269508003,"[M]Malignant lymphoma, mixed lymphocytic-histiocytic NOS (morphologic abnormality)",n,via Query Table
+461891000000102,[M]Plasma cell leukaemia NOS (morphologic abnormality),n,via Query Table
+93149008,Leukemic reticuloendotheliosis of lymph nodes of inguinal region AND/OR lower limb (disorder),n,via Query Table
+815031000000104,Hepatosplenic T-cell lymphoma (disorder),n,via Query Table
+366059005,Letterer-Siwe disease (disorder),n,via Query Table
+403451000000108,"[M]Hodgkin's disease, lymphocytic predominance (morphologic abnormality)",n,via Query Table
+190229005,"[X]Myelodysplastic syndrome, unspecified (disorder)",n,via Query Table
+190049008,[M]Aleukemic myeloid leukemia (morphologic abnormality),n,via Query Table
+833371000000108,Follicular lymphoma grade 3a,n,via Query Table
+425541000000104,[M] Large cell lymphoma (morphologic abnormality),n,via Query Table
+425191000000102,[M]Other monocytic leukaemia NOS (morphologic abnormality),n,via Query Table
+128087008,Monoclonal gammopathy of undetermined significance (MGUS) (disorder),n,via Query Table
+466491000000105,[M] Monoclonal gammopathy (morphologic abnormality),n,via Query Table
+398691000000101,"[M]Malignant lymphoma, lymphocytic, poorly differentiated NOS (morphologic abnormality)",n,via Query Table
+189961006,"[M]Malignant lymphoma, undifferentiated cell type NOS (morphologic abnormality)",n,via Query Table
+189963009,"[M]Malignant lymphoma, convoluted cell type NOS (morphologic abnormality)",n,via Query Table
+556141000000105,Malignant lymphoma otherwise specified (disorder),n,via Query Table
+450944007,Polymorphic post transplant lymphoproliferative disorder (morphologic abnormality),n,via Query Table
+539741000000101,Mycosis fungoides NOS (disorder),n,via Query Table
+389871000000106,[M]Burkitt's tumours (morphologic abnormality),n,via Query Table
+134182002,[M]Polycythemia vera (morphologic abnormality),n,via Query Table
+833351000000104,Follicular lymphoma grade 2,n,via Query Table
+778041000000106,"[M]Malignant lymphoma, large cell, diffuse NOS",n,via Query Table
+437761000000104,[X]Other lymphoid leukaemia (disorder),n,via Query Table
+556071000000103,Other specified reticulosarcoma or lymphosarcoma (disorder),n,via Query Table
+450051000000104,[X]Other types of follicular non-Hodgkin's lymphoma (disorder),n,via Query Table
+425261000000101,[M]Plasma cell tumour NOS (morphologic abnormality),n,via Query Table
+91859000,"Acute monocytic leukemia, FAB M5 (disorder)",n,via Query Table
+572201000000101,Hodgkin's sarcoma of unspecified site (disorder),n,via Query Table
+190031008,[M]Compound leukemia (morphologic abnormality),n,via Query Table
+285766002,Acute myeloblastic leukemia without maturation (disorder),n,via Query Table
+190023003,[M]Burkitt's tumor NOS (morphologic abnormality),n,via Query Table
+401241000000107,"[M]Malignant lymphoma, small cleaved cell, diffuse (morphologic abnormality)",n,via Query Table
+555761000000103,Letterer-Siwe disease of unspecified sites (disorder),n,via Query Table
+867931000000106,[M]Juvenile myelomonocytic leukaemia (morphologic abnormality),n,via Query Table
+466521000000108,"[M]Hodgkin's disease, lymphocytic depletion NOS (morphologic abnormality)",n,via Query Table
+833571000000101,Angioimmunoblastic lymphadenopathy with dysproteinaemia,n,via Query Table
+190008008,[M] Peripheral T-cell lymphoma NOS (morphologic abnormality),n,via Query Table
+190040007,[M]Erythroleukemias (morphologic abnormality),n,via Query Table
+189971008,"[M]Malignant lymphoma, follicular center cell, cleaved NOS (morphologic abnormality)",n,via Query Table
+399211000000101,"[X]Non-Hodgkin's lymphoma, unspecified type (disorder)",n,via Query Table
+863791000000103,Clinical stage C chronic lymphocytic leukaemia ,n,via Query Table
+425951000000108,[X]Other and unspecified peripheral and cutaneous T-cell lymphomas (disorder),n,via Query Table
+188658001,Letterer-Siwe disease of lymph nodes of inguinal region and lower limb (disorder),n,via Query Table
+190034000,[M]Acute lymphoid leukemia (morphologic abnormality),n,via Query Table
+833471000000102,Acute myeloid leukaemia with 11q23 abnormality,n,via Query Table
+190057006,[M]Monocytic leukemias (morphologic abnormality),n,via Query Table
+408331000000102,"[M]Malignant lymphoma, diffuse NOS (morphologic abnormality)",n,via Query Table
+833121000000106,Hepatosplenic T-cell lymphoma,n,via Query Table
+437801000000109,[M]Erythroleukemia NOS (morphologic abnormality),n,via Query Table
+832911000000106,Acute myeloblastic leukaemia,n,via Query Table
+189957000,"[M]Lymphomas, NOS or diffuse (morphologic abnormality)",n,via Query Table
+425521000000106,"[M]Malignant lymphoma, follicular centre cell, non-cleaved NOS (morphologic abnormality)",n,via Query Table
+687931000000101,Lymphoid and histiocytic malignancy NOS (disorder),n,via Query Table
+134180005,[M] Monoclonal gammopathy (morphologic abnormality),n,via Query Table
+833431000000104,[M]Erythroleukaemia,n,via Query Table
+189996006,"[M]Malignant lymphoma, lymphocytic, well differentiated, nodular (morphologic abnormality)",n,via Query Table
+833551000000105,Langerhans' cell histiocytosis,n,via Query Table
+539711000000102,Nodular lymphoma NOS (disorder),n,via Query Table
+399501000000100,[X]Other leukaemia of unspecified cell type (disorder),n,via Query Table
+188523008,"Hodgkin's paragranuloma of lymph nodes of head, face, and neck (disorder)",n,via Query Table
+464031000000108,"[M]Lymphoma, nodular or follicular NOS (morphologic abnormality)",n,via Query Table
+472951000000104,[M]Subacute lymphoid leukaemia (morphologic abnormality),n,via Query Table
+478021000000105,"[M]Malignant lymphoma, follicular centre cell, cleaved, follicular (morphologic abnormality)",n,via Query Table
+42215000,Solitary osseous myeloma (disorder),n,via Query Table
+189988001,"[M]Hodgkin's disease, lymphocytic predominance (morphologic abnormality)",n,via Query Table
+408831000000107,[M]Monocytic leukaemias (morphologic abnormality),n,via Query Table
+419427007,Primary cutaneous large B-cell lymphoma of the leg (morphologic abnormality),n,via Query Table
+546351000000108,Chronic myeloid leukemia NOS (disorder),n,via Query Table

--- a/codelists/opensafely-lung-cancer-snomed.csv
+++ b/codelists/opensafely-lung-cancer-snomed.csv
@@ -1,0 +1,599 @@
+id,name,active,notes
+187862007,Malignant neoplasm of upper lobe of lung (disorder),y,direct mapping
+112677002,Bronchiolo-alveolar adenocarcinoma (morphologic abnormality),y,direct mapping
+363493006,Malignant tumor of bronchus (disorder),y,direct mapping
+372111007,"Carcinoma of lower lobe, bronchus or lung (disorder)",y,direct mapping
+315006004,Metastasis from malignant tumor of lung (disorder),y,direct mapping
+372065009,Malignant neoplasm of main bronchus (disorder),y,direct mapping
+109378008,"Mesothelioma (malignant, clinical disorder) (disorder)",y,direct mapping
+449308006,Malignant neoplasm of visceral pleura (disorder),y,direct mapping
+254632001,Small cell carcinoma of lung (disorder),y,direct mapping
+128632008,Non-small cell carcinoma (morphologic abnormality),y,direct mapping
+254633006,Oat cell carcinoma of lung (disorder),y,direct mapping
+93827000,Primary malignant neoplasm of hilus of lung (disorder),y,direct mapping
+187868006,"Malignant neoplasm of lower lobe, bronchus or lung (disorder)",y,direct mapping
+254620000,Squamous cell carcinoma of trachea (disorder),y,direct mapping
+254619006,Adenoid cystic carcinoma of trachea (disorder),y,direct mapping
+314954002,Local recurrence of malignant tumor of lung (disorder),y,direct mapping
+269464000,"Malignant neoplasm of upper lobe, bronchus or lung (disorder)",y,direct mapping
+239297008,Lymphomatoid granulomatosis of the lung (disorder),y,direct mapping
+278065000,Pancoast's syndrome (disorder),y,direct mapping
+187853005,Malignant neoplasm of cartilage of trachea (disorder),y,direct mapping
+1090881000000100,Malignant neoplasm of bronchus or lung (disorder),y,direct mapping
+187865009,Malignant neoplasm of middle lobe bronchus (disorder),y,direct mapping
+253003009,Carcinoid bronchial adenoma (disorder),y,direct mapping
+449067008,Malignant neoplasm of parietal pleura (disorder),y,direct mapping
+711414003,Primary clear cell adenocarcinoma of lung (disorder),y,direct mapping
+254634000,Squamous cell carcinoma of lung (disorder),y,direct mapping
+313356004,Squamous cell carcinoma of bronchus in right middle lobe (disorder),y,direct mapping
+254627002,Carcinoid tumor of lung (disorder),y,direct mapping
+187857006,Malignant neoplasm of carina of bronchus (disorder),y,direct mapping
+109371002,Overlapping malignant neoplasm of bronchus and lung (disorder),y,direct mapping
+254629004,Large cell carcinoma of lung (disorder),y,direct mapping
+93880001,Primary malignant neoplasm of lung (disorder),y,direct mapping
+363432004,Malignant tumor of trachea (disorder),y,direct mapping
+254645002,Malignant mesothelioma of pleura (disorder),y,direct mapping
+254635004,Epithelioid hemangioendothelioma of lung (disorder),y,direct mapping
+449096009,Malignant neoplasm of respiratory system (disorder),y,direct mapping
+187869003,Malignant neoplasm of lower lobe bronchus (disorder),y,direct mapping
+187854004,Malignant neoplasm of mucosa of trachea (disorder),y,direct mapping
+233940007,Pulmonary tumor embolism (disorder),y,direct mapping
+5958006,"Small cell carcinoma, intermediate cell (morphologic abnormality)",y,direct mapping
+74042001,"Small cell carcinoma, fusiform cell (morphologic abnormality)",y,direct mapping
+43149009,Pulmonary blastoma (morphologic abnormality),y,direct mapping
+313354001,Squamous cell carcinoma of bronchus in left upper lobe (disorder),y,direct mapping
+254638002,Pancoast tumor (disorder),y,direct mapping
+313353007,Squamous cell carcinoma of bronchus in left lower lobe (disorder),y,direct mapping
+254625005,Malignant tumor of lung parenchyma (disorder),y,direct mapping
+448993007,Malignant epithelial neoplasm of lung (disorder),y,direct mapping
+187861000,Malignant neoplasm of upper lobe bronchus (disorder),y,direct mapping
+187864008,"Malignant neoplasm of middle lobe, bronchus or lung (disorder)",y,direct mapping
+36310008,Alveolar adenocarcinoma (morphologic abnormality),y,direct mapping
+76817009,Oat cell carcinoma (morphologic abnormality),y,direct mapping
+254622008,Squamous cell carcinoma of bronchus (disorder),y,direct mapping
+363433009,Malignant tumor of pleura (disorder),y,direct mapping
+254626006,Adenocarcinoma of lung (disorder),y,direct mapping
+254628007,Carcinoma of lung parenchyma (disorder),y,direct mapping
+254631008,Giant cell carcinoma of lung (disorder),y,direct mapping
+372136001,"Carcinoma of upper lobe, bronchus or lung (disorder)",y,direct mapping
+313355000,Squamous cell carcinoma of bronchus in right lower lobe (disorder),y,direct mapping
+430621000,Malignant neoplasm of lower respiratory tract (disorder),y,direct mapping
+254637007,Non-small cell lung cancer (disorder),y,direct mapping
+21326004,Combined small cell carcinoma (morphologic abnormality),y,direct mapping
+363358000,Malignant tumor of lung (disorder),y,direct mapping
+187870002,Malignant neoplasm of lower lobe of lung (disorder),y,direct mapping
+187866005,Malignant neoplasm of middle lobe of lung (disorder),y,direct mapping
+93734005,Primary malignant neoplasm of bronchus (disorder),y,direct mapping
+313357008,Squamous cell carcinoma of bronchus in right upper lobe (disorder),y,direct mapping
+372135002,"Primary malignant neoplasm of upper lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+254503007,Malignant tumor of inferior surface of soft palate (disorder),y,descendant of concept mapped from leaf
+94102002,Primary malignant neoplasm of tonsillar fossa (disorder),y,descendant of concept mapped from leaf
+109856007,Malignant mesothelioma of mesentery (disorder),y,descendant of concept mapped from leaf
+187844003,Malignant neoplasm of cricoid cartilage (disorder),y,descendant of concept mapped from leaf
+109369002,Overlapping malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+425048006,"Non-small cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+363423001,Malignant tumor of nasal septum (disorder),y,descendant of concept mapped from leaf
+707389001,Primary clear cell squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+109383000,Malignant mesothelioma of pericardium (disorder),y,descendant of concept mapped from leaf
+93772000,Primary malignant neoplasm of diaphragm (disorder),y,descendant of concept mapped from leaf
+424970000,"Large cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+707358000,Primary squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+94232001,Secondary malignant neoplasm of bronchus of right upper lobe (disorder),y,descendant of concept mapped from leaf
+93687001,Primary malignant neoplasm of base of tongue (disorder),y,descendant of concept mapped from leaf
+707337006,Primary adenocarcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+254639005,Carcinoma in situ of lung parenchyma (disorder),y,descendant of concept mapped from leaf
+187830009,Malignant neoplasm of nasal conchae (disorder),y,descendant of concept mapped from leaf
+707587000,Primary carcinoma ex pleomorphic adenoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707672001,Pleuropulmonary blastoma type II (disorder),y,descendant of concept mapped from leaf
+254435009,Carcinoma of soft palate (disorder),y,descendant of concept mapped from leaf
+372103002,Carcinoma of glottis (disorder),y,descendant of concept mapped from leaf
+363376007,Malignant tumor of base of tongue (disorder),y,descendant of concept mapped from leaf
+94238002,Secondary malignant neoplasm of carina (disorder),y,descendant of concept mapped from leaf
+422541001,Undifferentiated carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94679009,Secondary malignant neoplasm of vocal cord (disorder),y,descendant of concept mapped from leaf
+707451005,Primary adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94067008,Primary malignant neoplasm of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+707409003,Primary acinar cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+424132000,"Non-small cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+707580003,Primary basaloid carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+93739000,Primary malignant neoplasm of carina (disorder),y,descendant of concept mapped from leaf
+363400004,Malignant tumor of postcricoid region (disorder),y,descendant of concept mapped from leaf
+707487003,Primary giant cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707345001,Primary carcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+94523002,Secondary malignant neoplasm of right middle lobe of lung (disorder),y,descendant of concept mapped from leaf
+363377003,Malignant tumor of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+707670009,Pleuropulmonary blastoma (disorder),y,descendant of concept mapped from leaf
+94656008,Secondary malignant neoplasm of upper respiratory tract (disorder),y,descendant of concept mapped from leaf
+94334003,Secondary malignant neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+189815007,Pulmonary blastoma (disorder),y,descendant of concept mapped from leaf
+254436005,Carcinoma of uvula (disorder),y,descendant of concept mapped from leaf
+707494000,Primary verrucous carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+254520006,Malignant tumor of infrahyoid epiglottis (disorder),y,descendant of concept mapped from leaf
+707471001,Primary clear cell adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+707703001,Primary squamous cell carcinoma of postcricoid region (disorder),y,descendant of concept mapped from leaf
+94118008,Primary malignant neoplasm of upper respiratory tract (disorder),y,descendant of concept mapped from leaf
+722529000,Primary malignant epithelial neoplasm of nasopharynx (disorder),y,descendant of concept mapped from leaf
+363430007,Malignant tumor of subglottis (disorder),y,descendant of concept mapped from leaf
+707388009,Primary squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94170009,Secondary malignant neoplasm of anterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707353009,Primary squamous cell carcinoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+109855006,Malignant mesothelioma of pelvic peritoneum (disorder),y,descendant of concept mapped from leaf
+707538002,Primary squamous cell carcinoma of vallecula (disorder),y,descendant of concept mapped from leaf
+363397008,Malignant tumor of roof of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707705008,Nonkeratinizing carcinoma of the nasopharynx (disorder),y,descendant of concept mapped from leaf
+363487003,Malignant tumor of aryepiglottic fold - laryngeal aspect (disorder),y,descendant of concept mapped from leaf
+93729006,Primary malignant neoplasm of bronchus of left lower lobe (disorder),y,descendant of concept mapped from leaf
+707475005,Primary adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+109854005,Malignant mesothelioma of parietal peritoneum (disorder),y,descendant of concept mapped from leaf
+707349007,Primary carcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+423464009,Squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707342003,Primary adenocarcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+303012000,Malignant tumor of posterior wall of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707427000,Primary verrucous carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+67811000119102,"Primary small cell malignant neoplasm of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+187716008,Malignant tumor of Waldeyer's ring (disorder),y,descendant of concept mapped from leaf
+363388009,Malignant tumor of soft palate (disorder),y,descendant of concept mapped from leaf
+254509006,Malignant tumor of anterior commissure (disorder),y,descendant of concept mapped from leaf
+707628004,Overlapping squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93868009,Primary malignant neoplasm of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+93732009,Primary malignant neoplasm of bronchus of right middle lobe (disorder),y,descendant of concept mapped from leaf
+422758009,Carcinoma of nasal meatus (disorder),y,descendant of concept mapped from leaf
+707583001,Primary adenosquamous carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+372141009,Carcinoma of vocal cord (disorder),y,descendant of concept mapped from leaf
+721607006,Primary undifferentiated carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+110013004,Overlapping malignant neoplasm of tonsil (disorder),y,descendant of concept mapped from leaf
+94272005,Secondary malignant neoplasm of diaphragm (disorder),y,descendant of concept mapped from leaf
+67841000119103,"Primary small cell malignant neoplasm of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+363401000,Malignant tumor of pyriform fossa (disorder),y,descendant of concept mapped from leaf
+94142007,Primary malignant neoplasm of vomer (disorder),y,descendant of concept mapped from leaf
+707344002,Primary adenocarcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+707403002,Primary fetal adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93662008,Primary malignant neoplasm of adenoid (disorder),y,descendant of concept mapped from leaf
+707704007,Primary squamous cell carcinoma of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+274085008,Tonsil carcinoma (disorder),y,descendant of concept mapped from leaf
+94155008,Secondary malignant neoplasm of accessory sinus (disorder),y,descendant of concept mapped from leaf
+1078931000119107,Primary adenocarcinoma of lower lobe of right lung (disorder),y,descendant of concept mapped from leaf
+423600008,"Large cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+93816002,Primary malignant neoplasm of glottis (disorder),y,descendant of concept mapped from leaf
+707383000,Primary mucinous cystadenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+707454002,Primary basaloid squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94367004,Secondary malignant neoplasm of laryngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+15956181000119102,Secondary adenocarcinoma of bilateral lungs (disorder),y,descendant of concept mapped from leaf
+698288007,Malignant melanoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+187692001,Malignant tumor of nasopharynx (disorder),y,descendant of concept mapped from leaf
+363426009,Malignant tumor of ethmoid sinus (disorder),y,descendant of concept mapped from leaf
+707489000,Primary spindle cell squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93848003,Primary malignant neoplasm of junctional zone of tongue (disorder),y,descendant of concept mapped from leaf
+707590006,Primary acinar cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707421004,Primary undifferentiated carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+242862004,Secondary malignant neoplasm of nasopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+94680007,Secondary malignant neoplasm of vomer (disorder),y,descendant of concept mapped from leaf
+449248000,Nasopharyngeal carcinoma (disorder),y,descendant of concept mapped from leaf
+707407001,Primary signet ring cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+707411007,Primary papillary adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93948004,Primary malignant neoplasm of parietal pleura (disorder),y,descendant of concept mapped from leaf
+93659005,Primary malignant neoplasm of accessory sinus (disorder),y,descendant of concept mapped from leaf
+423295000,"Squamous cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+707391009,Primary papillary squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+109366009,Overlapping malignant neoplasm of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+448990005,Malignant epithelial neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+7391000119103,Primary adenoid cystic carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+703230006,Non-small cell lung cancer without mutation in epidermal growth factor receptor (disorder),y,descendant of concept mapped from leaf
+683991000119103,Extensive stage primary small cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+707360003,Primary lymphoepithelial carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+707591005,Primary mucoepidermoid carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707377003,Primary signet ring cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+371994002,Primary malignant neoplasm of laryngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+187702003,Malignant tumor of nasopharyngeal soft palate surface (disorder),y,descendant of concept mapped from leaf
+363488008,Malignant tumor of false cord (disorder),y,descendant of concept mapped from leaf
+448868009,Malignant neoplasm of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+363422006,Malignant tumor of nasal cavity (disorder),y,descendant of concept mapped from leaf
+707595001,Primary mucinous cystadenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+698285005,Malignant melanoma of ethmoid sinus (disorder),y,descendant of concept mapped from leaf
+733844008,Neuroendocrine type combined small cell carcinoma (morphologic abnormality),y,descendant of concept mapped from leaf
+94581003,Secondary malignant neoplasm of soft palate (disorder),y,descendant of concept mapped from leaf
+372112000,"Primary malignant neoplasm of middle lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+94376006,Secondary malignant neoplasm of left upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+285605009,Metastasis to pleura of unknown primary (disorder),y,descendant of concept mapped from leaf
+707584007,Primary lymphoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707357005,Primary squamous cell carcinoma of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+707484005,Primary adenoid squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707395000,Primary adenocarcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707384006,Primary solid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+423121009,"Non-small cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+707455001,Primary papillary squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+707397008,Primary basal cell adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707385007,Primary undifferentiated carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+187675005,Malignant tumor of tonsillar pillar (disorder),y,descendant of concept mapped from leaf
+93830007,Primary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+94104001,Primary malignant neoplasm of trachea (disorder),y,descendant of concept mapped from leaf
+93992002,Primary malignant neoplasm of right middle lobe of lung (disorder),y,descendant of concept mapped from leaf
+1078881000119102,Primary adenocarcinoma of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+707453008,Primary clear cell squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+109853004,Malignant mesothelioma of peritoneum (disorder),y,descendant of concept mapped from leaf
+94677006,Secondary malignant neoplasm of vestibule of nose (disorder),y,descendant of concept mapped from leaf
+94140004,Primary malignant neoplasm of visceral pleura (disorder),y,descendant of concept mapped from leaf
+353741000119106,Secondary malignant neoplasm of left lung (disorder),y,descendant of concept mapped from leaf
+372105009,Carcinoma of supraglottis (disorder),y,descendant of concept mapped from leaf
+707425008,Primary adenoid squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+94333009,Secondary malignant neoplasm of hypopharyngeal aspect of interarytenoid fold (disorder),y,descendant of concept mapped from leaf
+423318000,Adenoid cystic carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+93730001,Primary malignant neoplasm of bronchus of left upper lobe (disorder),y,descendant of concept mapped from leaf
+707354003,Primary squamous cell carcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+707464006,Primary myoepithelial carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+93933005,Primary malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+94399005,Secondary malignant neoplasm of main bronchus (disorder),y,descendant of concept mapped from leaf
+94368009,Secondary malignant neoplasm of laryngeal commissure (disorder),y,descendant of concept mapped from leaf
+94458003,Secondary malignant neoplasm of tonsil (disorder),y,descendant of concept mapped from leaf
+707674000,Primary malignant epithelial neoplasm of trachea (disorder),y,descendant of concept mapped from leaf
+94329002,Secondary malignant neoplasm of hilus of lung (disorder),y,descendant of concept mapped from leaf
+707582006,Primary spindle cell squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+187685006,Malignant neoplasm of junctional region of epiglottis (disorder),y,descendant of concept mapped from leaf
+707423001,Primary basaloid carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+187831008,Malignant tumor of nasal vestibule (disorder),y,descendant of concept mapped from leaf
+423468007,"Squamous cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+707627009,Primary salivary gland type carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707479004,Primary adenocarcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+707529004,Overlapping squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+363399006,Malignant tumor of hypopharynx (disorder),y,descendant of concept mapped from leaf
+94372008,Secondary malignant neoplasm of lateral wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707457009,Primary spindle cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94607007,Secondary malignant neoplasm of subglottis (disorder),y,descendant of concept mapped from leaf
+94078000,Primary malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94370000,Secondary malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+721605003,Primary squamous cell carcinoma of overlapping lesion of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+93971002,Primary malignant neoplasm of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+1078961000119104,Primary adenocarcinoma of upper lobe of right lung (disorder),y,descendant of concept mapped from leaf
+94231008,Secondary malignant neoplasm of bronchus of right middle lobe (disorder),y,descendant of concept mapped from leaf
+1078901000119100,Primary adenocarcinoma of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+285604008,Metastasis to lung of unknown primary (disorder),y,descendant of concept mapped from leaf
+722530005,Primary squamous cell carcinoma of pharyngeal tonsil (disorder),y,descendant of concept mapped from leaf
+698044008,Malignant melanoma of palatine arch (disorder),y,descendant of concept mapped from leaf
+94166001,Secondary malignant neoplasm of anterior aspect of epiglottis (disorder),y,descendant of concept mapped from leaf
+93882009,Primary malignant neoplasm of main bronchus (disorder),y,descendant of concept mapped from leaf
+449254004,Malignant epithelial neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+94373003,Secondary malignant neoplasm of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+424938000,"Large cell carcinoma of lung, TNM stage 1 (disorder)",y,descendant of concept mapped from leaf
+371995001,Primary malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+408648004,Squamous cell carcinoma of epiglottis (disorder),y,descendant of concept mapped from leaf
+94375005,Secondary malignant neoplasm of left lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+94473002,Secondary malignant neoplasm of parietal pleura (disorder),y,descendant of concept mapped from leaf
+94507002,Secondary malignant neoplasm of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+707408006,Primary small cell non-keratinizing squamous cell carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+18121000119104,Primary squamous cell carcinoma of palatine tonsil (disorder),y,descendant of concept mapped from leaf
+707579001,Primary basaloid squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707406005,Primary mucoepidermoid carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+697993003,Undifferentiated carcinoma of nasal sinus (disorder),y,descendant of concept mapped from leaf
+363506007,Malignant tumor of nasal sinuses (disorder),y,descendant of concept mapped from leaf
+707392002,Primary giant cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94129007,Primary malignant neoplasm of uvula (disorder),y,descendant of concept mapped from leaf
+15956381000119100,Adenocarcinoma of right lung (disorder),y,descendant of concept mapped from leaf
+94233006,Secondary malignant neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+187644001,Malignant tumor of junctional zone of tongue (disorder),y,descendant of concept mapped from leaf
+93787005,Primary malignant neoplasm of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+448214005,Malignant epithelial neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+440173001,Nonsquamous nonsmall cell neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+723182009,Primary squamous cell carcinoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+707426009,Primary papillary squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+363392002,Malignant tumor of oropharynx (disorder),y,descendant of concept mapped from leaf
+707686002,Primary squamous cell carcinoma of posterior wall of hypopharynx (disorder),y,descendant of concept mapped from leaf
+722527003,Primary malignant neuroendocrine neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+254526000,Malignant tumor of laryngeal ventricle (disorder),y,descendant of concept mapped from leaf
+707399006,Primary papillary adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+93966009,Primary malignant neoplasm of pleura (disorder),y,descendant of concept mapped from leaf
+255075004,Malignant tumor of lateral nasal wall (disorder),y,descendant of concept mapped from leaf
+353561000119103,Secondary malignant neoplasm of right lung (disorder),y,descendant of concept mapped from leaf
+94639000,Secondary malignant neoplasm of tonsillar fossa (disorder),y,descendant of concept mapped from leaf
+724060008,Malignant neoplasm of right upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+440527006,Primary squamous cell carcinoma of naris (disorder),y,descendant of concept mapped from leaf
+187683004,Malignant neoplasm of glossoepiglottic fold (disorder),y,descendant of concept mapped from leaf
+707586009,Primary myoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+187698002,Malignant tumor of opening of auditory tube (disorder),y,descendant of concept mapped from leaf
+707673006,Pleuropulmonary blastoma type III (disorder),y,descendant of concept mapped from leaf
+372110008,"Primary malignant neoplasm of lower lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+408649007,Squamous cell carcinoma of pharynx (disorder),y,descendant of concept mapped from leaf
+94678001,Secondary malignant neoplasm of visceral pleura (disorder),y,descendant of concept mapped from leaf
+707458004,Primary pleomorphic carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94495003,Secondary malignant neoplasm of postcricoid region (disorder),y,descendant of concept mapped from leaf
+94498001,Secondary malignant neoplasm of posterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+187842004,Malignant tumor of supraglottis (disorder),y,descendant of concept mapped from leaf
+67831000119107,"Primary small cell malignant neoplasm of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+241861008,Metastatic malignant neoplasm to nasopharynx (disorder),y,descendant of concept mapped from leaf
+94318001,Secondary malignant neoplasm of glottis (disorder),y,descendant of concept mapped from leaf
+722827008,Primary synovial sarcoma of respiratory organ (disorder),y,descendant of concept mapped from leaf
+707532001,Primary squamous cell carcinoma of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+94158005,Secondary malignant neoplasm of adenoid (disorder),y,descendant of concept mapped from leaf
+93784003,Primary malignant neoplasm of epiglottis (disorder),y,descendant of concept mapped from leaf
+94358004,Secondary malignant neoplasm of junctional region of epiglottis (disorder),y,descendant of concept mapped from leaf
+94366008,Secondary malignant neoplasm of laryngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+1090231000000103,Malignant neoplasm of respiratory tract (disorder),y,descendant of concept mapped from leaf
+372120003,Carcinoma of main bronchus (disorder),y,descendant of concept mapped from leaf
+724056005,Malignant neoplasm of lower lobe of right lung (disorder),y,descendant of concept mapped from leaf
+449417005,Malignant epithelial neoplasm of nasal septum (disorder),y,descendant of concept mapped from leaf
+372030009,Primary malignant neoplasm of vocal cord (disorder),y,descendant of concept mapped from leaf
+94515004,Secondary malignant neoplasm of respiratory tract (disorder),y,descendant of concept mapped from leaf
+698011002,Keratinizing squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+426964009,"Non-small cell lung cancer, positive for epidermal growth factor receptor expression (disorder)",y,descendant of concept mapped from leaf
+94144008,Primary malignant neoplasm of Waldeyer's ring (disorder),y,descendant of concept mapped from leaf
+93831006,Primary malignant neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+363389001,Malignant tumor of uvula (disorder),y,descendant of concept mapped from leaf
+707697002,Primary squamous cell carcinoma of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+448372003,Non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+733144006,Malignant epithelial neoplasm of bronchus (disorder),y,descendant of concept mapped from leaf
+93862005,Primary malignant neoplasm of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+94613003,Secondary malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+448672006,Follicular non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+718200007,Primary pulmonary lymphoma (disorder),y,descendant of concept mapped from leaf
+707593008,Primary salivary gland-type tumour of oropharynx (disorder),y,descendant of concept mapped from leaf
+722511005,Primary rhabdomyosarcoma of respiratory organ (disorder),y,descendant of concept mapped from leaf
+94103007,Primary malignant neoplasm of tonsillar pillar (disorder),y,descendant of concept mapped from leaf
+94075002,Primary malignant neoplasm of subglottis (disorder),y,descendant of concept mapped from leaf
+94640003,Secondary malignant neoplasm of tonsillar pillar (disorder),y,descendant of concept mapped from leaf
+707491008,Primary lymphoepithelial carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+363398003,Malignant tumor of lateral wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+363427000,Malignant tumor of frontal sinus (disorder),y,descendant of concept mapped from leaf
+449292003,Non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+94332004,Secondary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+363486007,Malignant tumor of vocal cord (disorder),y,descendant of concept mapped from leaf
+93986008,Primary malignant neoplasm of respiratory tract (disorder),y,descendant of concept mapped from leaf
+187681002,Malignant neoplasm of anterior epiglottis (disorder),y,descendant of concept mapped from leaf
+94391008,Secondary malignant neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+709031009,Malignant neoplasm of superior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+372104008,Carcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+94369001,Secondary malignant neoplasm of laryngeal surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+449058008,Follicular non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+94049001,Primary malignant neoplasm of soft palate (disorder),y,descendant of concept mapped from leaf
+187694000,Malignant tumor of adenoid (disorder),y,descendant of concept mapped from leaf
+707422006,Primary spindle cell squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+707398003,Primary polymorphous low grade adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707588005,Primary epithelial-myoepithelial carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+707466008,Primary adenoid cystic carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+707386008,Primary acinar cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+271943005,Carcinoma of base of tongue (disorder),y,descendant of concept mapped from leaf
+707467004,Primary salivary gland type carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+363507003,Malignant neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+363425008,Malignant tumor of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+707469001,Primary non-mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+254530002,Malignant tumor of parapharyngeal space (disorder),y,descendant of concept mapped from leaf
+722510006,Primary rhabdomyosarcoma of pharynx (disorder),y,descendant of concept mapped from leaf
+363395000,Malignant tumor of vallecula (disorder),y,descendant of concept mapped from leaf
+449066004,Malignant neoplasm of upper respiratory tract (disorder),y,descendant of concept mapped from leaf
+707452003,Primary mucinous adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+187688008,Malignant tumor of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+724058006,Malignant neoplasm of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+707346000,Primary carcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+735450006,Primary malignant neuroepitheliomatous neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+448665005,Malignant epithelial neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+94670008,Secondary malignant neoplasm of vallecula (disorder),y,descendant of concept mapped from leaf
+707348004,Primary carcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+94296000,Secondary malignant neoplasm of false vocal cord (disorder),y,descendant of concept mapped from leaf
+255119002,Lymphangitis carcinomatosa (disorder),y,descendant of concept mapped from leaf
+94139001,Primary malignant neoplasm of vestibule of nose (disorder),y,descendant of concept mapped from leaf
+187701005,Malignant neoplasm of floor of nasopharynx (disorder),y,descendant of concept mapped from leaf
+255074000,Malignant tumor of nasal cavity and nasopharynx (disorder),y,descendant of concept mapped from leaf
+707575007,Primary squamous cell carcinoma of supraglottis (disorder),y,descendant of concept mapped from leaf
+254517003,Malignant tumor of suprahyoid epiglottis (disorder),y,descendant of concept mapped from leaf
+187682009,"Malignant neoplasm of epiglottis, free border (disorder)",y,descendant of concept mapped from leaf
+93967000,Primary malignant neoplasm of postcricoid region (disorder),y,descendant of concept mapped from leaf
+275490009,Carcinoma of tongue base - dorsal surface (disorder),y,descendant of concept mapped from leaf
+707473003,Primary mucinous adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+707470000,Primary mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+363431006,Malignant tumor of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+187693006,Malignant tumor of posterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+93674007,Primary malignant neoplasm of anterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707359008,Primary squamous cell carcinoma of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+707596000,Primary carcinosarcoma of lung (disorder),y,descendant of concept mapped from leaf
+722528008,Primary malignant neuroendocrine neoplasm of lung (disorder),y,descendant of concept mapped from leaf
+371988005,Primary malignant neoplasm of false vocal cord (disorder),y,descendant of concept mapped from leaf
+372113005,"Carcinoma of middle lobe, bronchus or lung (disorder)",y,descendant of concept mapped from leaf
+254513004,Malignant tumor of posterior commissure (disorder),y,descendant of concept mapped from leaf
+109858008,Malignant mesothelioma of omentum (disorder),y,descendant of concept mapped from leaf
+94616006,Secondary malignant neoplasm of supraglottis (disorder),y,descendant of concept mapped from leaf
+402503002,Basal cell carcinoma of nasal columella (disorder),y,descendant of concept mapped from leaf
+93670003,Primary malignant neoplasm of anterior aspect of epiglottis (disorder),y,descendant of concept mapped from leaf
+707664003,Primary squamous cell carcinoma of glottis (disorder),y,descendant of concept mapped from leaf
+94493005,Secondary malignant neoplasm of pleura (disorder),y,descendant of concept mapped from leaf
+12240951000119107,Squamous cell carcinoma of left lung (disorder),y,descendant of concept mapped from leaf
+93918002,Primary malignant neoplasm of nasal concha (disorder),y,descendant of concept mapped from leaf
+707465007,Primary mucoepidermoid carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+721560002,Primary adenocarcinoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+285598005,Metastasis to trachea of unknown primary (disorder),y,descendant of concept mapped from leaf
+698040004,Malignant melanoma of nasal cavity (disorder),y,descendant of concept mapped from leaf
+707581004,Primary papillary squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+67821000119109,"Primary small cell malignant neoplasm of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+707356001,Primary squamous cell carcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+707535004,Primary squamous cell carcinoma of lateral wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+698048006,Undifferentiated nonkeratinizing squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94132005,Primary malignant neoplasm of vallecula (disorder),y,descendant of concept mapped from leaf
+448371005,Non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707343008,Primary adenocarcinoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+109832008,Overlapping malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+707430007,Overlapping squamous cell carcinoma of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+707394001,Primary spindle cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94228007,Secondary malignant neoplasm of bronchus of left lower lobe (disorder),y,descendant of concept mapped from leaf
+707539005,Primary adenoid cystic carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+94524008,Secondary malignant neoplasm of right upper lobe of lung (disorder),y,descendant of concept mapped from leaf
+93917007,Primary malignant neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+94230009,Secondary malignant neoplasm of bronchus of right lower lobe (disorder),y,descendant of concept mapped from leaf
+187708004,Malignant tumor aryepiglottic fold - hypopharyngeal aspect (disorder),y,descendant of concept mapped from leaf
+707592003,Primary infiltrating duct carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94310008,Secondary malignant neoplasm of frontal sinus (disorder),y,descendant of concept mapped from leaf
+109390005,Kaposi's sarcoma of lung (disorder),y,descendant of concept mapped from leaf
+422691006,Squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+93731002,Primary malignant neoplasm of bronchus of right lower lobe (disorder),y,descendant of concept mapped from leaf
+94499009,Secondary malignant neoplasm of posterior wall of oropharynx (disorder),y,descendant of concept mapped from leaf
+707492001,Primary squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+405822008,Squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+707400004,Primary mucinous adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94080006,Primary malignant neoplasm of supraglottis (disorder),y,descendant of concept mapped from leaf
+93808006,Primary malignant neoplasm of frontal sinus (disorder),y,descendant of concept mapped from leaf
+707671008,Pleuropulmonary blastoma type I (disorder),y,descendant of concept mapped from leaf
+187700006,Malignant tumor of anterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707472008,Primary papillary adenocarcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+724059003,Malignant neoplasm of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+93968005,Primary malignant neoplasm of posterior hypopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+707410008,Primary solid carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+723301009,Squamous non-small cell lung cancer (disorder),y,descendant of concept mapped from leaf
+12240991000119102,Squamous cell carcinoma of right lung (disorder),y,descendant of concept mapped from leaf
+707429002,Overlapping squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+707378008,Primary myoepithelial carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+93864006,Primary malignant neoplasm of lower lobe of left lung (disorder),y,descendant of concept mapped from leaf
+187843009,Malignant neoplasm of arytenoid cartilage (disorder),y,descendant of concept mapped from leaf
+722672002,Primary squamous cell carcinoma of base of tongue (disorder),y,descendant of concept mapped from leaf
+707482009,Primary papillary squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+109374005,Overlapping malignant neoplasm of mediastinum and pleura (disorder),y,descendant of concept mapped from leaf
+707350007,Malignant melanoma of accessory sinus (disorder),y,descendant of concept mapped from leaf
+707585008,Primary squamous cell carcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94641004,Secondary malignant neoplasm of trachea (disorder),y,descendant of concept mapped from leaf
+94002000,Primary malignant neoplasm of septum of nose (disorder),y,descendant of concept mapped from leaf
+707576008,Primary squamous cell carcinoma of subglottis (disorder),y,descendant of concept mapped from leaf
+94379004,Secondary malignant neoplasm of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+187846001,Malignant neoplasm of thyroid cartilage (disorder),y,descendant of concept mapped from leaf
+703549009,"Small cell carcinoma, hypercalcemic type (morphologic abnormality)",y,descendant of concept mapped from leaf
+94454001,Secondary malignant neoplasm of oropharynx (disorder),y,descendant of concept mapped from leaf
+707396004,Primary oxyphilic adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+94522007,Secondary malignant neoplasm of right lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+422968005,"Non-small cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+94496002,Secondary malignant neoplasm of posterior hypopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+707401000,Primary clear cell adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+109368005,Overlapping malignant neoplasm of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93961004,Primary malignant neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+707379000,Primary mucoepidermoid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+93857009,Primary malignant neoplasm of laryngeal commissure (disorder),y,descendant of concept mapped from leaf
+707486007,Primary basaloid carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+707660007,Primary giant cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+94436000,Secondary malignant neoplasm of nasal cavity (disorder),y,descendant of concept mapped from leaf
+448867004,Diffuse non-Hodgkin's lymphoma of lung (disorder),y,descendant of concept mapped from leaf
+733358002,Primary squamous cell carcinoma of respiratory system (disorder),y,descendant of concept mapped from leaf
+109370001,Primary malignant neoplasm of laryngeal cartilage (disorder),y,descendant of concept mapped from leaf
+93991009,Primary malignant neoplasm of right lower lobe of lung (disorder),y,descendant of concept mapped from leaf
+707528007,Primary squamous cell carcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94599006,Secondary malignant neoplasm of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+372020000,Primary malignant neoplasm of tonsil (disorder),y,descendant of concept mapped from leaf
+707481002,Primary basaloid squamous cell carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+422886007,Olfactory neuroblastoma (disorder),y,descendant of concept mapped from leaf
+707339009,Primary adenocarcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+94229004,Secondary malignant neoplasm of bronchus of left upper lobe (disorder),y,descendant of concept mapped from leaf
+423050000,"Large cell carcinoma of lung, TNM stage 2 (disorder)",y,descendant of concept mapped from leaf
+276975007,Carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+93861003,Primary malignant neoplasm of lateral wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+94682004,Secondary malignant neoplasm of Waldeyer's ring (disorder),y,descendant of concept mapped from leaf
+93993007,Primary malignant neoplasm of upper lobe of right lung (disorder),y,descendant of concept mapped from leaf
+448319002,Diffuse non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+187838002,"Malignant neoplasm, overlapping lesion of accessory sinuses (disorder)",y,descendant of concept mapped from leaf
+722673007,Primary squamous cell carcinoma of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+94359007,Secondary malignant neoplasm of junctional zone of tongue (disorder),y,descendant of concept mapped from leaf
+707662004,Primary basaloid squamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+187845002,Malignant neoplasm of cuneiform cartilage (disorder),y,descendant of concept mapped from leaf
+93978008,Primary malignant neoplasm of pyriform sinus (disorder),y,descendant of concept mapped from leaf
+707347009,Primary carcinoma of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+707405009,Primary adenosquamous carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+109367000,Overlapping malignant neoplasm of nasopharynx (disorder),y,descendant of concept mapped from leaf
+363394001,Malignant tumor of tonsillar fossa (disorder),y,descendant of concept mapped from leaf
+93865007,Primary malignant neoplasm of upper lobe of left lung (disorder),y,descendant of concept mapped from leaf
+707485006,Primary adenosquamous carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+721606002,Primary adenocarcinoma of overlapping lesion of accessory sinuses (disorder),y,descendant of concept mapped from leaf
+707424007,Primary adenosquamous cell carcinoma of larynx (disorder),y,descendant of concept mapped from leaf
+707362006,Malignant melanoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+94184004,Secondary malignant neoplasm of base of tongue (disorder),y,descendant of concept mapped from leaf
+449219006,Follicular non-Hodgkin's lymphoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+707456000,Primary undifferentiated carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+240163000,Malignant neoplasm of nasopharyngeal wall (disorder),y,descendant of concept mapped from leaf
+722425009,Reactive oxygen species 1 positive non-small cell lung cancer (disorder),y,descendant of concept mapped from leaf
+707589002,Primary cystadenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+425376008,"Squamous cell carcinoma of lung, TNM stage 4 (disorder)",y,descendant of concept mapped from leaf
+93858004,Primary malignant neoplasm of laryngeal surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+707468009,Primary mixed mucinous and non-mucinous bronchiolo-alveolar carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94534004,Secondary malignant neoplasm of septum of nose (disorder),y,descendant of concept mapped from leaf
+707393007,Primary adenosquamous carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+449173006,Diffuse non-Hodgkin's lymphoma of tonsil (disorder),y,descendant of concept mapped from leaf
+94437009,Secondary malignant neoplasm of nasal concha (disorder),y,descendant of concept mapped from leaf
+15956341000119105,Adenocarcinoma of left lung (disorder),y,descendant of concept mapped from leaf
+285603002,Metastasis to bronchus of unknown primary (disorder),y,descendant of concept mapped from leaf
+707380002,Primary salivary gland type carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94667009,Secondary malignant neoplasm of uvula (disorder),y,descendant of concept mapped from leaf
+254478004,Malignant tumor of inferior turbinate (disorder),y,descendant of concept mapped from leaf
+707537007,Primary squamous cell carcinoma of anterior surface of epiglottis (disorder),y,descendant of concept mapped from leaf
+707355002,Primary squamous cell carcinoma of sphenoidal sinus (disorder),y,descendant of concept mapped from leaf
+707402007,Primary adenocarcinoma of oropharynx (disorder),y,descendant of concept mapped from leaf
+726653000,Malignant carcinoid tumor of bronchus (disorder),y,descendant of concept mapped from leaf
+363429002,Malignant tumor of larynx (disorder),y,descendant of concept mapped from leaf
+707390005,Primary basaloid squamous cell carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94406009,Secondary malignant neoplasm of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+703228009,Non-small cell lung cancer with mutation in epidermal growth factor receptor (disorder),y,descendant of concept mapped from leaf
+707460002,Primary pseudosarcomatous carcinoma of lung (disorder),y,descendant of concept mapped from leaf
+94288005,Secondary malignant neoplasm of ethmoidal sinus (disorder),y,descendant of concept mapped from leaf
+187841006,Malignant tumor of glottis (disorder),y,descendant of concept mapped from leaf
+403889000,Verrucous carcinoma of oral cavity (disorder),y,descendant of concept mapped from leaf
+707493006,Primary lymphoepithelial carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+61471000119100,Basal cell carcinoma of naris (disorder),y,descendant of concept mapped from leaf
+254484001,Malignant tumor of posterior margin of nasal septum and choanae (disorder),y,descendant of concept mapped from leaf
+448509007,Transglottic malignant neoplasm of larynx (disorder),y,descendant of concept mapped from leaf
+254459004,Malignant tumor of anterior pillar of fauces (disorder),y,descendant of concept mapped from leaf
+254423005,Carcinoma of lingual tonsil (disorder),y,descendant of concept mapped from leaf
+363393007,Malignant tumor of tonsil (disorder),y,descendant of concept mapped from leaf
+93733004,Primary malignant neoplasm of bronchus of right upper lobe (disorder),y,descendant of concept mapped from leaf
+707404008,Primary mixed subtype adenocarcinoma of lung (disorder),y,descendant of concept mapped from leaf
+109384006,"Overlapping malignant neoplasm of heart, mediastinum and pleura (disorder)",y,descendant of concept mapped from leaf
+94488007,Secondary malignant neoplasm of pharynx (disorder),y,descendant of concept mapped from leaf
+733345003,Primary squamous cell carcinoma of pharynx (disorder),y,descendant of concept mapped from leaf
+425230006,"Squamous cell carcinoma of lung, TNM stage 3 (disorder)",y,descendant of concept mapped from leaf
+93889000,Primary malignant neoplasm of maxillary sinus (disorder),y,descendant of concept mapped from leaf
+187631006,Malignant neoplasm of base of tongue dorsal surface (disorder),y,descendant of concept mapped from leaf
+707495004,Primary squamous cell adenoid carcinoma of trachea (disorder),y,descendant of concept mapped from leaf
+94284007,Secondary malignant neoplasm of epiglottis (disorder),y,descendant of concept mapped from leaf
+363428005,Malignant tumor of sphenoid sinus (disorder),y,descendant of concept mapped from leaf
+254481009,Malignant tumor of middle turbinate (disorder),y,descendant of concept mapped from leaf
+707490009,Primary verrucous carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+423106003,Adenocarcinoma of nasopharynx (disorder),y,descendant of concept mapped from leaf
+427038005,"Non-small cell lung cancer, negative for epidermal growth factor receptor expression (disorder)",y,descendant of concept mapped from leaf
+187709007,Malignant neoplasm of posterior pharynx (disorder),y,descendant of concept mapped from leaf
+1661000119106,Metastasis to lung from adenocarcinoma (disorder),y,descendant of concept mapped from leaf
+93970001,Primary malignant neoplasm of posterior wall of nasopharynx (disorder),y,descendant of concept mapped from leaf
+187697007,Malignant tumor of pharyngeal recess (disorder),y,descendant of concept mapped from leaf
+707483004,Primary undifferentiated carcinoma of hypopharynx (disorder),y,descendant of concept mapped from leaf
+93829002,Primary malignant neoplasm of hypopharyngeal aspect of aryepiglottic fold (disorder),y,descendant of concept mapped from leaf
+707361004,Malignant melanoma of frontal sinus (disorder),y,descendant of concept mapped from leaf
+566551000000105,Malignant neoplasm of oropharynx NOS (disorder),n,via Query Table
+479031000000103,"[X]Malignant neoplasm of bronchus or lung, unspecified (disorder)",n,via Query Table
+557101000000105,"Malignant neoplasm of lower lobe, bronchus or lung NOS (disorder)",n,via Query Table
+397641000000107,[X]Malignant neoplasm of respiratory and intrathoracic organs (disorder),n,via Query Table
+550101000000109,Malignant neoplasm of trachea NOS (disorder),n,via Query Table
+566531000000103,"Malignant neoplasm of oropharynx, other specified sites (disorder)",n,via Query Table
+190110008,"[X]Mesothelioma, unspecified (disorder)",n,via Query Table
+559881000000101,Malignant neoplasm of anterior wall of nasopharynx NOS (disorder),n,via Query Table
+557091000000102,"Malignant neoplasm of middle lobe, bronchus or lung NOS (disorder)",n,via Query Table
+550081000000103,"Malignant neoplasm of larynx, other specified site (disorder)",n,via Query Table
+634591000000105,Malignant neoplasm of laryngeal cartilage NOS (disorder),n,via Query Table
+875391000000109,Non-small cell carcinoma,n,via Query Table
+439161000000107,[X]Secondary malignant neoplasm of other and unspecified respiratory organs (disorder),n,via Query Table
+561481000000106,Malignant neoplasm of tonsillar fossa NOS (disorder),n,via Query Table
+573621000000103,Malignant neoplasm of pharynx unspecified (disorder),n,via Query Table
+559871000000103,Malignant neoplasm of lateral wall of nasopharynx NOS (disorder),n,via Query Table
+550111000000106,Malignant neoplasm of main bronchus NOS (disorder),n,via Query Table
+561471000000109,Malignant neoplasm tonsil NOS (disorder),n,via Query Table
+666541000000104,Malignant neoplasm of nasal cavities NOS (disorder),n,via Query Table
+559181000000106,Malignant neoplasm of posterior wall of nasopharynx NOS (disorder),n,via Query Table
+269567005,Ca trachea/bronchus/lung NOS (disorder),n,via Query Table
+455771000000103,[X]Malignant neoplasm of ill-defined sites within the respiratory system (disorder),n,via Query Table
+254630009,Clear cell carcinoma of lung (disorder),n,via Query Table
+863141000000107,Non-small cell carcinoma (morphologic abnormality),n,via Query Table
+254523008,Malignant tumor of arytenoid (disorder),n,via Query Table
+390391000000109,"[X]Mesothelioma, unspecified (disorder)",n,via Query Table
+190096000,[X]Malignant neoplasm of ill-defined sites within the respiratory system (disorder),n,via Query Table
+691161000000101,Ca larynx - NOS (disorder),n,via Query Table
+542031000000104,Malignant neoplasm of nasopharynx NOS (disorder),n,via Query Table
+431561000000103,(Mesothelioma of lung) or ([X]mesothelioma of other sites),n,via Query Table
+566521000000100,Malignant neoplasm of anterior epiglottis NOS (disorder),n,via Query Table
+534671000000104,Malignant neoplasm of fixed part of tongue NOS (disorder),n,via Query Table
+557131000000104,Malignant neoplasm of pleura NOS (disorder),n,via Query Table
+187852000,"Malignant neoplasm of trachea, bronchus and lung (disorder)",n,via Query Table
+557081000000104,"Malignant neoplasm of upper lobe, bronchus or lung NOS (disorder)",n,via Query Table
+550091000000101,Malignant neoplasm of larynx NOS (disorder),n,via Query Table
+190091005,[X]Malignant neoplasm of respiratory and intrathoracic organs (disorder),n,via Query Table
+657371000000107,Malignant neoplasm of epiglottis NOS (disorder),n,via Query Table
+534781000000105,Malignant neoplasm of hypopharynx NOS (disorder),n,via Query Table
+566541000000107,Malignant neoplasm of other specified site of oropharynx NOS (disorder),n,via Query Table
+373627005,Bronchioloalveolar carcinoma (disorder),n,via Query Table
+190145000,[X]Secondary malignant neoplasm of other and unspecified respiratory organs (disorder),n,via Query Table
+557121000000101,Malignant neoplasm of other specified pleura (disorder),n,via Query Table


### PR DESCRIPTION
The CTV3-based codelists for cancer are returning to few patients to be reasonable. These scripts check the count of patients using the SNOMED-CT codelists.