### PR TITLE
Admission check

### DIFF
--- a/analysis/admission_check.R
+++ b/analysis/admission_check.R
@@ -1,0 +1,24 @@
+#
+#
+# This script is part of a debugging exercise. The purpose of this script is to
+# check the overlap between elective/emergency admissions as indicated by
+# HES codes, and the "day case" indication that is part of
+# 'patient_classification'.
+#
+
+# Process th raw input.
+source(here::here("analysis","dataset_preparation.R"))
+
+# mydata
+tbl_admission_check <-
+  myData %>%
+  dplyr::select(category_admission_method,
+                admission_method_patient_classification) %>%
+  table()
+
+# Save output.
+write.csv(
+  x = tbl_admission_check,
+  file = here::here("output",
+                    "tbl_admission_check.csv")
+)

--- a/analysis/dataset_preparation.R
+++ b/analysis/dataset_preparation.R
@@ -38,6 +38,7 @@ df_input <- readr::read_csv(
                    chronic_respiratory_disease = col_logical(),
                    cerebrovascular_disease = col_logical(),
                    admission_method = col_factor(),
+                   admission_method_patient_classification = col_factor(),
                    category_admission_method = col_factor(),
                    patient_id = col_integer())
 )
@@ -251,15 +252,15 @@ myData <- myData %>%
                     "Positive test and surgery on the same day. Surgery event excluded",
                 !is.na(.$date_latest_test_preOp_SARS_CoV_2_outcome_positive) & 
                   abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) > 0 & 
-                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) < 14 ~ 
+                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) <= 14 ~ 
                     "0-2 weeks record of pre-operative SARS-CoV-2 infection",
                 !is.na(.$date_latest_test_preOp_SARS_CoV_2_outcome_positive) & 
                   abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) > 15 &
-                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) < 28 ~
+                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) <= 28 ~
                     "3-4 weeks record of pre-operative SARS-CoV-2 infection",
                 !is.na(.$date_latest_test_preOp_SARS_CoV_2_outcome_positive) & 
                   abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) > 29 &
-                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) < 42 ~
+                  abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) <= 42 ~
                     "5-6 weeks record of pre-operative SARS-CoV-2 infection",
                 !is.na(.$date_latest_test_preOp_SARS_CoV_2_outcome_positive) & 
                   abs(.$date_surgery - .$date_latest_test_preOp_SARS_CoV_2_outcome_positive) >= 49 ~ 

--- a/analysis/study_definition_2.py
+++ b/analysis/study_definition_2.py
@@ -398,6 +398,17 @@ study = StudyDefinition(
 				}
 			}
 	),
+    
+    admission_method_patient_classification = patients.admitted_to_hospital(
+        with_these_procedures = OPCS_codelist_cancer_surgery,
+		returning = "patient_classification",
+		on_or_after = start_date,
+		find_first_match_in_period = True,
+		return_expectations = {
+			"category": {"ratios": {"1": 0.2, "2": 0.2, "3": 0.3, "4": 0.2, "5": 0.1}}, 
+			"incidence": 1
+		}
+    ),
 
 	### Local COVID-specific index of multiple deprivation.
 	# address_deprivation_index = patients.address_as_of(

--- a/analysis/study_definition_2.py.bak
+++ b/analysis/study_definition_2.py.bak
@@ -36,7 +36,7 @@ study = StudyDefinition(
 			# codelist_cancer_surgery,
 			# on_or_after = start_date
 		# ),
-	# ),
+	),
     
     has_surgery = patients.with_these_clinical_events(
 			codelist_cancer_surgery,

--- a/project.yaml
+++ b/project.yaml
@@ -208,3 +208,10 @@ actions:
                     table1Outcomes_CSP: output/table1Outcomes_CSP.csv
                     table1Outcomes_PWV: output/table1Outcomes_PWV.csv
                     TableEra: output/TableEra.csv
+                    
+    admission_check:
+        run: r:latest analysis/admission_check.R
+        needs: [generate_study_population_2]
+        outputs:
+            moderately_sensitive:
+                tbl_admission_check: output/tbl_admission_check.csv

--- a/project.yaml.bak
+++ b/project.yaml.bak
@@ -175,12 +175,12 @@ actions:
                 table1Outcomes_PNV_6mths: output/table1Outcomes_PNV_6mths.csv
                 table1Demogs_PWV_6mths: output/table1Demogs_PWV_6mths.csv
                 table1Outcomes_PWV_6mths: output/table1Outcomes_PWV_6mths.csv
-                table1Demogs_CSP_7wkThreshold: output/table1Demogs_CSP_7wkThreshold.csv
-                table1Outcomes_CSP_7wkThreshold: output/table1Outcomes_CSP_7wkThreshold.csv
-                table1Demogs_PNV_7wkThreshold: output/table1Demogs_PNV_7wkThreshold.csv
-                table1Outcomes_PNV_7wkThreshold: output/table1Outcomes_PNV_7wkThreshold.csv
-                table1Demogs_PWV_7wkThreshold: output/table1Demogs_PWV_7wkThreshold.csv
-                table1Outcomes_PWV_7wkThreshold: output/table1Outcomes_PWV_7wkThreshold.csv
+                table1Demogs_CSP_7wkThreshold: output/table1Demogs_CSP_EntireSurgeryCohort_7wkThreshold.csv
+                table1Outcomes_CSP_7wkThreshold: output/table1Outcomes_CSP_EntireSurgeryCohort_7wkThreshold.csv
+                table1Demogs_PNV_7wkThreshold: output/table1Demogs_PNV_EntireSurgeryCohort_7wkThreshold.csv
+                table1Outcomes_PNV_7wkThreshold: output/table1Outcomes_PNV_EntireSurgeryCohort_7wkThreshold.csv
+                table1Demogs_PWV_7wkThreshold: output/table1Demogs_PWV_EntireSurgeryCohort_7wkThreshold.csv
+                table1Outcomes_PWV_7wkThreshold: output/table1Outcomes_PWV_EntireSurgeryCohort_7wkThreshold.csv
                 table1Demogs_CSP_3mths_7wkThreshold: output/table1Demogs_CSP_3mths_7wkThreshold.csv
                 table1Outcomes_CSP_3mths_7wkThreshold: output/table1Outcomes_CSP_3mths_7wkThreshold.csv
                 table1Demogs_PNV_3mths_7wkThreshold: output/table1Demogs_PNV_3mths_7wkThreshold.csv


### PR DESCRIPTION
The sum of the two strata for Admission Method don’t always add to the expected 100%.
The count of patients missing should exactly equal patients who were either admitted without a HES admission code, or who were admitted with a HES admission code that we have not specified.

I need to return "patient_classification" from `patients.admitted_to_hospital()` to count the number day cases (# = 2).

Produce a table that counts:
1. The number of elective using HES.
2. The number of emergency using HES.
3. The number of elective using day case.
4. The number of emergency using day case.